### PR TITLE
With factorization of duplicated anonymous types

### DIFF
--- a/go/lib/Boilerplate.ml
+++ b/go/lib/Boilerplate.ml
@@ -20,32 +20,44 @@ let blank (env : env) () =
 let todo (env : env) _ =
    failwith "not implemented"
 
-let map_int_literal (env : env) (tok : CST.int_literal) =
-  token env tok (* int_literal *)
-
 let map_identifier (env : env) (tok : CST.identifier) =
   token env tok (* identifier *)
 
-let map_raw_string_literal (env : env) (tok : CST.raw_string_literal) =
-  token env tok (* raw_string_literal *)
-
-let map_rune_literal (env : env) (tok : CST.rune_literal) =
-  token env tok (* rune_literal *)
-
-let map_float_literal (env : env) (tok : CST.float_literal) =
-  token env tok (* float_literal *)
-
-let map_imaginary_literal (env : env) (tok : CST.imaginary_literal) =
-  token env tok (* imaginary_literal *)
+let map_anon_choice_new (env : env) (x : CST.anon_choice_new) =
+  (match x with
+  | `New tok -> token env tok (* "new" *)
+  | `Make tok -> token env tok (* "make" *)
+  )
 
 let map_escape_sequence (env : env) (tok : CST.escape_sequence) =
   token env tok (* escape_sequence *)
 
-let map_qualified_type (env : env) ((v1, v2, v3) : CST.qualified_type) =
-  let v1 = token env v1 (* identifier *) in
-  let v2 = token env v2 (* "." *) in
-  let v3 = token env v3 (* identifier *) in
-  todo env (v1, v2, v3)
+let map_raw_string_literal (env : env) (tok : CST.raw_string_literal) =
+  token env tok (* raw_string_literal *)
+
+let map_int_literal (env : env) (tok : CST.int_literal) =
+  token env tok (* int_literal *)
+
+let map_float_literal (env : env) (tok : CST.float_literal) =
+  token env tok (* float_literal *)
+
+let map_anon_choice_LF (env : env) (x : CST.anon_choice_LF) =
+  (match x with
+  | `LF tok -> token env tok (* "\n" *)
+  | `SEMI tok -> token env tok (* ";" *)
+  )
+
+let map_rune_literal (env : env) (tok : CST.rune_literal) =
+  token env tok (* rune_literal *)
+
+let map_imaginary_literal (env : env) (tok : CST.imaginary_literal) =
+  token env tok (* imaginary_literal *)
+
+let map_anon_choice_EQ (env : env) (x : CST.anon_choice_EQ) =
+  (match x with
+  | `EQ tok -> token env tok (* "=" *)
+  | `COLONEQ tok -> token env tok (* ":=" *)
+  )
 
 let map_package_clause (env : env) ((v1, v2) : CST.package_clause) =
   let v1 = token env v1 (* "package" *) in
@@ -57,431 +69,182 @@ let map_empty_labeled_statement (env : env) ((v1, v2) : CST.empty_labeled_statem
   let v2 = token env v2 (* ":" *) in
   todo env (v1, v2)
 
-let map_interpreted_string_literal (env : env) ((v1, v2, v3) : CST.interpreted_string_literal) =
-  let v1 = token env v1 (* "\"" *) in
+let map_field_name_list (env : env) ((v1, v2) : CST.field_name_list) =
+  let v1 = token env v1 (* identifier *) in
   let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Blank () -> todo env ()
-      | `Esc_seq tok -> token env tok (* escape_sequence *)
-      )
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = token env v2 (* identifier *) in
+      todo env (v1, v2)
     ) v2
-  in
-  let v3 = token env v3 (* "\"" *) in
-  todo env (v1, v2, v3)
-
-let map_import_spec (env : env) ((v1, v2) : CST.import_spec) =
-  let v1 =
-    (match v1 with
-    | Some x ->
-        (match x with
-        | `Dot tok -> token env tok (* "." *)
-        | `Blank_id tok -> token env tok (* "_" *)
-        | `Id tok -> token env tok (* identifier *)
-        )
-    | None -> todo env ())
-  in
-  let v2 =
-    (match v2 with
-    | `Raw_str_lit tok -> token env tok (* raw_string_literal *)
-    | `Inte_str_lit x -> map_interpreted_string_literal env x
-    )
   in
   todo env (v1, v2)
 
-let rec map_declaration (env : env) (x : CST.declaration) =
-  (match x with
-  | `Decl_const_decl (v1, v2) ->
-      let v1 = token env v1 (* "const" *) in
-      let v2 =
-        (match v2 with
-        | `Const_spec x -> map_const_spec env x
-        | `LPAR_rep_const_spec_choice_LF_RPAR (v1, v2, v3) ->
-            let v1 = token env v1 (* "(" *) in
-            let v2 =
-              List.map (fun (v1, v2) ->
-                let v1 = map_const_spec env v1 in
-                let v2 =
-                  (match v2 with
-                  | `LF tok -> token env tok (* "\n" *)
-                  | `SEMI tok -> token env tok (* ";" *)
-                  )
-                in
-                todo env (v1, v2)
-              ) v2
-            in
-            let v3 = token env v3 (* ")" *) in
-            todo env (v1, v2, v3)
-        )
-      in
-      todo env (v1, v2)
-  | `Decl_type_decl (v1, v2) ->
-      let v1 = token env v1 (* "type" *) in
-      let v2 =
-        (match v2 with
-        | `Type_spec x -> map_type_spec env x
-        | `Type_alias x -> map_type_alias env x
-        | `LPAR_rep_choice_type_spec_choice_LF_RPAR (v1, v2, v3) ->
-            let v1 = token env v1 (* "(" *) in
-            let v2 =
-              List.map (fun (v1, v2) ->
-                let v1 =
-                  (match v1 with
-                  | `Type_spec x -> map_type_spec env x
-                  | `Type_alias x -> map_type_alias env x
-                  )
-                in
-                let v2 =
-                  (match v2 with
-                  | `LF tok -> token env tok (* "\n" *)
-                  | `SEMI tok -> token env tok (* ";" *)
-                  )
-                in
-                todo env (v1, v2)
-              ) v2
-            in
-            let v3 = token env v3 (* ")" *) in
-            todo env (v1, v2, v3)
-        )
-      in
-      todo env (v1, v2)
-  | `Decl_var_decl (v1, v2) ->
-      let v1 = token env v1 (* "var" *) in
-      let v2 =
-        (match v2 with
-        | `Var_spec x -> map_var_spec env x
-        | `LPAR_rep_var_spec_choice_LF_RPAR (v1, v2, v3) ->
-            let v1 = token env v1 (* "(" *) in
-            let v2 =
-              List.map (fun (v1, v2) ->
-                let v1 = map_var_spec env v1 in
-                let v2 =
-                  (match v2 with
-                  | `LF tok -> token env tok (* "\n" *)
-                  | `SEMI tok -> token env tok (* ";" *)
-                  )
-                in
-                todo env (v1, v2)
-              ) v2
-            in
-            let v3 = token env v3 (* ")" *) in
-            todo env (v1, v2, v3)
-        )
-      in
-      todo env (v1, v2)
-  )
-
-
-and map_const_spec (env : env) ((v1, v2, v3) : CST.const_spec) =
+let map_qualified_type (env : env) ((v1, v2, v3) : CST.qualified_type) =
   let v1 = token env v1 (* identifier *) in
-  let v2 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 = token env v2 (* identifier *) in
-      todo env (v1, v2)
-    ) v2
-  in
-  let v3 =
-    (match v3 with
-    | Some (v1, v2, v3) ->
-        let v1 =
-          (match v1 with
-          | Some x ->
-              (match x with
-              | `Simple_type x -> map_simple_type env x
-              | `Paren_type x -> map_parenthesized_type env x
-              )
-          | None -> todo env ())
-        in
-        let v2 = token env v2 (* "=" *) in
-        let v3 = map_expression_list env v3 in
-        todo env (v1, v2, v3)
-    | None -> todo env ())
-  in
+  let v2 = token env v2 (* "." *) in
+  let v3 = token env v3 (* identifier *) in
   todo env (v1, v2, v3)
 
-
-and map_var_spec (env : env) ((v1, v2, v3) : CST.var_spec) =
-  let v1 = token env v1 (* identifier *) in
-  let v2 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 = token env v2 (* identifier *) in
-      todo env (v1, v2)
-    ) v2
-  in
-  let v3 =
-    (match v3 with
-    | `Choice_simple_type_opt_EQ_exp_list (v1, v2) ->
-        let v1 =
-          (match v1 with
-          | `Simple_type x -> map_simple_type env x
-          | `Paren_type x -> map_parenthesized_type env x
+let map_anon_choice_raw_str_lit (env : env) (x : CST.anon_choice_raw_str_lit) =
+  (match x with
+  | `Raw_str_lit tok -> token env tok (* raw_string_literal *)
+  | `Inte_str_lit (v1, v2, v3) ->
+      let v1 = token env v1 (* "\"" *) in
+      let v2 =
+        List.map (fun x ->
+          (match x with
+          | `Blank () -> todo env ()
+          | `Esc_seq tok -> token env tok (* escape_sequence *)
           )
-        in
-        let v2 =
-          (match v2 with
-          | Some (v1, v2) ->
-              let v1 = token env v1 (* "=" *) in
-              let v2 = map_expression_list env v2 in
-              todo env (v1, v2)
-          | None -> todo env ())
-        in
-        todo env (v1, v2)
-    | `EQ_exp_list (v1, v2) ->
-        let v1 = token env v1 (* "=" *) in
-        let v2 = map_expression_list env v2 in
-        todo env (v1, v2)
-    )
-  in
-  todo env (v1, v2, v3)
-
-
-and map_parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) ->
-        let v1 =
-          (match v1 with
-          | Some (v1, v2) ->
-              let v1 =
-                (match v1 with
-                | `Param_decl x -> map_parameter_declaration env x
-                | `Vari_param_decl x ->
-                    map_variadic_parameter_declaration env x
-                )
-              in
-              let v2 =
-                List.map (fun (v1, v2) ->
-                  let v1 = token env v1 (* "," *) in
-                  let v2 =
-                    (match v2 with
-                    | `Param_decl x -> map_parameter_declaration env x
-                    | `Vari_param_decl x ->
-                        map_variadic_parameter_declaration env x
-                    )
-                  in
-                  todo env (v1, v2)
-                ) v2
-              in
-              todo env (v1, v2)
-          | None -> todo env ())
-        in
-        let v2 =
-          (match v2 with
-          | Some tok -> token env tok (* "," *)
-          | None -> todo env ())
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v3 = token env v3 (* ")" *) in
-  todo env (v1, v2, v3)
-
-
-and map_parameter_declaration (env : env) ((v1, v2) : CST.parameter_declaration) =
-  let v1 =
-    (match v1 with
-    | Some (v1, v2) ->
-        let v1 = token env v1 (* identifier *) in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 = token env v2 (* identifier *) in
-            todo env (v1, v2)
-          ) v2
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v2 =
-    (match v2 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
-    )
-  in
-  todo env (v1, v2)
-
-
-and map_variadic_parameter_declaration (env : env) ((v1, v2, v3) : CST.variadic_parameter_declaration) =
-  let v1 =
-    (match v1 with
-    | Some tok -> token env tok (* identifier *)
-    | None -> todo env ())
-  in
-  let v2 = token env v2 (* "..." *) in
-  let v3 =
-    (match v3 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
-    )
-  in
-  todo env (v1, v2, v3)
-
-
-and map_type_alias (env : env) ((v1, v2, v3) : CST.type_alias) =
-  let v1 = token env v1 (* identifier *) in
-  let v2 = token env v2 (* "=" *) in
-  let v3 =
-    (match v3 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
-    )
-  in
-  todo env (v1, v2, v3)
-
-
-and map_type_spec (env : env) ((v1, v2) : CST.type_spec) =
-  let v1 = token env v1 (* identifier *) in
-  let v2 =
-    (match v2 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
-    )
-  in
-  todo env (v1, v2)
-
-
-and map_expression_list (env : env) ((v1, v2) : CST.expression_list) =
-  let v1 = map_expression env v1 in
-  let v2 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 = map_expression env v2 in
-      todo env (v1, v2)
-    ) v2
-  in
-  todo env (v1, v2)
-
-
-and map_parenthesized_type (env : env) ((v1, v2, v3) : CST.parenthesized_type) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 =
-    (match v2 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
-    )
-  in
-  let v3 = token env v3 (* ")" *) in
-  todo env (v1, v2, v3)
-
-
-and map_simple_type (env : env) (x : CST.simple_type) =
-  (match x with
-  | `Simple_type_id tok -> token env tok (* identifier *)
-  | `Simple_type_qual_type x -> map_qualified_type env x
-  | `Simple_type_poin_type (v1, v2) ->
-      let v1 = token env v1 (* "*" *) in
-      let v2 =
-        (match v2 with
-        | `Simple_type x -> map_simple_type env x
-        | `Paren_type x -> map_parenthesized_type env x
-        )
+        ) v2
       in
-      todo env (v1, v2)
-  | `Simple_type_stru_type x -> map_struct_type env x
-  | `Simple_type_inte_type (v1, v2) ->
-      let v1 = token env v1 (* "interface" *) in
-      let v2 = map_method_spec_list env v2 in
-      todo env (v1, v2)
-  | `Simple_type_array_type x -> map_array_type env x
-  | `Simple_type_slice_type x -> map_slice_type env x
-  | `Simple_type_map_type x -> map_map_type env x
-  | `Simple_type_chan_type x -> map_channel_type env x
-  | `Simple_type_func_type (v1, v2, v3) ->
-      let v1 = token env v1 (* "func" *) in
-      let v2 = map_parameter_list env v2 in
-      let v3 =
-        (match v3 with
-        | Some x ->
-            (match x with
-            | `Param_list x -> map_parameter_list env x
-            | `Simple_type x -> map_simple_type env x
-            )
-        | None -> todo env ())
-      in
+      let v3 = token env v3 (* "\"" *) in
       todo env (v1, v2, v3)
   )
 
-
-and map_array_type (env : env) ((v1, v2, v3, v4) : CST.array_type) =
-  let v1 = token env v1 (* "[" *) in
-  let v2 = map_expression env v2 in
-  let v3 = token env v3 (* "]" *) in
-  let v4 =
-    (match v4 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
-    )
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_implicit_length_array_type (env : env) ((v1, v2, v3, v4) : CST.implicit_length_array_type) =
-  let v1 = token env v1 (* "[" *) in
-  let v2 = token env v2 (* "..." *) in
-  let v3 = token env v3 (* "]" *) in
-  let v4 =
-    (match v4 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
-    )
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_slice_type (env : env) ((v1, v2, v3) : CST.slice_type) =
-  let v1 = token env v1 (* "[" *) in
-  let v2 = token env v2 (* "]" *) in
+let rec map_type_case (env : env) ((v1, v2, v3, v4, v5) : CST.type_case) =
+  let v1 = token env v1 (* "case" *) in
+  let v2 = map_anon_choice_simple_type env v2 in
   let v3 =
-    (match v3 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
-    )
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_anon_choice_simple_type env v2 in
+      todo env (v1, v2)
+    ) v3
   in
-  todo env (v1, v2, v3)
+  let v4 = token env v4 (* ":" *) in
+  let v5 =
+    (match v5 with
+    | Some x -> map_statement_list env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3, v4, v5)
 
+and map_simple_statement (env : env) (x : CST.simple_statement) =
+  (match x with
+  | `Simple_stmt_exp x -> map_expression env x
+  | `Simple_stmt_send_stmt x -> map_send_statement env x
+  | `Simple_stmt_inc_stmt (v1, v2) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "++" *) in
+      todo env (v1, v2)
+  | `Simple_stmt_dec_stmt (v1, v2) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "--" *) in
+      todo env (v1, v2)
+  | `Simple_stmt_assign_stmt (v1, v2, v3) ->
+      let v1 = map_expression_list env v1 in
+      let v2 =
+        (match v2 with
+        | `STAREQ tok -> token env tok (* "*=" *)
+        | `SLASHEQ tok -> token env tok (* "/=" *)
+        | `PERCEQ tok -> token env tok (* "%=" *)
+        | `LTLTEQ tok -> token env tok (* "<<=" *)
+        | `GTGTEQ tok -> token env tok (* ">>=" *)
+        | `AMPEQ tok -> token env tok (* "&=" *)
+        | `AMPHATEQ tok -> token env tok (* "&^=" *)
+        | `PLUSEQ tok -> token env tok (* "+=" *)
+        | `DASHEQ tok -> token env tok (* "-=" *)
+        | `BAREQ tok -> token env tok (* "|=" *)
+        | `HATEQ tok -> token env tok (* "^=" *)
+        | `EQ tok -> token env tok (* "=" *)
+        )
+      in
+      let v3 = map_expression_list env v3 in
+      todo env (v1, v2, v3)
+  | `Simple_stmt_short_var_decl (v1, v2, v3) ->
+      let v1 = map_expression_list env v1 in
+      let v2 = token env v2 (* ":=" *) in
+      let v3 = map_expression_list env v3 in
+      todo env (v1, v2, v3)
+  )
 
-and map_struct_type (env : env) ((v1, v2) : CST.struct_type) =
-  let v1 = token env v1 (* "struct" *) in
-  let v2 = map_field_declaration_list env v2 in
-  todo env (v1, v2)
+and map_anon_choice_exp (env : env) (x : CST.anon_choice_exp) =
+  (match x with
+  | `Exp x -> map_expression env x
+  | `Vari_arg (v1, v2) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "..." *) in
+      todo env (v1, v2)
+  )
 
+and map_binary_expression (env : env) (x : CST.binary_expression) =
+  (match x with
+  | `Bin_exp_exp_choice_STAR_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 =
+        (match v2 with
+        | `STAR tok -> token env tok (* "*" *)
+        | `SLASH tok -> token env tok (* "/" *)
+        | `PERC tok -> token env tok (* "%" *)
+        | `LTLT tok -> token env tok (* "<<" *)
+        | `GTGT tok -> token env tok (* ">>" *)
+        | `AMP tok -> token env tok (* "&" *)
+        | `AMPHAT tok -> token env tok (* "&^" *)
+        )
+      in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Bin_exp_exp_choice_PLUS_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 =
+        (match v2 with
+        | `PLUS tok -> token env tok (* "+" *)
+        | `DASH tok -> token env tok (* "-" *)
+        | `BAR tok -> token env tok (* "|" *)
+        | `HAT tok -> token env tok (* "^" *)
+        )
+      in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Bin_exp_exp_choice_EQEQ_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 =
+        (match v2 with
+        | `EQEQ tok -> token env tok (* "==" *)
+        | `BANGEQ tok -> token env tok (* "!=" *)
+        | `LT tok -> token env tok (* "<" *)
+        | `LTEQ tok -> token env tok (* "<=" *)
+        | `GT tok -> token env tok (* ">" *)
+        | `GTEQ tok -> token env tok (* ">=" *)
+        )
+      in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Bin_exp_exp_AMPAMP_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "&&" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Bin_exp_exp_BARBAR_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "||" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  )
 
-and map_field_declaration_list (env : env) ((v1, v2, v3) : CST.field_declaration_list) =
+and map_block (env : env) ((v1, v2, v3) : CST.block) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     (match v2 with
-    | Some (v1, v2, v3) ->
-        let v1 = map_field_declaration env v1 in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 =
-              (match v1 with
-              | `LF tok -> token env tok (* "\n" *)
-              | `SEMI tok -> token env tok (* ";" *)
-              )
-            in
-            let v2 = map_field_declaration env v2 in
-            todo env (v1, v2)
-          ) v2
-        in
-        let v3 =
-          (match v3 with
-          | Some x ->
-              (match x with
-              | `LF tok -> token env tok (* "\n" *)
-              | `SEMI tok -> token env tok (* ";" *)
-              )
-          | None -> todo env ())
-        in
-        todo env (v1, v2, v3)
+    | Some x -> map_statement_list env x
     | None -> todo env ())
   in
   let v3 = token env v3 (* "}" *) in
   todo env (v1, v2, v3)
 
+and map_receive_statement (env : env) ((v1, v2) : CST.receive_statement) =
+  let v1 =
+    (match v1 with
+    | Some (v1, v2) ->
+        let v1 = map_expression_list env v1 in
+        let v2 = map_anon_choice_EQ env v2 in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v2 = map_expression env v2 in
+  todo env (v1, v2)
 
 and map_field_declaration (env : env) ((v1, v2) : CST.field_declaration) =
   let v1 =
@@ -495,12 +258,7 @@ and map_field_declaration (env : env) ((v1, v2) : CST.field_declaration) =
             todo env (v1, v2)
           ) v2
         in
-        let v3 =
-          (match v3 with
-          | `Simple_type x -> map_simple_type env x
-          | `Paren_type x -> map_parenthesized_type env x
-          )
-        in
+        let v3 = map_anon_choice_simple_type env v3 in
         todo env (v1, v2, v3)
     | `Opt_STAR_choice_id (v1, v2) ->
         let v1 =
@@ -519,53 +277,96 @@ and map_field_declaration (env : env) ((v1, v2) : CST.field_declaration) =
   in
   let v2 =
     (match v2 with
-    | Some x ->
-        (match x with
-        | `Raw_str_lit tok -> token env tok (* raw_string_literal *)
-        | `Inte_str_lit x -> map_interpreted_string_literal env x
-        )
+    | Some x -> map_anon_choice_raw_str_lit env x
     | None -> todo env ())
   in
   todo env (v1, v2)
 
+and map_special_argument_list (env : env) ((v1, v2, v3, v4, v5) : CST.special_argument_list) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 = map_anon_choice_simple_type env v2 in
+  let v3 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+    ) v3
+  in
+  let v4 =
+    (match v4 with
+    | Some tok -> token env tok (* "," *)
+    | None -> todo env ())
+  in
+  let v5 = token env v5 (* ")" *) in
+  todo env (v1, v2, v3, v4, v5)
+
+and map_anon_choice_simple_type (env : env) (x : CST.anon_choice_simple_type) =
+  (match x with
+  | `Simple_type x -> map_simple_type env x
+  | `Paren_type (v1, v2, v3) ->
+      let v1 = token env v1 (* "(" *) in
+      let v2 = map_anon_choice_simple_type env v2 in
+      let v3 = token env v3 (* ")" *) in
+      todo env (v1, v2, v3)
+  )
+
+and map_for_clause (env : env) ((v1, v2, v3, v4, v5) : CST.for_clause) =
+  let v1 =
+    (match v1 with
+    | Some x -> map_simple_statement env x
+    | None -> todo env ())
+  in
+  let v2 = token env v2 (* ";" *) in
+  let v3 =
+    (match v3 with
+    | Some x -> map_expression env x
+    | None -> todo env ())
+  in
+  let v4 = token env v4 (* ";" *) in
+  let v5 =
+    (match v5 with
+    | Some x -> map_simple_statement env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3, v4, v5)
+
+and map_anon_choice_param_decl (env : env) (x : CST.anon_choice_param_decl) =
+  (match x with
+  | `Param_decl (v1, v2) ->
+      let v1 =
+        (match v1 with
+        | Some x -> map_field_name_list env x
+        | None -> todo env ())
+      in
+      let v2 = map_anon_choice_simple_type env v2 in
+      todo env (v1, v2)
+  | `Vari_param_decl (v1, v2, v3) ->
+      let v1 =
+        (match v1 with
+        | Some tok -> token env tok (* identifier *)
+        | None -> todo env ())
+      in
+      let v2 = token env v2 (* "..." *) in
+      let v3 = map_anon_choice_simple_type env v3 in
+      todo env (v1, v2, v3)
+  )
 
 and map_method_spec_list (env : env) ((v1, v2, v3) : CST.method_spec_list) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     (match v2 with
     | Some (v1, v2, v3) ->
-        let v1 =
-          (match v1 with
-          | `Id tok -> token env tok (* identifier *)
-          | `Qual_type x -> map_qualified_type env x
-          | `Meth_spec x -> map_method_spec env x
-          )
-        in
+        let v1 = map_anon_choice_id env v1 in
         let v2 =
           List.map (fun (v1, v2) ->
-            let v1 =
-              (match v1 with
-              | `LF tok -> token env tok (* "\n" *)
-              | `SEMI tok -> token env tok (* ";" *)
-              )
-            in
-            let v2 =
-              (match v2 with
-              | `Id tok -> token env tok (* identifier *)
-              | `Qual_type x -> map_qualified_type env x
-              | `Meth_spec x -> map_method_spec env x
-              )
-            in
+            let v1 = map_anon_choice_LF env v1 in
+            let v2 = map_anon_choice_id env v2 in
             todo env (v1, v2)
           ) v2
         in
         let v3 =
           (match v3 with
-          | Some x ->
-              (match x with
-              | `LF tok -> token env tok (* "\n" *)
-              | `SEMI tok -> token env tok (* ";" *)
-              )
+          | Some x -> map_anon_choice_LF env x
           | None -> todo env ())
         in
         todo env (v1, v2, v3)
@@ -574,124 +375,270 @@ and map_method_spec_list (env : env) ((v1, v2, v3) : CST.method_spec_list) =
   let v3 = token env v3 (* "}" *) in
   todo env (v1, v2, v3)
 
+and map_array_type (env : env) ((v1, v2, v3, v4) : CST.array_type) =
+  let v1 = token env v1 (* "[" *) in
+  let v2 = map_expression env v2 in
+  let v3 = token env v3 (* "]" *) in
+  let v4 = map_anon_choice_simple_type env v4 in
+  todo env (v1, v2, v3, v4)
 
-and map_method_spec (env : env) ((v1, v2, v3) : CST.method_spec) =
-  let v1 = token env v1 (* identifier *) in
-  let v2 = map_parameter_list env v2 in
-  let v3 =
-    (match v3 with
-    | Some x ->
-        (match x with
-        | `Param_list x -> map_parameter_list env x
-        | `Simple_type x -> map_simple_type env x
-        )
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3)
+and map_struct_type (env : env) ((v1, v2) : CST.struct_type) =
+  let v1 = token env v1 (* "struct" *) in
+  let v2 = map_field_declaration_list env v2 in
+  todo env (v1, v2)
 
-
-and map_map_type (env : env) ((v1, v2, v3, v4, v5) : CST.map_type) =
-  let v1 = token env v1 (* "map" *) in
-  let v2 = token env v2 (* "[" *) in
-  let v3 =
-    (match v3 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
-    )
-  in
-  let v4 = token env v4 (* "]" *) in
-  let v5 =
-    (match v5 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
-    )
-  in
-  todo env (v1, v2, v3, v4, v5)
-
-
-and map_channel_type (env : env) (x : CST.channel_type) =
+and map_anon_choice_param_list (env : env) (x : CST.anon_choice_param_list) =
   (match x with
-  | `Chan_type_chan_choice_simple_type (v1, v2) ->
-      let v1 = token env v1 (* "chan" *) in
-      let v2 =
-        (match v2 with
-        | `Simple_type x -> map_simple_type env x
-        | `Paren_type x -> map_parenthesized_type env x
-        )
-      in
-      todo env (v1, v2)
-  | `Chan_type_chan_LTDASH_choice_simple_type (v1, v2, v3) ->
-      let v1 = token env v1 (* "chan" *) in
-      let v2 = token env v2 (* "<-" *) in
-      let v3 =
-        (match v3 with
-        | `Simple_type x -> map_simple_type env x
-        | `Paren_type x -> map_parenthesized_type env x
-        )
-      in
-      todo env (v1, v2, v3)
-  | `Chan_type_LTDASH_chan_choice_simple_type (v1, v2, v3) ->
-      let v1 = token env v1 (* "<-" *) in
-      let v2 = token env v2 (* "chan" *) in
-      let v3 =
-        (match v3 with
-        | `Simple_type x -> map_simple_type env x
-        | `Paren_type x -> map_parenthesized_type env x
-        )
-      in
-      todo env (v1, v2, v3)
+  | `Param_list x -> map_parameter_list env x
+  | `Simple_type x -> map_simple_type env x
   )
 
-
-and map_block (env : env) ((v1, v2, v3) : CST.block) =
-  let v1 = token env v1 (* "{" *) in
-  let v2 =
-    (match v2 with
-    | Some x -> map_statement_list env x
-    | None -> todo env ())
-  in
-  let v3 = token env v3 (* "}" *) in
-  todo env (v1, v2, v3)
-
-
-and map_statement_list (env : env) (x : CST.statement_list) =
+and map_simple_type (env : env) (x : CST.simple_type) =
   (match x with
-  | `Stmt_list_stmt_rep_choice_LF_stmt_opt_choice_LF_opt_empty_labe_stmt (v1, v2, v3) ->
-      let v1 = map_statement env v1 in
-      let v2 =
-        List.map (fun (v1, v2) ->
-          let v1 =
-            (match v1 with
-            | `LF tok -> token env tok (* "\n" *)
-            | `SEMI tok -> token env tok (* ";" *)
-            )
-          in
-          let v2 = map_statement env v2 in
-          todo env (v1, v2)
-        ) v2
-      in
+  | `Simple_type_id tok -> token env tok (* identifier *)
+  | `Simple_type_qual_type x -> map_qualified_type env x
+  | `Simple_type_poin_type (v1, v2) ->
+      let v1 = token env v1 (* "*" *) in
+      let v2 = map_anon_choice_simple_type env v2 in
+      todo env (v1, v2)
+  | `Simple_type_stru_type x -> map_struct_type env x
+  | `Simple_type_inte_type (v1, v2) ->
+      let v1 = token env v1 (* "interface" *) in
+      let v2 = map_method_spec_list env v2 in
+      todo env (v1, v2)
+  | `Simple_type_array_type x -> map_array_type env x
+  | `Simple_type_slice_type x -> map_slice_type env x
+  | `Simple_type_map_type x -> map_map_type env x
+  | `Simple_type_chan_type x -> map_channel_type env x
+  | `Simple_type_func_type (v1, v2, v3) ->
+      let v1 = token env v1 (* "func" *) in
+      let v2 = map_parameter_list env v2 in
       let v3 =
         (match v3 with
-        | Some (v1, v2) ->
-            let v1 =
-              (match v1 with
-              | `LF tok -> token env tok (* "\n" *)
-              | `SEMI tok -> token env tok (* ";" *)
-              )
-            in
-            let v2 =
-              (match v2 with
-              | Some x -> map_empty_labeled_statement env x
-              | None -> todo env ())
-            in
-            todo env (v1, v2)
+        | Some x -> map_anon_choice_param_list env x
         | None -> todo env ())
       in
       todo env (v1, v2, v3)
-  | `Stmt_list_empty_labe_stmt x ->
-      map_empty_labeled_statement env x
   )
 
+and map_call_expression (env : env) (x : CST.call_expression) =
+  (match x with
+  | `Choice_new_spec_arg_list (v1, v2) ->
+      let v1 = map_anon_choice_new env v1 in
+      let v2 = map_special_argument_list env v2 in
+      todo env (v1, v2)
+  | `Exp_arg_list (v1, v2) ->
+      let v1 = map_expression env v1 in
+      let v2 = map_argument_list env v2 in
+      todo env (v1, v2)
+  )
+
+and map_default_case (env : env) ((v1, v2, v3) : CST.default_case) =
+  let v1 = token env v1 (* "default" *) in
+  let v2 = token env v2 (* ":" *) in
+  let v3 =
+    (match v3 with
+    | Some x -> map_statement_list env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3)
+
+and map_slice_type (env : env) ((v1, v2, v3) : CST.slice_type) =
+  let v1 = token env v1 (* "[" *) in
+  let v2 = token env v2 (* "]" *) in
+  let v3 = map_anon_choice_simple_type env v3 in
+  todo env (v1, v2, v3)
+
+and map_expression_list (env : env) ((v1, v2) : CST.expression_list) =
+  let v1 = map_expression env v1 in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+    ) v2
+  in
+  todo env (v1, v2)
+
+and map_expression (env : env) (x : CST.expression) =
+  (match x with
+  | `Exp_un_exp (v1, v2) ->
+      let v1 =
+        (match v1 with
+        | `PLUS tok -> token env tok (* "+" *)
+        | `DASH tok -> token env tok (* "-" *)
+        | `BANG tok -> token env tok (* "!" *)
+        | `HAT tok -> token env tok (* "^" *)
+        | `STAR tok -> token env tok (* "*" *)
+        | `AMP tok -> token env tok (* "&" *)
+        | `LTDASH tok -> token env tok (* "<-" *)
+        )
+      in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `Exp_bin_exp x -> map_binary_expression env x
+  | `Exp_sele_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "." *) in
+      let v3 = token env v3 (* identifier *) in
+      todo env (v1, v2, v3)
+  | `Exp_index_exp (v1, v2, v3, v4) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "[" *) in
+      let v3 = map_expression env v3 in
+      let v4 = token env v4 (* "]" *) in
+      todo env (v1, v2, v3, v4)
+  | `Exp_slice_exp (v1, v2, v3, v4) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "[" *) in
+      let v3 =
+        (match v3 with
+        | `Opt_exp_COLON_opt_exp (v1, v2, v3) ->
+            let v1 =
+              (match v1 with
+              | Some x -> map_expression env x
+              | None -> todo env ())
+            in
+            let v2 = token env v2 (* ":" *) in
+            let v3 =
+              (match v3 with
+              | Some x -> map_expression env x
+              | None -> todo env ())
+            in
+            todo env (v1, v2, v3)
+        | `Opt_exp_COLON_exp_COLON_exp (v1, v2, v3, v4, v5) ->
+            let v1 =
+              (match v1 with
+              | Some x -> map_expression env x
+              | None -> todo env ())
+            in
+            let v2 = token env v2 (* ":" *) in
+            let v3 = map_expression env v3 in
+            let v4 = token env v4 (* ":" *) in
+            let v5 = map_expression env v5 in
+            todo env (v1, v2, v3, v4, v5)
+        )
+      in
+      let v4 = token env v4 (* "]" *) in
+      todo env (v1, v2, v3, v4)
+  | `Exp_call_exp x -> map_call_expression env x
+  | `Exp_type_asse_exp (v1, v2, v3, v4, v5) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "." *) in
+      let v3 = token env v3 (* "(" *) in
+      let v4 = map_anon_choice_simple_type env v4 in
+      let v5 = token env v5 (* ")" *) in
+      todo env (v1, v2, v3, v4, v5)
+  | `Exp_type_conv_exp (v1, v2, v3, v4, v5) ->
+      let v1 = map_anon_choice_simple_type env v1 in
+      let v2 = token env v2 (* "(" *) in
+      let v3 = map_expression env v3 in
+      let v4 =
+        (match v4 with
+        | Some tok -> token env tok (* "," *)
+        | None -> todo env ())
+      in
+      let v5 = token env v5 (* ")" *) in
+      todo env (v1, v2, v3, v4, v5)
+  | `Exp_id tok -> token env tok (* identifier *)
+  | `Exp_choice_new x -> map_anon_choice_new env x
+  | `Exp_comp_lit (v1, v2) ->
+      let v1 =
+        (match v1 with
+        | `Map_type x -> map_map_type env x
+        | `Slice_type x -> map_slice_type env x
+        | `Array_type x -> map_array_type env x
+        | `Impl_len_array_type x ->
+            map_implicit_length_array_type env x
+        | `Stru_type x -> map_struct_type env x
+        | `Id tok -> token env tok (* identifier *)
+        | `Qual_type x -> map_qualified_type env x
+        )
+      in
+      let v2 = map_literal_value env v2 in
+      todo env (v1, v2)
+  | `Exp_func_lit (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "func" *) in
+      let v2 = map_parameter_list env v2 in
+      let v3 =
+        (match v3 with
+        | Some x -> map_anon_choice_param_list env x
+        | None -> todo env ())
+      in
+      let v4 = map_block env v4 in
+      todo env (v1, v2, v3, v4)
+  | `Exp_choice_raw_str_lit x ->
+      map_anon_choice_raw_str_lit env x
+  | `Exp_int_lit tok -> token env tok (* int_literal *)
+  | `Exp_float_lit tok -> token env tok (* float_literal *)
+  | `Exp_imag_lit tok -> token env tok (* imaginary_literal *)
+  | `Exp_rune_lit tok -> token env tok (* rune_literal *)
+  | `Exp_nil tok -> token env tok (* "nil" *)
+  | `Exp_true tok -> token env tok (* "true" *)
+  | `Exp_false tok -> token env tok (* "false" *)
+  | `Exp_paren_exp (v1, v2, v3) ->
+      let v1 = token env v1 (* "(" *) in
+      let v2 = map_expression env v2 in
+      let v3 = token env v3 (* ")" *) in
+      todo env (v1, v2, v3)
+  )
+
+and map_type_switch_header (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.type_switch_header) =
+  let v1 =
+    (match v1 with
+    | Some (v1, v2) ->
+        let v1 = map_simple_statement env v1 in
+        let v2 = token env v2 (* ";" *) in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2) ->
+        let v1 = map_expression_list env v1 in
+        let v2 = token env v2 (* ":=" *) in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v3 = map_expression env v3 in
+  let v4 = token env v4 (* "." *) in
+  let v5 = token env v5 (* "(" *) in
+  let v6 = token env v6 (* "type" *) in
+  let v7 = token env v7 (* ")" *) in
+  todo env (v1, v2, v3, v4, v5, v6, v7)
+
+and map_type_alias (env : env) ((v1, v2, v3) : CST.type_alias) =
+  let v1 = token env v1 (* identifier *) in
+  let v2 = token env v2 (* "=" *) in
+  let v3 = map_anon_choice_simple_type env v3 in
+  todo env (v1, v2, v3)
+
+and map_if_statement (env : env) ((v1, v2, v3, v4, v5) : CST.if_statement) =
+  let v1 = token env v1 (* "if" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2) ->
+        let v1 = map_simple_statement env v1 in
+        let v2 = token env v2 (* ";" *) in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v3 = map_expression env v3 in
+  let v4 = map_block env v4 in
+  let v5 =
+    (match v5 with
+    | Some (v1, v2) ->
+        let v1 = token env v1 (* "else" *) in
+        let v2 =
+          (match v2 with
+          | `Blk x -> map_block env x
+          | `If_stmt x -> map_if_statement env x
+          )
+        in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3, v4, v5)
 
 and map_statement (env : env) (x : CST.statement) =
   (match x with
@@ -811,132 +758,12 @@ and map_statement (env : env) (x : CST.statement) =
   | `Stmt_empty_stmt tok -> token env tok (* ";" *)
   )
 
-
-and map_simple_statement (env : env) (x : CST.simple_statement) =
-  (match x with
-  | `Simple_stmt_exp x -> map_expression env x
-  | `Simple_stmt_send_stmt x -> map_send_statement env x
-  | `Simple_stmt_inc_stmt (v1, v2) ->
-      let v1 = map_expression env v1 in
-      let v2 = token env v2 (* "++" *) in
-      todo env (v1, v2)
-  | `Simple_stmt_dec_stmt (v1, v2) ->
-      let v1 = map_expression env v1 in
-      let v2 = token env v2 (* "--" *) in
-      todo env (v1, v2)
-  | `Simple_stmt_assign_stmt (v1, v2, v3) ->
-      let v1 = map_expression_list env v1 in
-      let v2 =
-        (match v2 with
-        | `STAREQ tok -> token env tok (* "*=" *)
-        | `SLASHEQ tok -> token env tok (* "/=" *)
-        | `PERCEQ tok -> token env tok (* "%=" *)
-        | `LTLTEQ tok -> token env tok (* "<<=" *)
-        | `GTGTEQ tok -> token env tok (* ">>=" *)
-        | `AMPEQ tok -> token env tok (* "&=" *)
-        | `AMPHATEQ tok -> token env tok (* "&^=" *)
-        | `PLUSEQ tok -> token env tok (* "+=" *)
-        | `DASHEQ tok -> token env tok (* "-=" *)
-        | `BAREQ tok -> token env tok (* "|=" *)
-        | `HATEQ tok -> token env tok (* "^=" *)
-        | `EQ tok -> token env tok (* "=" *)
-        )
-      in
-      let v3 = map_expression_list env v3 in
-      todo env (v1, v2, v3)
-  | `Simple_stmt_short_var_decl (v1, v2, v3) ->
-      let v1 = map_expression_list env v1 in
-      let v2 = token env v2 (* ":=" *) in
-      let v3 = map_expression_list env v3 in
-      todo env (v1, v2, v3)
-  )
-
-
-and map_send_statement (env : env) ((v1, v2, v3) : CST.send_statement) =
-  let v1 = map_expression env v1 in
-  let v2 = token env v2 (* "<-" *) in
-  let v3 = map_expression env v3 in
-  todo env (v1, v2, v3)
-
-
-and map_receive_statement (env : env) ((v1, v2) : CST.receive_statement) =
-  let v1 =
-    (match v1 with
-    | Some (v1, v2) ->
-        let v1 = map_expression_list env v1 in
-        let v2 =
-          (match v2 with
-          | `EQ tok -> token env tok (* "=" *)
-          | `COLONEQ tok -> token env tok (* ":=" *)
-          )
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v2 = map_expression env v2 in
-  todo env (v1, v2)
-
-
-and map_if_statement (env : env) ((v1, v2, v3, v4, v5) : CST.if_statement) =
-  let v1 = token env v1 (* "if" *) in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) ->
-        let v1 = map_simple_statement env v1 in
-        let v2 = token env v2 (* ";" *) in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v3 = map_expression env v3 in
-  let v4 = map_block env v4 in
-  let v5 =
-    (match v5 with
-    | Some (v1, v2) ->
-        let v1 = token env v1 (* "else" *) in
-        let v2 =
-          (match v2 with
-          | `Blk x -> map_block env x
-          | `If_stmt x -> map_if_statement env x
-          )
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3, v4, v5)
-
-
-and map_for_clause (env : env) ((v1, v2, v3, v4, v5) : CST.for_clause) =
-  let v1 =
-    (match v1 with
-    | Some x -> map_simple_statement env x
-    | None -> todo env ())
-  in
-  let v2 = token env v2 (* ";" *) in
-  let v3 =
-    (match v3 with
-    | Some x -> map_expression env x
-    | None -> todo env ())
-  in
-  let v4 = token env v4 (* ";" *) in
-  let v5 =
-    (match v5 with
-    | Some x -> map_simple_statement env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3, v4, v5)
-
-
 and map_range_clause (env : env) ((v1, v2, v3) : CST.range_clause) =
   let v1 =
     (match v1 with
     | Some (v1, v2) ->
         let v1 = map_expression_list env v1 in
-        let v2 =
-          (match v2 with
-          | `EQ tok -> token env tok (* "=" *)
-          | `COLONEQ tok -> token env tok (* ":=" *)
-          )
-        in
+        let v2 = map_anon_choice_EQ env v2 in
         todo env (v1, v2)
     | None -> todo env ())
   in
@@ -944,6 +771,65 @@ and map_range_clause (env : env) ((v1, v2, v3) : CST.range_clause) =
   let v3 = map_expression env v3 in
   todo env (v1, v2, v3)
 
+and map_send_statement (env : env) ((v1, v2, v3) : CST.send_statement) =
+  let v1 = map_expression env v1 in
+  let v2 = token env v2 (* "<-" *) in
+  let v3 = map_expression env v3 in
+  todo env (v1, v2, v3)
+
+and map_field_declaration_list (env : env) ((v1, v2, v3) : CST.field_declaration_list) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2, v3) ->
+        let v1 = map_field_declaration env v1 in
+        let v2 =
+          List.map (fun (v1, v2) ->
+            let v1 = map_anon_choice_LF env v1 in
+            let v2 = map_field_declaration env v2 in
+            todo env (v1, v2)
+          ) v2
+        in
+        let v3 =
+          (match v3 with
+          | Some x -> map_anon_choice_LF env x
+          | None -> todo env ())
+        in
+        todo env (v1, v2, v3)
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+and map_map_type (env : env) ((v1, v2, v3, v4, v5) : CST.map_type) =
+  let v1 = token env v1 (* "map" *) in
+  let v2 = token env v2 (* "[" *) in
+  let v3 = map_anon_choice_simple_type env v3 in
+  let v4 = token env v4 (* "]" *) in
+  let v5 = map_anon_choice_simple_type env v5 in
+  todo env (v1, v2, v3, v4, v5)
+
+and map_implicit_length_array_type (env : env) ((v1, v2, v3, v4) : CST.implicit_length_array_type) =
+  let v1 = token env v1 (* "[" *) in
+  let v2 = token env v2 (* "..." *) in
+  let v3 = token env v3 (* "]" *) in
+  let v4 = map_anon_choice_simple_type env v4 in
+  todo env (v1, v2, v3, v4)
+
+and map_anon_choice_id (env : env) (x : CST.anon_choice_id) =
+  (match x with
+  | `Id tok -> token env tok (* identifier *)
+  | `Qual_type x -> map_qualified_type env x
+  | `Meth_spec (v1, v2, v3) ->
+      let v1 = token env v1 (* identifier *) in
+      let v2 = map_parameter_list env v2 in
+      let v3 =
+        (match v3 with
+        | Some x -> map_anon_choice_param_list env x
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3)
+  )
 
 and map_expression_case (env : env) ((v1, v2, v3, v4) : CST.expression_case) =
   let v1 = token env v1 (* "case" *) in
@@ -956,71 +842,263 @@ and map_expression_case (env : env) ((v1, v2, v3, v4) : CST.expression_case) =
   in
   todo env (v1, v2, v3, v4)
 
+and map_argument_list (env : env) ((v1, v2, v3) : CST.argument_list) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2, v3) ->
+        let v1 = map_anon_choice_exp env v1 in
+        let v2 =
+          List.map (fun (v1, v2) ->
+            let v1 = token env v1 (* "," *) in
+            let v2 = map_anon_choice_exp env v2 in
+            todo env (v1, v2)
+          ) v2
+        in
+        let v3 =
+          (match v3 with
+          | Some tok -> token env tok (* "," *)
+          | None -> todo env ())
+        in
+        todo env (v1, v2, v3)
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
 
-and map_default_case (env : env) ((v1, v2, v3) : CST.default_case) =
-  let v1 = token env v1 (* "default" *) in
-  let v2 = token env v2 (* ":" *) in
+and map_const_spec (env : env) ((v1, v2, v3) : CST.const_spec) =
+  let v1 = token env v1 (* identifier *) in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = token env v2 (* identifier *) in
+      todo env (v1, v2)
+    ) v2
+  in
   let v3 =
     (match v3 with
-    | Some x -> map_statement_list env x
+    | Some (v1, v2, v3) ->
+        let v1 =
+          (match v1 with
+          | Some x -> map_anon_choice_simple_type env x
+          | None -> todo env ())
+        in
+        let v2 = token env v2 (* "=" *) in
+        let v3 = map_expression_list env v3 in
+        todo env (v1, v2, v3)
     | None -> todo env ())
   in
   todo env (v1, v2, v3)
 
-
-and map_type_switch_header (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.type_switch_header) =
-  let v1 =
-    (match v1 with
-    | Some (v1, v2) ->
-        let v1 = map_simple_statement env v1 in
-        let v2 = token env v2 (* ";" *) in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) ->
-        let v1 = map_expression_list env v1 in
-        let v2 = token env v2 (* ":=" *) in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v3 = map_expression env v3 in
-  let v4 = token env v4 (* "." *) in
-  let v5 = token env v5 (* "(" *) in
-  let v6 = token env v6 (* "type" *) in
-  let v7 = token env v7 (* ")" *) in
-  todo env (v1, v2, v3, v4, v5, v6, v7)
-
-
-and map_type_case (env : env) ((v1, v2, v3, v4, v5) : CST.type_case) =
-  let v1 = token env v1 (* "case" *) in
-  let v2 =
-    (match v2 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
-    )
-  in
-  let v3 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
+and map_anon_choice_elem (env : env) (x : CST.anon_choice_elem) =
+  (match x with
+  | `Elem x -> map_element env x
+  | `Keyed_elem (v1, v2) ->
+      let v1 =
+        (match v1 with
+        | `Exp_COLON (v1, v2) ->
+            let v1 = map_expression env v1 in
+            let v2 = token env v2 (* ":" *) in
+            todo env (v1, v2)
+        | `Lit_value_COLON (v1, v2) ->
+            let v1 = map_literal_value env v1 in
+            let v2 = token env v2 (* ":" *) in
+            todo env (v1, v2)
+        | `Id_COLON x -> map_empty_labeled_statement env x
+        )
+      in
       let v2 =
         (match v2 with
-        | `Simple_type x -> map_simple_type env x
-        | `Paren_type x -> map_parenthesized_type env x
+        | `Exp x -> map_expression env x
+        | `Lit_value x -> map_literal_value env x
         )
       in
       todo env (v1, v2)
-    ) v3
-  in
-  let v4 = token env v4 (* ":" *) in
-  let v5 =
-    (match v5 with
-    | Some x -> map_statement_list env x
+  )
+
+and map_type_spec (env : env) ((v1, v2) : CST.type_spec) =
+  let v1 = token env v1 (* identifier *) in
+  let v2 = map_anon_choice_simple_type env v2 in
+  todo env (v1, v2)
+
+and map_channel_type (env : env) (x : CST.channel_type) =
+  (match x with
+  | `Chan_type_chan_choice_simple_type (v1, v2) ->
+      let v1 = token env v1 (* "chan" *) in
+      let v2 = map_anon_choice_simple_type env v2 in
+      todo env (v1, v2)
+  | `Chan_type_chan_LTDASH_choice_simple_type (v1, v2, v3) ->
+      let v1 = token env v1 (* "chan" *) in
+      let v2 = token env v2 (* "<-" *) in
+      let v3 = map_anon_choice_simple_type env v3 in
+      todo env (v1, v2, v3)
+  | `Chan_type_LTDASH_chan_choice_simple_type (v1, v2, v3) ->
+      let v1 = token env v1 (* "<-" *) in
+      let v2 = token env v2 (* "chan" *) in
+      let v3 = map_anon_choice_simple_type env v3 in
+      todo env (v1, v2, v3)
+  )
+
+and map_parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2) ->
+        let v1 =
+          (match v1 with
+          | Some (v1, v2) ->
+              let v1 = map_anon_choice_param_decl env v1 in
+              let v2 =
+                List.map (fun (v1, v2) ->
+                  let v1 = token env v1 (* "," *) in
+                  let v2 = map_anon_choice_param_decl env v2 in
+                  todo env (v1, v2)
+                ) v2
+              in
+              todo env (v1, v2)
+          | None -> todo env ())
+        in
+        let v2 =
+          (match v2 with
+          | Some tok -> token env tok (* "," *)
+          | None -> todo env ())
+        in
+        todo env (v1, v2)
     | None -> todo env ())
   in
-  todo env (v1, v2, v3, v4, v5)
+  let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
 
+and map_element (env : env) (x : CST.element) =
+  (match x with
+  | `Elem_exp x -> map_expression env x
+  | `Elem_lit_value x -> map_literal_value env x
+  )
+
+and map_var_spec (env : env) ((v1, v2, v3) : CST.var_spec) =
+  let v1 = token env v1 (* identifier *) in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = token env v2 (* identifier *) in
+      todo env (v1, v2)
+    ) v2
+  in
+  let v3 =
+    (match v3 with
+    | `Choice_simple_type_opt_EQ_exp_list (v1, v2) ->
+        let v1 = map_anon_choice_simple_type env v1 in
+        let v2 =
+          (match v2 with
+          | Some (v1, v2) ->
+              let v1 = token env v1 (* "=" *) in
+              let v2 = map_expression_list env v2 in
+              todo env (v1, v2)
+          | None -> todo env ())
+        in
+        todo env (v1, v2)
+    | `EQ_exp_list (v1, v2) ->
+        let v1 = token env v1 (* "=" *) in
+        let v2 = map_expression_list env v2 in
+        todo env (v1, v2)
+    )
+  in
+  todo env (v1, v2, v3)
+
+and map_declaration (env : env) (x : CST.declaration) =
+  (match x with
+  | `Decl_const_decl (v1, v2) ->
+      let v1 = token env v1 (* "const" *) in
+      let v2 =
+        (match v2 with
+        | `Const_spec x -> map_const_spec env x
+        | `LPAR_rep_const_spec_choice_LF_RPAR (v1, v2, v3) ->
+            let v1 = token env v1 (* "(" *) in
+            let v2 =
+              List.map (fun (v1, v2) ->
+                let v1 = map_const_spec env v1 in
+                let v2 = map_anon_choice_LF env v2 in
+                todo env (v1, v2)
+              ) v2
+            in
+            let v3 = token env v3 (* ")" *) in
+            todo env (v1, v2, v3)
+        )
+      in
+      todo env (v1, v2)
+  | `Decl_type_decl (v1, v2) ->
+      let v1 = token env v1 (* "type" *) in
+      let v2 =
+        (match v2 with
+        | `Type_spec x -> map_type_spec env x
+        | `Type_alias x -> map_type_alias env x
+        | `LPAR_rep_choice_type_spec_choice_LF_RPAR (v1, v2, v3) ->
+            let v1 = token env v1 (* "(" *) in
+            let v2 =
+              List.map (fun (v1, v2) ->
+                let v1 =
+                  (match v1 with
+                  | `Type_spec x -> map_type_spec env x
+                  | `Type_alias x -> map_type_alias env x
+                  )
+                in
+                let v2 = map_anon_choice_LF env v2 in
+                todo env (v1, v2)
+              ) v2
+            in
+            let v3 = token env v3 (* ")" *) in
+            todo env (v1, v2, v3)
+        )
+      in
+      todo env (v1, v2)
+  | `Decl_var_decl (v1, v2) ->
+      let v1 = token env v1 (* "var" *) in
+      let v2 =
+        (match v2 with
+        | `Var_spec x -> map_var_spec env x
+        | `LPAR_rep_var_spec_choice_LF_RPAR (v1, v2, v3) ->
+            let v1 = token env v1 (* "(" *) in
+            let v2 =
+              List.map (fun (v1, v2) ->
+                let v1 = map_var_spec env v1 in
+                let v2 = map_anon_choice_LF env v2 in
+                todo env (v1, v2)
+              ) v2
+            in
+            let v3 = token env v3 (* ")" *) in
+            todo env (v1, v2, v3)
+        )
+      in
+      todo env (v1, v2)
+  )
+
+and map_statement_list (env : env) (x : CST.statement_list) =
+  (match x with
+  | `Stmt_list_stmt_rep_choice_LF_stmt_opt_choice_LF_opt_empty_labe_stmt (v1, v2, v3) ->
+      let v1 = map_statement env v1 in
+      let v2 =
+        List.map (fun (v1, v2) ->
+          let v1 = map_anon_choice_LF env v1 in
+          let v2 = map_statement env v2 in
+          todo env (v1, v2)
+        ) v2
+      in
+      let v3 =
+        (match v3 with
+        | Some (v1, v2) ->
+            let v1 = map_anon_choice_LF env v1 in
+            let v2 =
+              (match v2 with
+              | Some x -> map_empty_labeled_statement env x
+              | None -> todo env ())
+            in
+            todo env (v1, v2)
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3)
+  | `Stmt_list_empty_labe_stmt x ->
+      map_empty_labeled_statement env x
+  )
 
 and map_communication_case (env : env) ((v1, v2, v3, v4) : CST.communication_case) =
   let v1 = token env v1 (* "case" *) in
@@ -1038,255 +1116,16 @@ and map_communication_case (env : env) ((v1, v2, v3, v4) : CST.communication_cas
   in
   todo env (v1, v2, v3, v4)
 
-
-and map_expression (env : env) (x : CST.expression) =
-  (match x with
-  | `Exp_un_exp (v1, v2) ->
-      let v1 =
-        (match v1 with
-        | `PLUS tok -> token env tok (* "+" *)
-        | `DASH tok -> token env tok (* "-" *)
-        | `BANG tok -> token env tok (* "!" *)
-        | `HAT tok -> token env tok (* "^" *)
-        | `STAR tok -> token env tok (* "*" *)
-        | `AMP tok -> token env tok (* "&" *)
-        | `LTDASH tok -> token env tok (* "<-" *)
-        )
-      in
-      let v2 = map_expression env v2 in
-      todo env (v1, v2)
-  | `Exp_bin_exp x -> map_binary_expression env x
-  | `Exp_sele_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
-      let v2 = token env v2 (* "." *) in
-      let v3 = token env v3 (* identifier *) in
-      todo env (v1, v2, v3)
-  | `Exp_index_exp (v1, v2, v3, v4) ->
-      let v1 = map_expression env v1 in
-      let v2 = token env v2 (* "[" *) in
-      let v3 = map_expression env v3 in
-      let v4 = token env v4 (* "]" *) in
-      todo env (v1, v2, v3, v4)
-  | `Exp_slice_exp (v1, v2, v3, v4) ->
-      let v1 = map_expression env v1 in
-      let v2 = token env v2 (* "[" *) in
-      let v3 =
-        (match v3 with
-        | `Opt_exp_COLON_opt_exp (v1, v2, v3) ->
-            let v1 =
-              (match v1 with
-              | Some x -> map_expression env x
-              | None -> todo env ())
-            in
-            let v2 = token env v2 (* ":" *) in
-            let v3 =
-              (match v3 with
-              | Some x -> map_expression env x
-              | None -> todo env ())
-            in
-            todo env (v1, v2, v3)
-        | `Opt_exp_COLON_exp_COLON_exp (v1, v2, v3, v4, v5) ->
-            let v1 =
-              (match v1 with
-              | Some x -> map_expression env x
-              | None -> todo env ())
-            in
-            let v2 = token env v2 (* ":" *) in
-            let v3 = map_expression env v3 in
-            let v4 = token env v4 (* ":" *) in
-            let v5 = map_expression env v5 in
-            todo env (v1, v2, v3, v4, v5)
-        )
-      in
-      let v4 = token env v4 (* "]" *) in
-      todo env (v1, v2, v3, v4)
-  | `Exp_call_exp x -> map_call_expression env x
-  | `Exp_type_asse_exp (v1, v2, v3, v4, v5) ->
-      let v1 = map_expression env v1 in
-      let v2 = token env v2 (* "." *) in
-      let v3 = token env v3 (* "(" *) in
-      let v4 =
-        (match v4 with
-        | `Simple_type x -> map_simple_type env x
-        | `Paren_type x -> map_parenthesized_type env x
-        )
-      in
-      let v5 = token env v5 (* ")" *) in
-      todo env (v1, v2, v3, v4, v5)
-  | `Exp_type_conv_exp (v1, v2, v3, v4, v5) ->
-      let v1 =
-        (match v1 with
-        | `Simple_type x -> map_simple_type env x
-        | `Paren_type x -> map_parenthesized_type env x
-        )
-      in
-      let v2 = token env v2 (* "(" *) in
-      let v3 = map_expression env v3 in
-      let v4 =
-        (match v4 with
-        | Some tok -> token env tok (* "," *)
-        | None -> todo env ())
-      in
-      let v5 = token env v5 (* ")" *) in
-      todo env (v1, v2, v3, v4, v5)
-  | `Exp_id tok -> token env tok (* identifier *)
-  | `Exp_choice_new x ->
-      (match x with
-      | `New tok -> token env tok (* "new" *)
-      | `Make tok -> token env tok (* "make" *)
-      )
-  | `Exp_comp_lit (v1, v2) ->
-      let v1 =
-        (match v1 with
-        | `Map_type x -> map_map_type env x
-        | `Slice_type x -> map_slice_type env x
-        | `Array_type x -> map_array_type env x
-        | `Impl_len_array_type x ->
-            map_implicit_length_array_type env x
-        | `Stru_type x -> map_struct_type env x
-        | `Id tok -> token env tok (* identifier *)
-        | `Qual_type x -> map_qualified_type env x
-        )
-      in
-      let v2 = map_literal_value env v2 in
-      todo env (v1, v2)
-  | `Exp_func_lit (v1, v2, v3, v4) ->
-      let v1 = token env v1 (* "func" *) in
-      let v2 = map_parameter_list env v2 in
-      let v3 =
-        (match v3 with
-        | Some x ->
-            (match x with
-            | `Param_list x -> map_parameter_list env x
-            | `Simple_type x -> map_simple_type env x
-            )
-        | None -> todo env ())
-      in
-      let v4 = map_block env v4 in
-      todo env (v1, v2, v3, v4)
-  | `Exp_choice_raw_str_lit x ->
-      (match x with
-      | `Raw_str_lit tok -> token env tok (* raw_string_literal *)
-      | `Inte_str_lit x -> map_interpreted_string_literal env x
-      )
-  | `Exp_int_lit tok -> token env tok (* int_literal *)
-  | `Exp_float_lit tok -> token env tok (* float_literal *)
-  | `Exp_imag_lit tok -> token env tok (* imaginary_literal *)
-  | `Exp_rune_lit tok -> token env tok (* rune_literal *)
-  | `Exp_nil tok -> token env tok (* "nil" *)
-  | `Exp_true tok -> token env tok (* "true" *)
-  | `Exp_false tok -> token env tok (* "false" *)
-  | `Exp_paren_exp (v1, v2, v3) ->
-      let v1 = token env v1 (* "(" *) in
-      let v2 = map_expression env v2 in
-      let v3 = token env v3 (* ")" *) in
-      todo env (v1, v2, v3)
-  )
-
-
-and map_call_expression (env : env) (x : CST.call_expression) =
-  (match x with
-  | `Choice_new_spec_arg_list (v1, v2) ->
-      let v1 =
-        (match v1 with
-        | `New tok -> token env tok (* "new" *)
-        | `Make tok -> token env tok (* "make" *)
-        )
-      in
-      let v2 = map_special_argument_list env v2 in
-      todo env (v1, v2)
-  | `Exp_arg_list (v1, v2) ->
-      let v1 = map_expression env v1 in
-      let v2 = map_argument_list env v2 in
-      todo env (v1, v2)
-  )
-
-
-and map_variadic_argument (env : env) ((v1, v2) : CST.variadic_argument) =
-  let v1 = map_expression env v1 in
-  let v2 = token env v2 (* "..." *) in
-  todo env (v1, v2)
-
-
-and map_special_argument_list (env : env) ((v1, v2, v3, v4, v5) : CST.special_argument_list) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 =
-    (match v2 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
-    )
-  in
-  let v3 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 = map_expression env v2 in
-      todo env (v1, v2)
-    ) v3
-  in
-  let v4 =
-    (match v4 with
-    | Some tok -> token env tok (* "," *)
-    | None -> todo env ())
-  in
-  let v5 = token env v5 (* ")" *) in
-  todo env (v1, v2, v3, v4, v5)
-
-
-and map_argument_list (env : env) ((v1, v2, v3) : CST.argument_list) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2, v3) ->
-        let v1 =
-          (match v1 with
-          | `Exp x -> map_expression env x
-          | `Vari_arg x -> map_variadic_argument env x
-          )
-        in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 =
-              (match v2 with
-              | `Exp x -> map_expression env x
-              | `Vari_arg x -> map_variadic_argument env x
-              )
-            in
-            todo env (v1, v2)
-          ) v2
-        in
-        let v3 =
-          (match v3 with
-          | Some tok -> token env tok (* "," *)
-          | None -> todo env ())
-        in
-        todo env (v1, v2, v3)
-    | None -> todo env ())
-  in
-  let v3 = token env v3 (* ")" *) in
-  todo env (v1, v2, v3)
-
-
 and map_literal_value (env : env) ((v1, v2, v3) : CST.literal_value) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     (match v2 with
     | Some (v1, v2, v3) ->
-        let v1 =
-          (match v1 with
-          | `Elem x -> map_element env x
-          | `Keyed_elem x -> map_keyed_element env x
-          )
-        in
+        let v1 = map_anon_choice_elem env v1 in
         let v2 =
           List.map (fun (v1, v2) ->
             let v1 = token env v1 (* "," *) in
-            let v2 =
-              (match v2 with
-              | `Elem x -> map_element env x
-              | `Keyed_elem x -> map_keyed_element env x
-              )
-            in
+            let v2 = map_anon_choice_elem env v2 in
             todo env (v1, v2)
           ) v2
         in
@@ -1301,111 +1140,19 @@ and map_literal_value (env : env) ((v1, v2, v3) : CST.literal_value) =
   let v3 = token env v3 (* "}" *) in
   todo env (v1, v2, v3)
 
-
-and map_keyed_element (env : env) ((v1, v2) : CST.keyed_element) =
+let map_import_spec (env : env) ((v1, v2) : CST.import_spec) =
   let v1 =
     (match v1 with
-    | `Exp_COLON (v1, v2) ->
-        let v1 = map_expression env v1 in
-        let v2 = token env v2 (* ":" *) in
-        todo env (v1, v2)
-    | `Lit_value_COLON (v1, v2) ->
-        let v1 = map_literal_value env v1 in
-        let v2 = token env v2 (* ":" *) in
-        todo env (v1, v2)
-    | `Id_COLON (v1, v2) ->
-        let v1 = token env v1 (* identifier *) in
-        let v2 = token env v2 (* ":" *) in
-        todo env (v1, v2)
-    )
+    | Some x ->
+        (match x with
+        | `Dot tok -> token env tok (* "." *)
+        | `Blank_id tok -> token env tok (* "_" *)
+        | `Id tok -> token env tok (* identifier *)
+        )
+    | None -> todo env ())
   in
-  let v2 =
-    (match v2 with
-    | `Exp x -> map_expression env x
-    | `Lit_value x -> map_literal_value env x
-    )
-  in
+  let v2 = map_anon_choice_raw_str_lit env v2 in
   todo env (v1, v2)
-
-
-and map_element (env : env) (x : CST.element) =
-  (match x with
-  | `Elem_exp x -> map_expression env x
-  | `Elem_lit_value x -> map_literal_value env x
-  )
-
-
-and map_binary_expression (env : env) (x : CST.binary_expression) =
-  (match x with
-  | `Bin_exp_exp_choice_STAR_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
-      let v2 =
-        (match v2 with
-        | `STAR tok -> token env tok (* "*" *)
-        | `SLASH tok -> token env tok (* "/" *)
-        | `PERC tok -> token env tok (* "%" *)
-        | `LTLT tok -> token env tok (* "<<" *)
-        | `GTGT tok -> token env tok (* ">>" *)
-        | `AMP tok -> token env tok (* "&" *)
-        | `AMPHAT tok -> token env tok (* "&^" *)
-        )
-      in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  | `Bin_exp_exp_choice_PLUS_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
-      let v2 =
-        (match v2 with
-        | `PLUS tok -> token env tok (* "+" *)
-        | `DASH tok -> token env tok (* "-" *)
-        | `BAR tok -> token env tok (* "|" *)
-        | `HAT tok -> token env tok (* "^" *)
-        )
-      in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  | `Bin_exp_exp_choice_EQEQ_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
-      let v2 =
-        (match v2 with
-        | `EQEQ tok -> token env tok (* "==" *)
-        | `BANGEQ tok -> token env tok (* "!=" *)
-        | `LT tok -> token env tok (* "<" *)
-        | `LTEQ tok -> token env tok (* "<=" *)
-        | `GT tok -> token env tok (* ">" *)
-        | `GTEQ tok -> token env tok (* ">=" *)
-        )
-      in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  | `Bin_exp_exp_AMPAMP_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
-      let v2 = token env v2 (* "&&" *) in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  | `Bin_exp_exp_BARBAR_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
-      let v2 = token env v2 (* "||" *) in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  )
-
-let map_import_spec_list (env : env) ((v1, v2, v3) : CST.import_spec_list) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 =
-    List.map (fun (v1, v2) ->
-      let v1 = map_import_spec env v1 in
-      let v2 =
-        (match v2 with
-        | `LF tok -> token env tok (* "\n" *)
-        | `SEMI tok -> token env tok (* ";" *)
-        )
-      in
-      todo env (v1, v2)
-    ) v2
-  in
-  let v3 = token env v3 (* ")" *) in
-  todo env (v1, v2, v3)
 
 let map_method_declaration (env : env) ((v1, v2, v3, v4, v5, v6) : CST.method_declaration) =
   let v1 = token env v1 (* "func" *) in
@@ -1414,11 +1161,7 @@ let map_method_declaration (env : env) ((v1, v2, v3, v4, v5, v6) : CST.method_de
   let v4 = map_parameter_list env v4 in
   let v5 =
     (match v5 with
-    | Some x ->
-        (match x with
-        | `Param_list x -> map_parameter_list env x
-        | `Simple_type x -> map_simple_type env x
-        )
+    | Some x -> map_anon_choice_param_list env x
     | None -> todo env ())
   in
   let v6 =
@@ -1434,11 +1177,7 @@ let map_function_declaration (env : env) ((v1, v2, v3, v4, v5) : CST.function_de
   let v3 = map_parameter_list env v3 in
   let v4 =
     (match v4 with
-    | Some x ->
-        (match x with
-        | `Param_list x -> map_parameter_list env x
-        | `Simple_type x -> map_simple_type env x
-        )
+    | Some x -> map_anon_choice_param_list env x
     | None -> todo env ())
   in
   let v5 =
@@ -1447,6 +1186,18 @@ let map_function_declaration (env : env) ((v1, v2, v3, v4, v5) : CST.function_de
     | None -> todo env ())
   in
   todo env (v1, v2, v3, v4, v5)
+
+let map_import_spec_list (env : env) ((v1, v2, v3) : CST.import_spec_list) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = map_import_spec env v1 in
+      let v2 = map_anon_choice_LF env v2 in
+      todo env (v1, v2)
+    ) v2
+  in
+  let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
 
 let map_import_declaration (env : env) ((v1, v2) : CST.import_declaration) =
   let v1 = token env v1 (* "import" *) in
@@ -1463,12 +1214,7 @@ let map_source_file (env : env) (xs : CST.source_file) =
     (match x with
     | `Stmt_choice_LF (v1, v2) ->
         let v1 = map_statement env v1 in
-        let v2 =
-          (match v2 with
-          | `LF tok -> token env tok (* "\n" *)
-          | `SEMI tok -> token env tok (* ";" *)
-          )
-        in
+        let v2 = map_anon_choice_LF env v2 in
         todo env (v1, v2)
     | `Choice_pack_clau_opt_choice_LF (v1, v2) ->
         let v1 =
@@ -1481,14 +1227,9 @@ let map_source_file (env : env) (xs : CST.source_file) =
         in
         let v2 =
           (match v2 with
-          | Some x ->
-              (match x with
-              | `LF tok -> token env tok (* "\n" *)
-              | `SEMI tok -> token env tok (* ";" *)
-              )
+          | Some x -> map_anon_choice_LF env x
           | None -> todo env ())
         in
         todo env (v1, v2)
     )
   ) xs
-

--- a/java/lib/Boilerplate.ml
+++ b/java/lib/Boilerplate.ml
@@ -20,23 +20,8 @@ let blank (env : env) () =
 let todo (env : env) _ =
    failwith "not implemented"
 
-let map_floating_point_type (env : env) (x : CST.floating_point_type) =
-  (match x with
-  | `Floa_point_type_float tok -> token env tok (* "float" *)
-  | `Floa_point_type_doub tok -> token env tok (* "double" *)
-  )
-
 let map_octal_integer_literal (env : env) (tok : CST.octal_integer_literal) =
   token env tok (* octal_integer_literal *)
-
-let map_binary_integer_literal (env : env) (tok : CST.binary_integer_literal) =
-  token env tok (* binary_integer_literal *)
-
-let map_identifier (env : env) (tok : CST.identifier) =
-  token env tok (* pattern [a-zA-Z_]\w* *)
-
-let map_hex_integer_literal (env : env) (tok : CST.hex_integer_literal) =
-  token env tok (* hex_integer_literal *)
 
 let map_integral_type (env : env) (x : CST.integral_type) =
   (match x with
@@ -47,20 +32,23 @@ let map_integral_type (env : env) (x : CST.integral_type) =
   | `Inte_type_char tok -> token env tok (* "char" *)
   )
 
-let map_decimal_floating_point_literal (env : env) (tok : CST.decimal_floating_point_literal) =
-  token env tok (* decimal_floating_point_literal *)
-
-let map_character_literal (env : env) (tok : CST.character_literal) =
-  token env tok (* character_literal *)
+let map_anon_choice_open (env : env) (x : CST.anon_choice_open) =
+  (match x with
+  | `Open tok -> token env tok (* "open" *)
+  | `Modu tok -> token env tok (* "module" *)
+  )
 
 let map_string_literal (env : env) (tok : CST.string_literal) =
   token env tok (* string_literal *)
 
-let map_hex_floating_point_literal (env : env) (tok : CST.hex_floating_point_literal) =
-  token env tok (* hex_floating_point_literal *)
-
 let map_decimal_integer_literal (env : env) (tok : CST.decimal_integer_literal) =
   token env tok (* decimal_integer_literal *)
+
+let map_character_literal (env : env) (tok : CST.character_literal) =
+  token env tok (* character_literal *)
+
+let map_decimal_floating_point_literal (env : env) (tok : CST.decimal_floating_point_literal) =
+  token env tok (* decimal_floating_point_literal *)
 
 let map_requires_modifier (env : env) (x : CST.requires_modifier) =
   (match x with
@@ -68,34 +56,23 @@ let map_requires_modifier (env : env) (x : CST.requires_modifier) =
   | `Requis_modi_stat tok -> token env tok (* "static" *)
   )
 
-let rec map_scoped_identifier (env : env) ((v1, v2, v3) : CST.scoped_identifier) =
-  let v1 =
-    (match v1 with
-    | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-    | `Choice_open x ->
-        (match x with
-        | `Open tok -> token env tok (* "open" *)
-        | `Modu tok -> token env tok (* "module" *)
-        )
-    | `Scop_id x -> map_scoped_identifier env x
-    )
-  in
-  let v2 = token env v2 (* "." *) in
-  let v3 = token env v3 (* pattern [a-zA-Z_]\w* *) in
-  todo env (v1, v2, v3)
+let map_hex_integer_literal (env : env) (tok : CST.hex_integer_literal) =
+  token env tok (* hex_integer_literal *)
 
-let map_inferred_parameters (env : env) ((v1, v2, v3, v4) : CST.inferred_parameters) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 = token env v2 (* pattern [a-zA-Z_]\w* *) in
-  let v3 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 = token env v2 (* pattern [a-zA-Z_]\w* *) in
-      todo env (v1, v2)
-    ) v3
-  in
-  let v4 = token env v4 (* ")" *) in
-  todo env (v1, v2, v3, v4)
+let map_floating_point_type (env : env) (x : CST.floating_point_type) =
+  (match x with
+  | `Floa_point_type_float tok -> token env tok (* "float" *)
+  | `Floa_point_type_doub tok -> token env tok (* "double" *)
+  )
+
+let map_hex_floating_point_literal (env : env) (tok : CST.hex_floating_point_literal) =
+  token env tok (* hex_floating_point_literal *)
+
+let map_binary_integer_literal (env : env) (tok : CST.binary_integer_literal) =
+  token env tok (* binary_integer_literal *)
+
+let map_identifier (env : env) (tok : CST.identifier) =
+  token env tok (* pattern [a-zA-Z_]\w* *)
 
 let map_literal (env : env) (x : CST.literal) =
   (match x with
@@ -118,37 +95,47 @@ let map_literal (env : env) (x : CST.literal) =
   | `Lit_null_lit tok -> token env tok (* "null" *)
   )
 
+let map_anon_choice_id (env : env) (x : CST.anon_choice_id) =
+  (match x with
+  | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
+  | `Choice_open x -> map_anon_choice_open env x
+  )
+
+let map_inferred_parameters (env : env) ((v1, v2, v3, v4) : CST.inferred_parameters) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 = token env v2 (* pattern [a-zA-Z_]\w* *) in
+  let v3 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = token env v2 (* pattern [a-zA-Z_]\w* *) in
+      todo env (v1, v2)
+    ) v3
+  in
+  let v4 = token env v4 (* ")" *) in
+  todo env (v1, v2, v3, v4)
+
+let rec map_anon_choice_id_ (env : env) (x : CST.anon_choice_id_) =
+  (match x with
+  | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
+  | `Choice_open x -> map_anon_choice_open env x
+  | `Scop_id (v1, v2, v3) ->
+      let v1 = map_anon_choice_id_ env v1 in
+      let v2 = token env v2 (* "." *) in
+      let v3 = token env v3 (* pattern [a-zA-Z_]\w* *) in
+      todo env (v1, v2, v3)
+  )
+
 let map_module_directive (env : env) ((v1, v2) : CST.module_directive) =
   let v1 =
     (match v1 with
     | `Requis_rep_requis_modi_choice_id (v1, v2, v3) ->
         let v1 = token env v1 (* "requires" *) in
         let v2 = List.map (map_requires_modifier env) v2 in
-        let v3 =
-          (match v3 with
-          | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-          | `Choice_open x ->
-              (match x with
-              | `Open tok -> token env tok (* "open" *)
-              | `Modu tok -> token env tok (* "module" *)
-              )
-          | `Scop_id x -> map_scoped_identifier env x
-          )
-        in
+        let v3 = map_anon_choice_id_ env v3 in
         todo env (v1, v2, v3)
     | `Expors_choice_id_opt_to_opt_choice_id_rep_COMMA_choice_id (v1, v2, v3, v4, v5) ->
         let v1 = token env v1 (* "exports" *) in
-        let v2 =
-          (match v2 with
-          | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-          | `Choice_open x ->
-              (match x with
-              | `Open tok -> token env tok (* "open" *)
-              | `Modu tok -> token env tok (* "module" *)
-              )
-          | `Scop_id x -> map_scoped_identifier env x
-          )
-        in
+        let v2 = map_anon_choice_id_ env v2 in
         let v3 =
           (match v3 with
           | Some tok -> token env tok (* "to" *)
@@ -156,49 +143,20 @@ let map_module_directive (env : env) ((v1, v2) : CST.module_directive) =
         in
         let v4 =
           (match v4 with
-          | Some x ->
-              (match x with
-              | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-              | `Choice_open x ->
-                  (match x with
-                  | `Open tok -> token env tok (* "open" *)
-                  | `Modu tok -> token env tok (* "module" *)
-                  )
-              | `Scop_id x -> map_scoped_identifier env x
-              )
+          | Some x -> map_anon_choice_id_ env x
           | None -> todo env ())
         in
         let v5 =
           List.map (fun (v1, v2) ->
             let v1 = token env v1 (* "," *) in
-            let v2 =
-              (match v2 with
-              | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-              | `Choice_open x ->
-                  (match x with
-                  | `Open tok -> token env tok (* "open" *)
-                  | `Modu tok -> token env tok (* "module" *)
-                  )
-              | `Scop_id x -> map_scoped_identifier env x
-              )
-            in
+            let v2 = map_anon_choice_id_ env v2 in
             todo env (v1, v2)
           ) v5
         in
         todo env (v1, v2, v3, v4, v5)
     | `Opens_choice_id_opt_to_opt_choice_id_rep_COMMA_choice_id (v1, v2, v3, v4, v5) ->
         let v1 = token env v1 (* "opens" *) in
-        let v2 =
-          (match v2 with
-          | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-          | `Choice_open x ->
-              (match x with
-              | `Open tok -> token env tok (* "open" *)
-              | `Modu tok -> token env tok (* "module" *)
-              )
-          | `Scop_id x -> map_scoped_identifier env x
-          )
-        in
+        let v2 = map_anon_choice_id_ env v2 in
         let v3 =
           (match v3 with
           | Some tok -> token env tok (* "to" *)
@@ -206,89 +164,30 @@ let map_module_directive (env : env) ((v1, v2) : CST.module_directive) =
         in
         let v4 =
           (match v4 with
-          | Some x ->
-              (match x with
-              | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-              | `Choice_open x ->
-                  (match x with
-                  | `Open tok -> token env tok (* "open" *)
-                  | `Modu tok -> token env tok (* "module" *)
-                  )
-              | `Scop_id x -> map_scoped_identifier env x
-              )
+          | Some x -> map_anon_choice_id_ env x
           | None -> todo env ())
         in
         let v5 =
           List.map (fun (v1, v2) ->
             let v1 = token env v1 (* "," *) in
-            let v2 =
-              (match v2 with
-              | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-              | `Choice_open x ->
-                  (match x with
-                  | `Open tok -> token env tok (* "open" *)
-                  | `Modu tok -> token env tok (* "module" *)
-                  )
-              | `Scop_id x -> map_scoped_identifier env x
-              )
-            in
+            let v2 = map_anon_choice_id_ env v2 in
             todo env (v1, v2)
           ) v5
         in
         todo env (v1, v2, v3, v4, v5)
     | `Uses_choice_id (v1, v2) ->
         let v1 = token env v1 (* "uses" *) in
-        let v2 =
-          (match v2 with
-          | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-          | `Choice_open x ->
-              (match x with
-              | `Open tok -> token env tok (* "open" *)
-              | `Modu tok -> token env tok (* "module" *)
-              )
-          | `Scop_id x -> map_scoped_identifier env x
-          )
-        in
+        let v2 = map_anon_choice_id_ env v2 in
         todo env (v1, v2)
     | `Provis_choice_id_with_choice_id_rep_COMMA_choice_id (v1, v2, v3, v4, v5) ->
         let v1 = token env v1 (* "provides" *) in
-        let v2 =
-          (match v2 with
-          | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-          | `Choice_open x ->
-              (match x with
-              | `Open tok -> token env tok (* "open" *)
-              | `Modu tok -> token env tok (* "module" *)
-              )
-          | `Scop_id x -> map_scoped_identifier env x
-          )
-        in
+        let v2 = map_anon_choice_id_ env v2 in
         let v3 = token env v3 (* "with" *) in
-        let v4 =
-          (match v4 with
-          | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-          | `Choice_open x ->
-              (match x with
-              | `Open tok -> token env tok (* "open" *)
-              | `Modu tok -> token env tok (* "module" *)
-              )
-          | `Scop_id x -> map_scoped_identifier env x
-          )
-        in
+        let v4 = map_anon_choice_id_ env v4 in
         let v5 =
           List.map (fun (v1, v2) ->
             let v1 = token env v1 (* "," *) in
-            let v2 =
-              (match v2 with
-              | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-              | `Choice_open x ->
-                  (match x with
-                  | `Open tok -> token env tok (* "open" *)
-                  | `Modu tok -> token env tok (* "module" *)
-                  )
-              | `Scop_id x -> map_scoped_identifier env x
-              )
-            in
+            let v2 = map_anon_choice_id_ env v2 in
             todo env (v1, v2)
           ) v5
         in
@@ -304,86 +203,53 @@ let map_module_body (env : env) ((v1, v2, v3) : CST.module_body) =
   let v3 = token env v3 (* "}" *) in
   todo env (v1, v2, v3)
 
-let rec map_expression (env : env) (x : CST.expression) =
+let rec map_parenthesized_expression (env : env) ((v1, v2, v3) : CST.parenthesized_expression) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 = map_expression env v2 in
+  let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
+
+and map_anon_choice_type (env : env) (x : CST.anon_choice_type) =
   (match x with
-  | `Exp_assign_exp (v1, v2, v3) ->
-      let v1 =
-        (match v1 with
-        | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-        | `Choice_open x ->
-            (match x with
-            | `Open tok -> token env tok (* "open" *)
-            | `Modu tok -> token env tok (* "module" *)
-            )
-        | `Field_acce x -> map_field_access env x
-        | `Array_acce x -> map_array_access env x
-        )
-      in
-      let v2 =
-        (match v2 with
-        | `EQ tok -> token env tok (* "=" *)
-        | `PLUSEQ tok -> token env tok (* "+=" *)
-        | `DASHEQ tok -> token env tok (* "-=" *)
-        | `STAREQ tok -> token env tok (* "*=" *)
-        | `SLASHEQ tok -> token env tok (* "/=" *)
-        | `AMPEQ tok -> token env tok (* "&=" *)
-        | `BAREQ tok -> token env tok (* "|=" *)
-        | `HATEQ tok -> token env tok (* "^=" *)
-        | `PERCEQ tok -> token env tok (* "%=" *)
-        | `LTLTEQ tok -> token env tok (* "<<=" *)
-        | `GTGTEQ tok -> token env tok (* ">>=" *)
-        | `GTGTGTEQ tok -> token env tok (* ">>>=" *)
-        )
-      in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  | `Exp_bin_exp x -> map_binary_expression env x
-  | `Exp_inst_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
-      let v2 = token env v2 (* "instanceof" *) in
-      let v3 = map_type_ env v3 in
-      todo env (v1, v2, v3)
-  | `Exp_lamb_exp (v1, v2, v3) ->
-      let v1 =
-        (match v1 with
-        | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-        | `Form_params x -> map_formal_parameters env x
-        | `Infe_params x -> map_inferred_parameters env x
-        )
-      in
-      let v2 = token env v2 (* "->" *) in
+  | `Type x -> map_type_ env x
+  | `Wild (v1, v2, v3) ->
+      let v1 = List.map (map_annotation env) v1 in
+      let v2 = token env v2 (* "?" *) in
       let v3 =
         (match v3 with
-        | `Exp x -> map_expression env x
-        | `Blk x -> map_block env x
-        )
+        | Some x -> map_wildcard_bounds env x
+        | None -> todo env ())
       in
       todo env (v1, v2, v3)
-  | `Exp_tern_exp (v1, v2, v3, v4, v5) ->
-      let v1 = map_expression env v1 in
-      let v2 = token env v2 (* "?" *) in
-      let v3 = map_expression env v3 in
-      let v4 = token env v4 (* ":" *) in
-      let v5 = map_expression env v5 in
-      todo env (v1, v2, v3, v4, v5)
-  | `Exp_upda_exp x -> map_update_expression env x
-  | `Exp_prim x -> map_primary env x
-  | `Exp_un_exp x -> map_unary_expression env x
-  | `Exp_cast_exp (v1, v2, v3, v4, v5) ->
-      let v1 = token env v1 (* "(" *) in
-      let v2 = map_type_ env v2 in
-      let v3 =
-        List.map (fun (v1, v2) ->
-          let v1 = token env v1 (* "&" *) in
-          let v2 = map_type_ env v2 in
-          todo env (v1, v2)
-        ) v3
-      in
-      let v4 = token env v4 (* ")" *) in
-      let v5 = map_expression env v5 in
-      todo env (v1, v2, v3, v4, v5)
   )
 
+and map_generic_type (env : env) ((v1, v2) : CST.generic_type) =
+  let v1 =
+    (match v1 with
+    | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
+    | `Scop_type_id x -> map_scoped_type_identifier env x
+    )
+  in
+  let v2 = map_type_arguments env v2 in
+  todo env (v1, v2)
+
+and map_throws (env : env) ((v1, v2, v3) : CST.throws) =
+  let v1 = token env v1 (* "throws" *) in
+  let v2 = map_type_ env v2 in
+  let v3 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_type_ env v2 in
+      todo env (v1, v2)
+    ) v3
+  in
+  todo env (v1, v2, v3)
+
+and map_anon_choice_exp (env : env) (x : CST.anon_choice_exp) =
+  (match x with
+  | `Exp x -> map_expression env x
+  | `Array_init x -> map_array_initializer env x
+  )
 
 and map_binary_expression (env : env) (x : CST.binary_expression) =
   (match x with
@@ -484,48 +350,96 @@ and map_binary_expression (env : env) (x : CST.binary_expression) =
       todo env (v1, v2, v3)
   )
 
+and map_extends_interfaces (env : env) ((v1, v2) : CST.extends_interfaces) =
+  let v1 = token env v1 (* "extends" *) in
+  let v2 = map_interface_type_list env v2 in
+  todo env (v1, v2)
 
-and map_unary_expression (env : env) (x : CST.unary_expression) =
-  (match x with
-  | `Un_exp_PLUS_exp (v1, v2) ->
-      let v1 = token env v1 (* "+" *) in
-      let v2 = map_expression env v2 in
-      todo env (v1, v2)
-  | `Un_exp_DASH_exp (v1, v2) ->
-      let v1 = token env v1 (* "-" *) in
-      let v2 = map_expression env v2 in
-      todo env (v1, v2)
-  | `Un_exp_BANG_exp (v1, v2) ->
-      let v1 = token env v1 (* "!" *) in
-      let v2 = map_expression env v2 in
-      todo env (v1, v2)
-  | `Un_exp_TILDE_exp (v1, v2) ->
-      let v1 = token env v1 (* "~" *) in
-      let v2 = map_expression env v2 in
-      todo env (v1, v2)
-  )
+and map_block (env : env) ((v1, v2, v3) : CST.block) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 = map_program env v2 in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
 
+and map_variable_declarator (env : env) ((v1, v2) : CST.variable_declarator) =
+  let v1 = map_variable_declarator_id env v1 in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2) ->
+        let v1 = token env v1 (* "=" *) in
+        let v2 = map_anon_choice_exp env v2 in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  todo env (v1, v2)
 
-and map_update_expression (env : env) (x : CST.update_expression) =
-  (match x with
-  | `Exp_PLUSPLUS (v1, v2) ->
-      let v1 = map_expression env v1 in
-      let v2 = token env v2 (* "++" *) in
-      todo env (v1, v2)
-  | `Exp_DASHDASH (v1, v2) ->
-      let v1 = map_expression env v1 in
-      let v2 = token env v2 (* "--" *) in
-      todo env (v1, v2)
-  | `PLUSPLUS_exp (v1, v2) ->
-      let v1 = token env v1 (* "++" *) in
-      let v2 = map_expression env v2 in
-      todo env (v1, v2)
-  | `DASHDASH_exp (v1, v2) ->
-      let v1 = token env v1 (* "--" *) in
-      let v2 = map_expression env v2 in
-      todo env (v1, v2)
-  )
+and map_type_arguments (env : env) ((v1, v2, v3) : CST.type_arguments) =
+  let v1 = token env v1 (* "<" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2) ->
+        let v1 = map_anon_choice_type env v1 in
+        let v2 =
+          List.map (fun (v1, v2) ->
+            let v1 = token env v1 (* "," *) in
+            let v2 = map_anon_choice_type env v2 in
+            todo env (v1, v2)
+          ) v2
+        in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* ">" *) in
+  todo env (v1, v2, v3)
 
+and map_class_body (env : env) ((v1, v2, v3) : CST.class_body) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 = List.map (map_anon_choice_field_decl env) v2 in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+and map_type_parameter (env : env) ((v1, v2, v3) : CST.type_parameter) =
+  let v1 = List.map (map_annotation env) v1 in
+  let v2 = token env v2 (* pattern [a-zA-Z_]\w* *) in
+  let v3 =
+    (match v3 with
+    | Some x -> map_type_bound env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3)
+
+and map_catch_type (env : env) ((v1, v2) : CST.catch_type) =
+  let v1 = map_unannotated_type env v1 in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "|" *) in
+      let v2 = map_unannotated_type env v2 in
+      todo env (v1, v2)
+    ) v2
+  in
+  todo env (v1, v2)
+
+and map_interface_type_list (env : env) ((v1, v2) : CST.interface_type_list) =
+  let v1 = map_type_ env v1 in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_type_ env v2 in
+      todo env (v1, v2)
+    ) v2
+  in
+  todo env (v1, v2)
+
+and map_local_variable_declaration (env : env) ((v1, v2, v3, v4) : CST.local_variable_declaration) =
+  let v1 =
+    (match v1 with
+    | Some x -> map_modifiers env x
+    | None -> todo env ())
+  in
+  let v2 = map_unannotated_type env v2 in
+  let v3 = map_variable_declarator_list env v3 in
+  let v4 = token env v4 (* ";" *) in
+  todo env (v1, v2, v3, v4)
 
 and map_primary (env : env) (x : CST.primary) =
   (match x with
@@ -537,11 +451,7 @@ and map_primary (env : env) (x : CST.primary) =
       todo env (v1, v2, v3)
   | `Prim_this tok -> token env tok (* "this" *)
   | `Prim_id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-  | `Prim_choice_open x ->
-      (match x with
-      | `Open tok -> token env tok (* "open" *)
-      | `Modu tok -> token env tok (* "module" *)
-      )
+  | `Prim_choice_open x -> map_anon_choice_open env x
   | `Prim_paren_exp x -> map_parenthesized_expression env x
   | `Prim_obj_crea_exp x ->
       map_object_creation_expression env x
@@ -550,22 +460,9 @@ and map_primary (env : env) (x : CST.primary) =
   | `Prim_meth_invo (v1, v2) ->
       let v1 =
         (match v1 with
-        | `Choice_id x ->
-            (match x with
-            | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-            | `Choice_open x ->
-                (match x with
-                | `Open tok -> token env tok (* "open" *)
-                | `Modu tok -> token env tok (* "module" *)
-                )
-            )
+        | `Choice_id x -> map_anon_choice_id env x
         | `Choice_prim_DOT_opt_super_DOT_opt_type_args_choice_id (v1, v2, v3, v4, v5) ->
-            let v1 =
-              (match v1 with
-              | `Prim x -> map_primary env x
-              | `Super tok -> token env tok (* "super" *)
-              )
-            in
+            let v1 = map_anon_choice_prim env v1 in
             let v2 = token env v2 (* "." *) in
             let v3 =
               (match v3 with
@@ -580,16 +477,7 @@ and map_primary (env : env) (x : CST.primary) =
               | Some x -> map_type_arguments env x
               | None -> todo env ())
             in
-            let v5 =
-              (match v5 with
-              | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-              | `Choice_open x ->
-                  (match x with
-                  | `Open tok -> token env tok (* "open" *)
-                  | `Modu tok -> token env tok (* "module" *)
-                  )
-              )
-            in
+            let v5 = map_anon_choice_id env v5 in
             todo env (v1, v2, v3, v4, v5)
         )
       in
@@ -618,17 +506,7 @@ and map_primary (env : env) (x : CST.primary) =
       todo env (v1, v2, v3, v4)
   | `Prim_array_crea_exp (v1, v2, v3) ->
       let v1 = token env v1 (* "new" *) in
-      let v2 =
-        (match v2 with
-        | `Void_type tok -> token env tok (* "void" *)
-        | `Inte_type x -> map_integral_type env x
-        | `Floa_point_type x -> map_floating_point_type env x
-        | `Bool_type tok -> token env tok (* "boolean" *)
-        | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-        | `Scop_type_id x -> map_scoped_type_identifier env x
-        | `Gene_type x -> map_generic_type env x
-        )
-      in
+      let v2 = map_anon_choice_void_type env v2 in
       let v3 =
         (match v3 with
         | `Rep1_dimens_expr_opt_dimens (v1, v2) ->
@@ -648,175 +526,6 @@ and map_primary (env : env) (x : CST.primary) =
       todo env (v1, v2, v3)
   )
 
-
-and map_dimensions_expr (env : env) ((v1, v2, v3, v4) : CST.dimensions_expr) =
-  let v1 = List.map (map_annotation env) v1 in
-  let v2 = token env v2 (* "[" *) in
-  let v3 = map_expression env v3 in
-  let v4 = token env v4 (* "]" *) in
-  todo env (v1, v2, v3, v4)
-
-
-and map_parenthesized_expression (env : env) ((v1, v2, v3) : CST.parenthesized_expression) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 = map_expression env v2 in
-  let v3 = token env v3 (* ")" *) in
-  todo env (v1, v2, v3)
-
-
-and map_object_creation_expression (env : env) (x : CST.object_creation_expression) =
-  (match x with
-  | `Obj_crea_exp_unqu_obj_crea_exp x ->
-      map_unqualified_object_creation_expression env x
-  | `Obj_crea_exp_prim_DOT_unqu_obj_crea_exp (v1, v2, v3) ->
-      let v1 = map_primary env v1 in
-      let v2 = token env v2 (* "." *) in
-      let v3 =
-        map_unqualified_object_creation_expression env v3
-      in
-      todo env (v1, v2, v3)
-  )
-
-
-and map_unqualified_object_creation_expression (env : env) ((v1, v2, v3, v4, v5) : CST.unqualified_object_creation_expression) =
-  let v1 = token env v1 (* "new" *) in
-  let v2 =
-    (match v2 with
-    | Some x -> map_type_arguments env x
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | `Void_type tok -> token env tok (* "void" *)
-    | `Inte_type x -> map_integral_type env x
-    | `Floa_point_type x -> map_floating_point_type env x
-    | `Bool_type tok -> token env tok (* "boolean" *)
-    | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-    | `Scop_type_id x -> map_scoped_type_identifier env x
-    | `Gene_type x -> map_generic_type env x
-    )
-  in
-  let v4 = map_argument_list env v4 in
-  let v5 =
-    (match v5 with
-    | Some x -> map_class_body env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3, v4, v5)
-
-
-and map_field_access (env : env) ((v1, v2, v3, v4) : CST.field_access) =
-  let v1 =
-    (match v1 with
-    | `Prim x -> map_primary env x
-    | `Super tok -> token env tok (* "super" *)
-    )
-  in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) ->
-        let v1 = token env v1 (* "." *) in
-        let v2 = token env v2 (* "super" *) in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v3 = token env v3 (* "." *) in
-  let v4 =
-    (match v4 with
-    | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-    | `Choice_open x ->
-        (match x with
-        | `Open tok -> token env tok (* "open" *)
-        | `Modu tok -> token env tok (* "module" *)
-        )
-    | `This tok -> token env tok (* "this" *)
-    )
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_array_access (env : env) ((v1, v2, v3, v4) : CST.array_access) =
-  let v1 = map_primary env v1 in
-  let v2 = token env v2 (* "[" *) in
-  let v3 = map_expression env v3 in
-  let v4 = token env v4 (* "]" *) in
-  todo env (v1, v2, v3, v4)
-
-
-and map_argument_list (env : env) ((v1, v2, v3) : CST.argument_list) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) ->
-        let v1 = map_expression env v1 in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 = map_expression env v2 in
-            todo env (v1, v2)
-          ) v2
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v3 = token env v3 (* ")" *) in
-  todo env (v1, v2, v3)
-
-
-and map_type_arguments (env : env) ((v1, v2, v3) : CST.type_arguments) =
-  let v1 = token env v1 (* "<" *) in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) ->
-        let v1 =
-          (match v1 with
-          | `Type x -> map_type_ env x
-          | `Wild x -> map_wildcard env x
-          )
-        in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 =
-              (match v2 with
-              | `Type x -> map_type_ env x
-              | `Wild x -> map_wildcard env x
-              )
-            in
-            todo env (v1, v2)
-          ) v2
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v3 = token env v3 (* ">" *) in
-  todo env (v1, v2, v3)
-
-
-and map_wildcard (env : env) ((v1, v2, v3) : CST.wildcard) =
-  let v1 = List.map (map_annotation env) v1 in
-  let v2 = token env v2 (* "?" *) in
-  let v3 =
-    (match v3 with
-    | Some x -> map_wildcard_bounds env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3)
-
-
-and map_wildcard_bounds (env : env) (x : CST.wildcard_bounds) =
-  (match x with
-  | `Wild_bounds_extens_type (v1, v2) ->
-      let v1 = token env v1 (* "extends" *) in
-      let v2 = map_type_ env v2 in
-      todo env (v1, v2)
-  | `Wild_bounds_super_type (v1, v2) ->
-      let v1 = token env v1 (* "super" *) in
-      let v2 = map_type_ env v2 in
-      todo env (v1, v2)
-  )
-
-
 and map_dimensions (env : env) (xs : CST.dimensions) =
   List.map (fun (v1, v2, v3) ->
     let v1 = List.map (map_annotation env) v1 in
@@ -825,6 +534,314 @@ and map_dimensions (env : env) (xs : CST.dimensions) =
     todo env (v1, v2, v3)
   ) xs
 
+and map_variable_declarator_list (env : env) ((v1, v2) : CST.variable_declarator_list) =
+  let v1 = map_variable_declarator env v1 in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_variable_declarator env v2 in
+      todo env (v1, v2)
+    ) v2
+  in
+  todo env (v1, v2)
+
+and map_switch_label (env : env) (x : CST.switch_label) =
+  (match x with
+  | `Swit_label_case_exp_COLON (v1, v2, v3) ->
+      let v1 = token env v1 (* "case" *) in
+      let v2 = map_expression env v2 in
+      let v3 = token env v3 (* ":" *) in
+      todo env (v1, v2, v3)
+  | `Swit_label_defa_COLON (v1, v2) ->
+      let v1 = token env v1 (* "default" *) in
+      let v2 = token env v2 (* ":" *) in
+      todo env (v1, v2)
+  )
+
+and map_array_initializer (env : env) ((v1, v2, v3, v4) : CST.array_initializer) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2) ->
+        let v1 = map_anon_choice_exp env v1 in
+        let v2 =
+          List.map (fun (v1, v2) ->
+            let v1 = token env v1 (* "," *) in
+            let v2 = map_anon_choice_exp env v2 in
+            todo env (v1, v2)
+          ) v2
+        in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v3 =
+    (match v3 with
+    | Some tok -> token env tok (* "," *)
+    | None -> todo env ())
+  in
+  let v4 = token env v4 (* "}" *) in
+  todo env (v1, v2, v3, v4)
+
+and map_interface_declaration (env : env) ((v1, v2, v3, v4, v5, v6) : CST.interface_declaration) =
+  let v1 =
+    (match v1 with
+    | Some x -> map_modifiers env x
+    | None -> todo env ())
+  in
+  let v2 = token env v2 (* "interface" *) in
+  let v3 = token env v3 (* pattern [a-zA-Z_]\w* *) in
+  let v4 =
+    (match v4 with
+    | Some x -> map_type_parameters env x
+    | None -> todo env ())
+  in
+  let v5 =
+    (match v5 with
+    | Some x -> map_extends_interfaces env x
+    | None -> todo env ())
+  in
+  let v6 = map_interface_body env v6 in
+  todo env (v1, v2, v3, v4, v5, v6)
+
+and map_annotation_type_declaration (env : env) ((v1, v2, v3, v4) : CST.annotation_type_declaration) =
+  let v1 =
+    (match v1 with
+    | Some x -> map_modifiers env x
+    | None -> todo env ())
+  in
+  let v2 = token env v2 (* "@interface" *) in
+  let v3 = token env v3 (* pattern [a-zA-Z_]\w* *) in
+  let v4 = map_annotation_type_body env v4 in
+  todo env (v1, v2, v3, v4)
+
+and map_interface_body (env : env) ((v1, v2, v3) : CST.interface_body) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    List.map (fun x ->
+      (match x with
+      | `Cst_decl x -> map_constant_declaration env x
+      | `Enum_decl x -> map_enum_declaration env x
+      | `Meth_decl x -> map_method_declaration env x
+      | `Class_decl x -> map_class_declaration env x
+      | `Inte_decl x -> map_interface_declaration env x
+      | `Anno_type_decl x -> map_annotation_type_declaration env x
+      | `SEMI tok -> token env tok (* ";" *)
+      )
+    ) v2
+  in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+and map_catch_clause (env : env) ((v1, v2, v3, v4, v5) : CST.catch_clause) =
+  let v1 = token env v1 (* "catch" *) in
+  let v2 = token env v2 (* "(" *) in
+  let v3 = map_catch_formal_parameter env v3 in
+  let v4 = token env v4 (* ")" *) in
+  let v5 = map_block env v5 in
+  todo env (v1, v2, v3, v4, v5)
+
+and map_anon_exp_rep_COMMA_exp (env : env) ((v1, v2) : CST.anon_exp_rep_COMMA_exp) =
+  let v1 = map_expression env v1 in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+    ) v2
+  in
+  todo env (v1, v2)
+
+and map_scoped_type_identifier (env : env) ((v1, v2, v3, v4) : CST.scoped_type_identifier) =
+  let v1 =
+    (match v1 with
+    | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
+    | `Scop_type_id x -> map_scoped_type_identifier env x
+    | `Gene_type x -> map_generic_type env x
+    )
+  in
+  let v2 = token env v2 (* "." *) in
+  let v3 = List.map (map_annotation env) v3 in
+  let v4 = token env v4 (* pattern [a-zA-Z_]\w* *) in
+  todo env (v1, v2, v3, v4)
+
+and map_expression (env : env) (x : CST.expression) =
+  (match x with
+  | `Exp_assign_exp (v1, v2, v3) ->
+      let v1 =
+        (match v1 with
+        | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
+        | `Choice_open x -> map_anon_choice_open env x
+        | `Field_acce x -> map_field_access env x
+        | `Array_acce x -> map_array_access env x
+        )
+      in
+      let v2 =
+        (match v2 with
+        | `EQ tok -> token env tok (* "=" *)
+        | `PLUSEQ tok -> token env tok (* "+=" *)
+        | `DASHEQ tok -> token env tok (* "-=" *)
+        | `STAREQ tok -> token env tok (* "*=" *)
+        | `SLASHEQ tok -> token env tok (* "/=" *)
+        | `AMPEQ tok -> token env tok (* "&=" *)
+        | `BAREQ tok -> token env tok (* "|=" *)
+        | `HATEQ tok -> token env tok (* "^=" *)
+        | `PERCEQ tok -> token env tok (* "%=" *)
+        | `LTLTEQ tok -> token env tok (* "<<=" *)
+        | `GTGTEQ tok -> token env tok (* ">>=" *)
+        | `GTGTGTEQ tok -> token env tok (* ">>>=" *)
+        )
+      in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_bin_exp x -> map_binary_expression env x
+  | `Exp_inst_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "instanceof" *) in
+      let v3 = map_type_ env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_lamb_exp (v1, v2, v3) ->
+      let v1 =
+        (match v1 with
+        | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
+        | `Form_params x -> map_formal_parameters env x
+        | `Infe_params x -> map_inferred_parameters env x
+        )
+      in
+      let v2 = token env v2 (* "->" *) in
+      let v3 =
+        (match v3 with
+        | `Exp x -> map_expression env x
+        | `Blk x -> map_block env x
+        )
+      in
+      todo env (v1, v2, v3)
+  | `Exp_tern_exp (v1, v2, v3, v4, v5) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "?" *) in
+      let v3 = map_expression env v3 in
+      let v4 = token env v4 (* ":" *) in
+      let v5 = map_expression env v5 in
+      todo env (v1, v2, v3, v4, v5)
+  | `Exp_upda_exp x -> map_update_expression env x
+  | `Exp_prim x -> map_primary env x
+  | `Exp_un_exp x -> map_unary_expression env x
+  | `Exp_cast_exp (v1, v2, v3, v4, v5) ->
+      let v1 = token env v1 (* "(" *) in
+      let v2 = map_type_ env v2 in
+      let v3 =
+        List.map (fun (v1, v2) ->
+          let v1 = token env v1 (* "&" *) in
+          let v2 = map_type_ env v2 in
+          todo env (v1, v2)
+        ) v3
+      in
+      let v4 = token env v4 (* ")" *) in
+      let v5 = map_expression env v5 in
+      todo env (v1, v2, v3, v4, v5)
+  )
+
+and map_annotation_type_element_declaration (env : env) ((v1, v2, v3, v4, v5, v6, v7, v8) : CST.annotation_type_element_declaration) =
+  let v1 =
+    (match v1 with
+    | Some x -> map_modifiers env x
+    | None -> todo env ())
+  in
+  let v2 = map_unannotated_type env v2 in
+  let v3 = token env v3 (* pattern [a-zA-Z_]\w* *) in
+  let v4 = token env v4 (* "(" *) in
+  let v5 = token env v5 (* ")" *) in
+  let v6 =
+    (match v6 with
+    | Some x -> map_dimensions env x
+    | None -> todo env ())
+  in
+  let v7 =
+    (match v7 with
+    | Some x -> map_default_value env x
+    | None -> todo env ())
+  in
+  let v8 = token env v8 (* ";" *) in
+  todo env (v1, v2, v3, v4, v5, v6, v7, v8)
+
+and map_unary_expression (env : env) (x : CST.unary_expression) =
+  (match x with
+  | `Un_exp_PLUS_exp (v1, v2) ->
+      let v1 = token env v1 (* "+" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `Un_exp_DASH_exp (v1, v2) ->
+      let v1 = token env v1 (* "-" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `Un_exp_BANG_exp (v1, v2) ->
+      let v1 = token env v1 (* "!" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `Un_exp_TILDE_exp (v1, v2) ->
+      let v1 = token env v1 (* "~" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  )
+
+and map_formal_parameters (env : env) ((v1, v2, v3, v4) : CST.formal_parameters) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    (match v2 with
+    | Some x -> map_receiver_parameter env x
+    | None -> todo env ())
+  in
+  let v3 =
+    (match v3 with
+    | Some (v1, v2) ->
+        let v1 = map_anon_choice_form_param env v1 in
+        let v2 =
+          List.map (fun (v1, v2) ->
+            let v1 = token env v1 (* "," *) in
+            let v2 = map_anon_choice_form_param env v2 in
+            todo env (v1, v2)
+          ) v2
+        in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v4 = token env v4 (* ")" *) in
+  todo env (v1, v2, v3, v4)
+
+and map_array_access (env : env) ((v1, v2, v3, v4) : CST.array_access) =
+  let v1 = map_primary env v1 in
+  let v2 = token env v2 (* "[" *) in
+  let v3 = map_expression env v3 in
+  let v4 = token env v4 (* "]" *) in
+  todo env (v1, v2, v3, v4)
+
+and map_modifiers (env : env) (xs : CST.modifiers) =
+  List.map (fun x ->
+    (match x with
+    | `Anno x -> map_annotation env x
+    | `Publ tok -> token env tok (* "public" *)
+    | `Prot tok -> token env tok (* "protected" *)
+    | `Priv tok -> token env tok (* "private" *)
+    | `Abst tok -> token env tok (* "abstract" *)
+    | `Stat tok -> token env tok (* "static" *)
+    | `Final tok -> token env tok (* "final" *)
+    | `Stri tok -> token env tok (* "strictfp" *)
+    | `Defa tok -> token env tok (* "default" *)
+    | `Sync tok -> token env tok (* "synchronized" *)
+    | `Nati tok -> token env tok (* "native" *)
+    | `Tran tok -> token env tok (* "transient" *)
+    | `Vola tok -> token env tok (* "volatile" *)
+    )
+  ) xs
+
+and map_catch_formal_parameter (env : env) ((v1, v2, v3) : CST.catch_formal_parameter) =
+  let v1 =
+    (match v1 with
+    | Some x -> map_modifiers env x
+    | None -> todo env ())
+  in
+  let v2 = map_catch_type env v2 in
+  let v3 = map_variable_declarator_id env v3 in
+  todo env (v1, v2, v3)
 
 and map_statement (env : env) (x : CST.statement) =
   (match x with
@@ -865,16 +882,7 @@ and map_statement (env : env) (x : CST.statement) =
         | `Opt_exp_rep_COMMA_exp_SEMI (v1, v2) ->
             let v1 =
               (match v1 with
-              | Some (v1, v2) ->
-                  let v1 = map_expression env v1 in
-                  let v2 =
-                    List.map (fun (v1, v2) ->
-                      let v1 = token env v1 (* "," *) in
-                      let v2 = map_expression env v2 in
-                      todo env (v1, v2)
-                    ) v2
-                  in
-                  todo env (v1, v2)
+              | Some x -> map_anon_exp_rep_COMMA_exp env x
               | None -> todo env ())
             in
             let v2 = token env v2 (* ";" *) in
@@ -889,16 +897,7 @@ and map_statement (env : env) (x : CST.statement) =
       let v5 = token env v5 (* ";" *) in
       let v6 =
         (match v6 with
-        | Some (v1, v2) ->
-            let v1 = map_expression env v1 in
-            let v2 =
-              List.map (fun (v1, v2) ->
-                let v1 = token env v1 (* "," *) in
-                let v2 = map_expression env v2 in
-                todo env (v1, v2)
-              ) v2
-            in
-            todo env (v1, v2)
+        | Some x -> map_anon_exp_rep_COMMA_exp env x
         | None -> todo env ())
       in
       let v7 = token env v7 (* ")" *) in
@@ -999,167 +998,40 @@ and map_statement (env : env) (x : CST.statement) =
       todo env (v1, v2, v3, v4, v5)
   )
 
+and map_enum_body_declarations (env : env) ((v1, v2) : CST.enum_body_declarations) =
+  let v1 = token env v1 (* ";" *) in
+  let v2 = List.map (map_anon_choice_field_decl env) v2 in
+  todo env (v1, v2)
 
-and map_block (env : env) ((v1, v2, v3) : CST.block) =
-  let v1 = token env v1 (* "{" *) in
-  let v2 = List.map (map_statement env) v2 in
-  let v3 = token env v3 (* "}" *) in
-  todo env (v1, v2, v3)
-
-
-and map_assert_statement (env : env) (x : CST.assert_statement) =
+and map_anon_choice_prim (env : env) (x : CST.anon_choice_prim) =
   (match x with
-  | `Asse_stmt_asse_exp_SEMI (v1, v2, v3) ->
-      let v1 = token env v1 (* "assert" *) in
-      let v2 = map_expression env v2 in
-      let v3 = token env v3 (* ";" *) in
-      todo env (v1, v2, v3)
-  | `Asse_stmt_asse_exp_COLON_exp_SEMI (v1, v2, v3, v4, v5) ->
-      let v1 = token env v1 (* "assert" *) in
-      let v2 = map_expression env v2 in
-      let v3 = token env v3 (* ":" *) in
-      let v4 = map_expression env v4 in
-      let v5 = token env v5 (* ";" *) in
-      todo env (v1, v2, v3, v4, v5)
+  | `Prim x -> map_primary env x
+  | `Super tok -> token env tok (* "super" *)
   )
 
-
-and map_switch_block (env : env) ((v1, v2, v3) : CST.switch_block) =
-  let v1 = token env v1 (* "{" *) in
-  let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Swit_label x -> map_switch_label env x
-      | `Stmt x -> map_statement env x
-      )
-    ) v2
-  in
-  let v3 = token env v3 (* "}" *) in
-  todo env (v1, v2, v3)
-
-
-and map_switch_label (env : env) (x : CST.switch_label) =
+and map_unannotated_type (env : env) (x : CST.unannotated_type) =
   (match x with
-  | `Swit_label_case_exp_COLON (v1, v2, v3) ->
-      let v1 = token env v1 (* "case" *) in
-      let v2 = map_expression env v2 in
-      let v3 = token env v3 (* ":" *) in
-      todo env (v1, v2, v3)
-  | `Swit_label_defa_COLON (v1, v2) ->
-      let v1 = token env v1 (* "default" *) in
-      let v2 = token env v2 (* ":" *) in
+  | `Unan_type_choice_void_type x ->
+      map_anon_choice_void_type env x
+  | `Unan_type_array_type (v1, v2) ->
+      let v1 = map_unannotated_type env v1 in
+      let v2 = map_dimensions env v2 in
       todo env (v1, v2)
   )
 
-
-and map_catch_clause (env : env) ((v1, v2, v3, v4, v5) : CST.catch_clause) =
-  let v1 = token env v1 (* "catch" *) in
-  let v2 = token env v2 (* "(" *) in
-  let v3 = map_catch_formal_parameter env v3 in
-  let v4 = token env v4 (* ")" *) in
-  let v5 = map_block env v5 in
-  todo env (v1, v2, v3, v4, v5)
-
-
-and map_catch_formal_parameter (env : env) ((v1, v2, v3) : CST.catch_formal_parameter) =
-  let v1 =
-    (match v1 with
-    | Some x -> map_modifiers env x
-    | None -> todo env ())
-  in
-  let v2 = map_catch_type env v2 in
-  let v3 = map_variable_declarator_id env v3 in
-  todo env (v1, v2, v3)
-
-
-and map_catch_type (env : env) ((v1, v2) : CST.catch_type) =
-  let v1 = map_unannotated_type env v1 in
-  let v2 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "|" *) in
-      let v2 = map_unannotated_type env v2 in
-      todo env (v1, v2)
-    ) v2
-  in
-  todo env (v1, v2)
-
-
-and map_finally_clause (env : env) ((v1, v2) : CST.finally_clause) =
-  let v1 = token env v1 (* "finally" *) in
-  let v2 = map_block env v2 in
-  todo env (v1, v2)
-
-
-and map_resource_specification (env : env) ((v1, v2, v3, v4, v5) : CST.resource_specification) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 = map_resource env v2 in
+and map_receiver_parameter (env : env) ((v1, v2, v3, v4) : CST.receiver_parameter) =
+  let v1 = List.map (map_annotation env) v1 in
+  let v2 = map_unannotated_type env v2 in
   let v3 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* ";" *) in
-      let v2 = map_resource env v2 in
-      todo env (v1, v2)
-    ) v3
-  in
-  let v4 =
-    (match v4 with
-    | Some tok -> token env tok (* ";" *)
+    (match v3 with
+    | Some (v1, v2) ->
+        let v1 = token env v1 (* pattern [a-zA-Z_]\w* *) in
+        let v2 = token env v2 (* "." *) in
+        todo env (v1, v2)
     | None -> todo env ())
   in
-  let v5 = token env v5 (* ")" *) in
-  todo env (v1, v2, v3, v4, v5)
-
-
-and map_resource (env : env) (x : CST.resource) =
-  (match x with
-  | `Reso_opt_modifs_unan_type_var_decl_id_EQ_exp (v1, v2, v3, v4, v5) ->
-      let v1 =
-        (match v1 with
-        | Some x -> map_modifiers env x
-        | None -> todo env ())
-      in
-      let v2 = map_unannotated_type env v2 in
-      let v3 = map_variable_declarator_id env v3 in
-      let v4 = token env v4 (* "=" *) in
-      let v5 = map_expression env v5 in
-      todo env (v1, v2, v3, v4, v5)
-  | `Reso_id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-  | `Reso_field_acce x -> map_field_access env x
-  )
-
-
-and map_annotation (env : env) (x : CST.annotation) =
-  (match x with
-  | `Anno_mark_anno (v1, v2) ->
-      let v1 = token env v1 (* "@" *) in
-      let v2 =
-        (match v2 with
-        | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-        | `Choice_open x ->
-            (match x with
-            | `Open tok -> token env tok (* "open" *)
-            | `Modu tok -> token env tok (* "module" *)
-            )
-        | `Scop_id x -> map_scoped_identifier env x
-        )
-      in
-      todo env (v1, v2)
-  | `Anno_anno_ (v1, v2, v3) ->
-      let v1 = token env v1 (* "@" *) in
-      let v2 =
-        (match v2 with
-        | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-        | `Choice_open x ->
-            (match x with
-            | `Open tok -> token env tok (* "open" *)
-            | `Modu tok -> token env tok (* "module" *)
-            )
-        | `Scop_id x -> map_scoped_identifier env x
-        )
-      in
-      let v3 = map_annotation_argument_list env v3 in
-      todo env (v1, v2, v3)
-  )
-
+  let v4 = token env v4 (* "this" *) in
+  todo env (v1, v2, v3, v4)
 
 and map_annotation_argument_list (env : env) ((v1, v2, v3) : CST.annotation_argument_list) =
   let v1 = token env v1 (* "(" *) in
@@ -1184,134 +1056,159 @@ and map_annotation_argument_list (env : env) ((v1, v2, v3) : CST.annotation_argu
   let v3 = token env v3 (* ")" *) in
   todo env (v1, v2, v3)
 
-
-and map_element_value_pair (env : env) ((v1, v2, v3) : CST.element_value_pair) =
-  let v1 = token env v1 (* pattern [a-zA-Z_]\w* *) in
-  let v2 = token env v2 (* "=" *) in
-  let v3 = map_element_value env v3 in
-  todo env (v1, v2, v3)
-
-
-and map_element_value (env : env) (x : CST.element_value) =
-  (match x with
-  | `Exp x -> map_expression env x
-  | `Elem_value_array_init (v1, v2, v3, v4) ->
-      let v1 = token env v1 (* "{" *) in
-      let v2 =
-        (match v2 with
-        | Some (v1, v2) ->
-            let v1 = map_element_value env v1 in
-            let v2 =
-              List.map (fun (v1, v2) ->
-                let v1 = token env v1 (* "," *) in
-                let v2 = map_element_value env v2 in
-                todo env (v1, v2)
-              ) v2
-            in
-            todo env (v1, v2)
-        | None -> todo env ())
-      in
-      let v3 =
-        (match v3 with
-        | Some tok -> token env tok (* "," *)
-        | None -> todo env ())
-      in
-      let v4 = token env v4 (* "}" *) in
-      todo env (v1, v2, v3, v4)
-  | `Anno x -> map_annotation env x
-  )
-
-
-and map_declaration (env : env) (x : CST.declaration) =
-  (match x with
-  | `Modu_decl (v1, v2, v3, v4, v5) ->
-      let v1 = List.map (map_annotation env) v1 in
-      let v2 =
-        (match v2 with
-        | Some tok -> token env tok (* "open" *)
-        | None -> todo env ())
-      in
-      let v3 = token env v3 (* "module" *) in
-      let v4 =
-        (match v4 with
-        | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-        | `Choice_open x ->
-            (match x with
-            | `Open tok -> token env tok (* "open" *)
-            | `Modu tok -> token env tok (* "module" *)
-            )
-        | `Scop_id x -> map_scoped_identifier env x
-        )
-      in
-      let v5 = map_module_body env v5 in
-      todo env (v1, v2, v3, v4, v5)
-  | `Pack_decl (v1, v2, v3, v4) ->
-      let v1 = List.map (map_annotation env) v1 in
-      let v2 = token env v2 (* "package" *) in
-      let v3 =
-        (match v3 with
-        | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-        | `Choice_open x ->
-            (match x with
-            | `Open tok -> token env tok (* "open" *)
-            | `Modu tok -> token env tok (* "module" *)
-            )
-        | `Scop_id x -> map_scoped_identifier env x
-        )
-      in
-      let v4 = token env v4 (* ";" *) in
-      todo env (v1, v2, v3, v4)
-  | `Impo_decl (v1, v2, v3, v4, v5) ->
-      let v1 = token env v1 (* "import" *) in
-      let v2 =
-        (match v2 with
-        | Some tok -> token env tok (* "static" *)
-        | None -> todo env ())
-      in
-      let v3 =
-        (match v3 with
-        | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-        | `Choice_open x ->
-            (match x with
-            | `Open tok -> token env tok (* "open" *)
-            | `Modu tok -> token env tok (* "module" *)
-            )
-        | `Scop_id x -> map_scoped_identifier env x
-        )
-      in
-      let v4 =
-        (match v4 with
-        | Some (v1, v2) ->
-            let v1 = token env v1 (* "." *) in
-            let v2 = token env v2 (* "*" *) in
-            todo env (v1, v2)
-        | None -> todo env ())
-      in
-      let v5 = token env v5 (* ";" *) in
-      todo env (v1, v2, v3, v4, v5)
-  | `Class_decl x -> map_class_declaration env x
-  | `Inte_decl x -> map_interface_declaration env x
-  | `Anno_type_decl x -> map_annotation_type_declaration env x
-  | `Enum_decl x -> map_enum_declaration env x
-  )
-
-
-and map_enum_declaration (env : env) ((v1, v2, v3, v4, v5) : CST.enum_declaration) =
+and map_enum_constant (env : env) ((v1, v2, v3, v4) : CST.enum_constant) =
   let v1 =
     (match v1 with
     | Some x -> map_modifiers env x
     | None -> todo env ())
   in
-  let v2 = token env v2 (* "enum" *) in
+  let v2 = token env v2 (* pattern [a-zA-Z_]\w* *) in
+  let v3 =
+    (match v3 with
+    | Some x -> map_argument_list env x
+    | None -> todo env ())
+  in
+  let v4 =
+    (match v4 with
+    | Some x -> map_class_body env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3, v4)
+
+and map_class_declaration (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.class_declaration) =
+  let v1 =
+    (match v1 with
+    | Some x -> map_modifiers env x
+    | None -> todo env ())
+  in
+  let v2 = token env v2 (* "class" *) in
   let v3 = token env v3 (* pattern [a-zA-Z_]\w* *) in
   let v4 =
     (match v4 with
+    | Some x -> map_type_parameters env x
+    | None -> todo env ())
+  in
+  let v5 =
+    (match v5 with
+    | Some x -> map_superclass env x
+    | None -> todo env ())
+  in
+  let v6 =
+    (match v6 with
     | Some x -> map_super_interfaces env x
     | None -> todo env ())
   in
-  let v5 = map_enum_body env v5 in
-  todo env (v1, v2, v3, v4, v5)
+  let v7 = map_class_body env v7 in
+  todo env (v1, v2, v3, v4, v5, v6, v7)
 
+and map_annotation (env : env) (x : CST.annotation) =
+  (match x with
+  | `Anno_mark_anno (v1, v2) ->
+      let v1 = token env v1 (* "@" *) in
+      let v2 = map_anon_choice_id_ env v2 in
+      todo env (v1, v2)
+  | `Anno_anno_ (v1, v2, v3) ->
+      let v1 = token env v1 (* "@" *) in
+      let v2 = map_anon_choice_id_ env v2 in
+      let v3 = map_annotation_argument_list env v3 in
+      todo env (v1, v2, v3)
+  )
+
+and map_annotation_type_body (env : env) ((v1, v2, v3) : CST.annotation_type_body) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    List.map (fun x ->
+      (match x with
+      | `Anno_type_elem_decl x ->
+          map_annotation_type_element_declaration env x
+      | `Cst_decl x -> map_constant_declaration env x
+      | `Class_decl x -> map_class_declaration env x
+      | `Inte_decl x -> map_interface_declaration env x
+      | `Anno_type_decl x -> map_annotation_type_declaration env x
+      )
+    ) v2
+  in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+and map_object_creation_expression (env : env) (x : CST.object_creation_expression) =
+  (match x with
+  | `Obj_crea_exp_unqu_obj_crea_exp x ->
+      map_unqualified_object_creation_expression env x
+  | `Obj_crea_exp_prim_DOT_unqu_obj_crea_exp (v1, v2, v3) ->
+      let v1 = map_primary env v1 in
+      let v2 = token env v2 (* "." *) in
+      let v3 =
+        map_unqualified_object_creation_expression env v3
+      in
+      todo env (v1, v2, v3)
+  )
+
+and map_update_expression (env : env) (x : CST.update_expression) =
+  (match x with
+  | `Exp_PLUSPLUS (v1, v2) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "++" *) in
+      todo env (v1, v2)
+  | `Exp_DASHDASH (v1, v2) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "--" *) in
+      todo env (v1, v2)
+  | `PLUSPLUS_exp (v1, v2) ->
+      let v1 = token env v1 (* "++" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `DASHDASH_exp (v1, v2) ->
+      let v1 = token env v1 (* "--" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  )
+
+and map_wildcard_bounds (env : env) (x : CST.wildcard_bounds) =
+  (match x with
+  | `Wild_bounds_extens_type x -> map_superclass env x
+  | `Wild_bounds_super_type (v1, v2) ->
+      let v1 = token env v1 (* "super" *) in
+      let v2 = map_type_ env v2 in
+      todo env (v1, v2)
+  )
+
+and map_anon_choice_form_param (env : env) (x : CST.anon_choice_form_param) =
+  (match x with
+  | `Form_param (v1, v2, v3) ->
+      let v1 =
+        (match v1 with
+        | Some x -> map_modifiers env x
+        | None -> todo env ())
+      in
+      let v2 = map_unannotated_type env v2 in
+      let v3 = map_variable_declarator_id env v3 in
+      todo env (v1, v2, v3)
+  | `Spre_param (v1, v2, v3, v4) ->
+      let v1 =
+        (match v1 with
+        | Some x -> map_modifiers env x
+        | None -> todo env ())
+      in
+      let v2 = map_unannotated_type env v2 in
+      let v3 = token env v3 (* "..." *) in
+      let v4 = map_variable_declarator env v4 in
+      todo env (v1, v2, v3, v4)
+  )
+
+and map_program (env : env) (xs : CST.program) =
+  List.map (map_statement env) xs
+
+and map_constant_declaration (env : env) ((v1, v2, v3, v4) : CST.constant_declaration) =
+  let v1 =
+    (match v1 with
+    | Some x -> map_modifiers env x
+    | None -> todo env ())
+  in
+  let v2 = map_unannotated_type env v2 in
+  let v3 = map_variable_declarator_list env v3 in
+  let v4 = token env v4 (* ";" *) in
+  todo env (v1, v2, v3, v4)
 
 and map_enum_body (env : env) ((v1, v2, v3, v4, v5) : CST.enum_body) =
   let v1 = token env v1 (* "{" *) in
@@ -1342,94 +1239,185 @@ and map_enum_body (env : env) ((v1, v2, v3, v4, v5) : CST.enum_body) =
   let v5 = token env v5 (* "}" *) in
   todo env (v1, v2, v3, v4, v5)
 
-
-and map_enum_body_declarations (env : env) ((v1, v2) : CST.enum_body_declarations) =
-  let v1 = token env v1 (* ";" *) in
+and map_variable_declarator_id (env : env) ((v1, v2) : CST.variable_declarator_id) =
+  let v1 = map_anon_choice_id env v1 in
   let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Field_decl x -> map_field_declaration env x
-      | `Meth_decl x -> map_method_declaration env x
-      | `Class_decl x -> map_class_declaration env x
-      | `Inte_decl x -> map_interface_declaration env x
-      | `Anno_type_decl x -> map_annotation_type_declaration env x
-      | `Enum_decl x -> map_enum_declaration env x
-      | `Blk x -> map_block env x
-      | `Stat_init x -> map_static_initializer env x
-      | `Cons_decl x -> map_constructor_declaration env x
-      | `SEMI tok -> token env tok (* ";" *)
-      )
-    ) v2
+    (match v2 with
+    | Some x -> map_dimensions env x
+    | None -> todo env ())
   in
   todo env (v1, v2)
 
+and map_assert_statement (env : env) (x : CST.assert_statement) =
+  (match x with
+  | `Asse_stmt_asse_exp_SEMI (v1, v2, v3) ->
+      let v1 = token env v1 (* "assert" *) in
+      let v2 = map_expression env v2 in
+      let v3 = token env v3 (* ";" *) in
+      todo env (v1, v2, v3)
+  | `Asse_stmt_asse_exp_COLON_exp_SEMI (v1, v2, v3, v4, v5) ->
+      let v1 = token env v1 (* "assert" *) in
+      let v2 = map_expression env v2 in
+      let v3 = token env v3 (* ":" *) in
+      let v4 = map_expression env v4 in
+      let v5 = token env v5 (* ";" *) in
+      todo env (v1, v2, v3, v4, v5)
+  )
 
-and map_enum_constant (env : env) ((v1, v2, v3, v4) : CST.enum_constant) =
-  let v1 =
-    (match v1 with
-    | Some x -> map_modifiers env x
+and map_resource (env : env) (x : CST.resource) =
+  (match x with
+  | `Reso_opt_modifs_unan_type_var_decl_id_EQ_exp (v1, v2, v3, v4, v5) ->
+      let v1 =
+        (match v1 with
+        | Some x -> map_modifiers env x
+        | None -> todo env ())
+      in
+      let v2 = map_unannotated_type env v2 in
+      let v3 = map_variable_declarator_id env v3 in
+      let v4 = token env v4 (* "=" *) in
+      let v5 = map_expression env v5 in
+      todo env (v1, v2, v3, v4, v5)
+  | `Reso_id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
+  | `Reso_field_acce x -> map_field_access env x
+  )
+
+and map_superclass (env : env) ((v1, v2) : CST.superclass) =
+  let v1 = token env v1 (* "extends" *) in
+  let v2 = map_type_ env v2 in
+  todo env (v1, v2)
+
+and map_element_value (env : env) (x : CST.element_value) =
+  (match x with
+  | `Exp x -> map_expression env x
+  | `Elem_value_array_init (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "{" *) in
+      let v2 =
+        (match v2 with
+        | Some (v1, v2) ->
+            let v1 = map_element_value env v1 in
+            let v2 =
+              List.map (fun (v1, v2) ->
+                let v1 = token env v1 (* "," *) in
+                let v2 = map_element_value env v2 in
+                todo env (v1, v2)
+              ) v2
+            in
+            todo env (v1, v2)
+        | None -> todo env ())
+      in
+      let v3 =
+        (match v3 with
+        | Some tok -> token env tok (* "," *)
+        | None -> todo env ())
+      in
+      let v4 = token env v4 (* "}" *) in
+      todo env (v1, v2, v3, v4)
+  | `Anno x -> map_annotation env x
+  )
+
+and map_finally_clause (env : env) ((v1, v2) : CST.finally_clause) =
+  let v1 = token env v1 (* "finally" *) in
+  let v2 = map_block env v2 in
+  todo env (v1, v2)
+
+and map_constructor_body (env : env) ((v1, v2, v3, v4) : CST.constructor_body) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    (match v2 with
+    | Some x -> map_explicit_constructor_invocation env x
     | None -> todo env ())
   in
-  let v2 = token env v2 (* pattern [a-zA-Z_]\w* *) in
-  let v3 =
-    (match v3 with
-    | Some x -> map_argument_list env x
+  let v3 = map_program env v3 in
+  let v4 = token env v4 (* "}" *) in
+  todo env (v1, v2, v3, v4)
+
+and map_unqualified_object_creation_expression (env : env) ((v1, v2, v3, v4, v5) : CST.unqualified_object_creation_expression) =
+  let v1 = token env v1 (* "new" *) in
+  let v2 =
+    (match v2 with
+    | Some x -> map_type_arguments env x
     | None -> todo env ())
   in
-  let v4 =
-    (match v4 with
+  let v3 = map_anon_choice_void_type env v3 in
+  let v4 = map_argument_list env v4 in
+  let v5 =
+    (match v5 with
     | Some x -> map_class_body env x
     | None -> todo env ())
   in
-  todo env (v1, v2, v3, v4)
+  todo env (v1, v2, v3, v4, v5)
 
+and map_switch_block (env : env) ((v1, v2, v3) : CST.switch_block) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    List.map (fun x ->
+      (match x with
+      | `Swit_label x -> map_switch_label env x
+      | `Stmt x -> map_statement env x
+      )
+    ) v2
+  in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
 
-and map_class_declaration (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.class_declaration) =
+and map_default_value (env : env) ((v1, v2) : CST.default_value) =
+  let v1 = token env v1 (* "default" *) in
+  let v2 = map_element_value env v2 in
+  todo env (v1, v2)
+
+and map_method_declaration (env : env) ((v1, v2, v3) : CST.method_declaration) =
   let v1 =
     (match v1 with
     | Some x -> map_modifiers env x
     | None -> todo env ())
   in
-  let v2 = token env v2 (* "class" *) in
-  let v3 = token env v3 (* pattern [a-zA-Z_]\w* *) in
+  let v2 = map_method_header env v2 in
+  let v3 =
+    (match v3 with
+    | `Blk x -> map_block env x
+    | `SEMI tok -> token env tok (* ";" *)
+    )
+  in
+  todo env (v1, v2, v3)
+
+and map_field_access (env : env) ((v1, v2, v3, v4) : CST.field_access) =
+  let v1 = map_anon_choice_prim env v1 in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2) ->
+        let v1 = token env v1 (* "." *) in
+        let v2 = token env v2 (* "super" *) in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* "." *) in
   let v4 =
     (match v4 with
-    | Some x -> map_type_parameters env x
-    | None -> todo env ())
-  in
-  let v5 =
-    (match v5 with
-    | Some x -> map_superclass env x
-    | None -> todo env ())
-  in
-  let v6 =
-    (match v6 with
-    | Some x -> map_super_interfaces env x
-    | None -> todo env ())
-  in
-  let v7 = map_class_body env v7 in
-  todo env (v1, v2, v3, v4, v5, v6, v7)
-
-
-and map_modifiers (env : env) (xs : CST.modifiers) =
-  List.map (fun x ->
-    (match x with
-    | `Anno x -> map_annotation env x
-    | `Publ tok -> token env tok (* "public" *)
-    | `Prot tok -> token env tok (* "protected" *)
-    | `Priv tok -> token env tok (* "private" *)
-    | `Abst tok -> token env tok (* "abstract" *)
-    | `Stat tok -> token env tok (* "static" *)
-    | `Final tok -> token env tok (* "final" *)
-    | `Stri tok -> token env tok (* "strictfp" *)
-    | `Defa tok -> token env tok (* "default" *)
-    | `Sync tok -> token env tok (* "synchronized" *)
-    | `Nati tok -> token env tok (* "native" *)
-    | `Tran tok -> token env tok (* "transient" *)
-    | `Vola tok -> token env tok (* "volatile" *)
+    | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
+    | `Choice_open x -> map_anon_choice_open env x
+    | `This tok -> token env tok (* "this" *)
     )
-  ) xs
+  in
+  todo env (v1, v2, v3, v4)
 
+and map_argument_list (env : env) ((v1, v2, v3) : CST.argument_list) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    (match v2 with
+    | Some x -> map_anon_exp_rep_COMMA_exp env x
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
+
+and map_type_ (env : env) (x : CST.type_) =
+  (match x with
+  | `Type_unan_type x -> map_unannotated_type env x
+  | `Type_anno_type (v1, v2) ->
+      let v1 = List.map (map_annotation env) v1 in
+      let v2 = map_unannotated_type env v2 in
+      todo env (v1, v2)
+  )
 
 and map_type_parameters (env : env) ((v1, v2, v3, v4) : CST.type_parameters) =
   let v1 = token env v1 (* "<" *) in
@@ -1444,121 +1432,56 @@ and map_type_parameters (env : env) ((v1, v2, v3, v4) : CST.type_parameters) =
   let v4 = token env v4 (* ">" *) in
   todo env (v1, v2, v3, v4)
 
-
-and map_type_parameter (env : env) ((v1, v2, v3) : CST.type_parameter) =
-  let v1 = List.map (map_annotation env) v1 in
-  let v2 = token env v2 (* pattern [a-zA-Z_]\w* *) in
-  let v3 =
-    (match v3 with
-    | Some x -> map_type_bound env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3)
-
-
-and map_type_bound (env : env) ((v1, v2, v3) : CST.type_bound) =
-  let v1 = token env v1 (* "extends" *) in
-  let v2 = map_type_ env v2 in
-  let v3 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "&" *) in
-      let v2 = map_type_ env v2 in
+and map_anon_choice_field_decl (env : env) (x : CST.anon_choice_field_decl) =
+  (match x with
+  | `Field_decl (v1, v2, v3, v4) ->
+      let v1 =
+        (match v1 with
+        | Some x -> map_modifiers env x
+        | None -> todo env ())
+      in
+      let v2 = map_unannotated_type env v2 in
+      let v3 = map_variable_declarator_list env v3 in
+      let v4 = token env v4 (* ";" *) in
+      todo env (v1, v2, v3, v4)
+  | `Meth_decl x -> map_method_declaration env x
+  | `Class_decl x -> map_class_declaration env x
+  | `Inte_decl x -> map_interface_declaration env x
+  | `Anno_type_decl x -> map_annotation_type_declaration env x
+  | `Enum_decl x -> map_enum_declaration env x
+  | `Blk x -> map_block env x
+  | `Stat_init (v1, v2) ->
+      let v1 = token env v1 (* "static" *) in
+      let v2 = map_block env v2 in
       todo env (v1, v2)
-    ) v3
-  in
-  todo env (v1, v2, v3)
-
-
-and map_superclass (env : env) ((v1, v2) : CST.superclass) =
-  let v1 = token env v1 (* "extends" *) in
-  let v2 = map_type_ env v2 in
-  todo env (v1, v2)
-
+  | `Cons_decl (v1, v2, v3, v4) ->
+      let v1 =
+        (match v1 with
+        | Some x -> map_modifiers env x
+        | None -> todo env ())
+      in
+      let v2 = map_constructor_declarator env v2 in
+      let v3 =
+        (match v3 with
+        | Some x -> map_throws env x
+        | None -> todo env ())
+      in
+      let v4 = map_constructor_body env v4 in
+      todo env (v1, v2, v3, v4)
+  | `SEMI tok -> token env tok (* ";" *)
+  )
 
 and map_super_interfaces (env : env) ((v1, v2) : CST.super_interfaces) =
   let v1 = token env v1 (* "implements" *) in
   let v2 = map_interface_type_list env v2 in
   todo env (v1, v2)
 
-
-and map_interface_type_list (env : env) ((v1, v2) : CST.interface_type_list) =
-  let v1 = map_type_ env v1 in
-  let v2 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 = map_type_ env v2 in
-      todo env (v1, v2)
-    ) v2
-  in
-  todo env (v1, v2)
-
-
-and map_class_body (env : env) ((v1, v2, v3) : CST.class_body) =
-  let v1 = token env v1 (* "{" *) in
-  let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Field_decl x -> map_field_declaration env x
-      | `Meth_decl x -> map_method_declaration env x
-      | `Class_decl x -> map_class_declaration env x
-      | `Inte_decl x -> map_interface_declaration env x
-      | `Anno_type_decl x -> map_annotation_type_declaration env x
-      | `Enum_decl x -> map_enum_declaration env x
-      | `Blk x -> map_block env x
-      | `Stat_init x -> map_static_initializer env x
-      | `Cons_decl x -> map_constructor_declaration env x
-      | `SEMI tok -> token env tok (* ";" *)
-      )
-    ) v2
-  in
-  let v3 = token env v3 (* "}" *) in
-  todo env (v1, v2, v3)
-
-
-and map_static_initializer (env : env) ((v1, v2) : CST.static_initializer) =
-  let v1 = token env v1 (* "static" *) in
-  let v2 = map_block env v2 in
-  todo env (v1, v2)
-
-
-and map_constructor_declaration (env : env) ((v1, v2, v3, v4) : CST.constructor_declaration) =
-  let v1 =
-    (match v1 with
-    | Some x -> map_modifiers env x
-    | None -> todo env ())
-  in
-  let v2 = map_constructor_declarator env v2 in
-  let v3 =
-    (match v3 with
-    | Some x -> map_throws env x
-    | None -> todo env ())
-  in
-  let v4 = map_constructor_body env v4 in
+and map_dimensions_expr (env : env) ((v1, v2, v3, v4) : CST.dimensions_expr) =
+  let v1 = List.map (map_annotation env) v1 in
+  let v2 = token env v2 (* "[" *) in
+  let v3 = map_expression env v3 in
+  let v4 = token env v4 (* "]" *) in
   todo env (v1, v2, v3, v4)
-
-
-and map_constructor_declarator (env : env) ((v1, v2, v3) : CST.constructor_declarator) =
-  let v1 =
-    (match v1 with
-    | Some x -> map_type_parameters env x
-    | None -> todo env ())
-  in
-  let v2 = token env v2 (* pattern [a-zA-Z_]\w* *) in
-  let v3 = map_formal_parameters env v3 in
-  todo env (v1, v2, v3)
-
-
-and map_constructor_body (env : env) ((v1, v2, v3, v4) : CST.constructor_body) =
-  let v1 = token env v1 (* "{" *) in
-  let v2 =
-    (match v2 with
-    | Some x -> map_explicit_constructor_invocation env x
-    | None -> todo env ())
-  in
-  let v3 = List.map (map_statement env) v3 in
-  let v4 = token env v4 (* "}" *) in
-  todo env (v1, v2, v3, v4)
-
 
 and map_explicit_constructor_invocation (env : env) ((v1, v2, v3) : CST.explicit_constructor_invocation) =
   let v1 =
@@ -1596,275 +1519,131 @@ and map_explicit_constructor_invocation (env : env) ((v1, v2, v3) : CST.explicit
   let v3 = token env v3 (* ";" *) in
   todo env (v1, v2, v3)
 
-
-and map_field_declaration (env : env) ((v1, v2, v3, v4) : CST.field_declaration) =
+and map_constructor_declarator (env : env) ((v1, v2, v3) : CST.constructor_declarator) =
   let v1 =
     (match v1 with
-    | Some x -> map_modifiers env x
-    | None -> todo env ())
-  in
-  let v2 = map_unannotated_type env v2 in
-  let v3 = map_variable_declarator_list env v3 in
-  let v4 = token env v4 (* ";" *) in
-  todo env (v1, v2, v3, v4)
-
-
-and map_annotation_type_declaration (env : env) ((v1, v2, v3, v4) : CST.annotation_type_declaration) =
-  let v1 =
-    (match v1 with
-    | Some x -> map_modifiers env x
-    | None -> todo env ())
-  in
-  let v2 = token env v2 (* "@interface" *) in
-  let v3 = token env v3 (* pattern [a-zA-Z_]\w* *) in
-  let v4 = map_annotation_type_body env v4 in
-  todo env (v1, v2, v3, v4)
-
-
-and map_annotation_type_body (env : env) ((v1, v2, v3) : CST.annotation_type_body) =
-  let v1 = token env v1 (* "{" *) in
-  let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Anno_type_elem_decl x ->
-          map_annotation_type_element_declaration env x
-      | `Cst_decl x -> map_constant_declaration env x
-      | `Class_decl x -> map_class_declaration env x
-      | `Inte_decl x -> map_interface_declaration env x
-      | `Anno_type_decl x -> map_annotation_type_declaration env x
-      )
-    ) v2
-  in
-  let v3 = token env v3 (* "}" *) in
-  todo env (v1, v2, v3)
-
-
-and map_annotation_type_element_declaration (env : env) ((v1, v2, v3, v4, v5, v6, v7, v8) : CST.annotation_type_element_declaration) =
-  let v1 =
-    (match v1 with
-    | Some x -> map_modifiers env x
-    | None -> todo env ())
-  in
-  let v2 = map_unannotated_type env v2 in
-  let v3 = token env v3 (* pattern [a-zA-Z_]\w* *) in
-  let v4 = token env v4 (* "(" *) in
-  let v5 = token env v5 (* ")" *) in
-  let v6 =
-    (match v6 with
-    | Some x -> map_dimensions env x
-    | None -> todo env ())
-  in
-  let v7 =
-    (match v7 with
-    | Some x -> map_default_value env x
-    | None -> todo env ())
-  in
-  let v8 = token env v8 (* ";" *) in
-  todo env (v1, v2, v3, v4, v5, v6, v7, v8)
-
-
-and map_default_value (env : env) ((v1, v2) : CST.default_value) =
-  let v1 = token env v1 (* "default" *) in
-  let v2 = map_element_value env v2 in
-  todo env (v1, v2)
-
-
-and map_interface_declaration (env : env) ((v1, v2, v3, v4, v5, v6) : CST.interface_declaration) =
-  let v1 =
-    (match v1 with
-    | Some x -> map_modifiers env x
-    | None -> todo env ())
-  in
-  let v2 = token env v2 (* "interface" *) in
-  let v3 = token env v3 (* pattern [a-zA-Z_]\w* *) in
-  let v4 =
-    (match v4 with
     | Some x -> map_type_parameters env x
     | None -> todo env ())
   in
-  let v5 =
-    (match v5 with
-    | Some x -> map_extends_interfaces env x
-    | None -> todo env ())
-  in
-  let v6 = map_interface_body env v6 in
-  todo env (v1, v2, v3, v4, v5, v6)
-
-
-and map_extends_interfaces (env : env) ((v1, v2) : CST.extends_interfaces) =
-  let v1 = token env v1 (* "extends" *) in
-  let v2 = map_interface_type_list env v2 in
-  todo env (v1, v2)
-
-
-and map_interface_body (env : env) ((v1, v2, v3) : CST.interface_body) =
-  let v1 = token env v1 (* "{" *) in
-  let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Cst_decl x -> map_constant_declaration env x
-      | `Enum_decl x -> map_enum_declaration env x
-      | `Meth_decl x -> map_method_declaration env x
-      | `Class_decl x -> map_class_declaration env x
-      | `Inte_decl x -> map_interface_declaration env x
-      | `Anno_type_decl x -> map_annotation_type_declaration env x
-      | `SEMI tok -> token env tok (* ";" *)
-      )
-    ) v2
-  in
-  let v3 = token env v3 (* "}" *) in
+  let v2 = token env v2 (* pattern [a-zA-Z_]\w* *) in
+  let v3 = map_formal_parameters env v3 in
   todo env (v1, v2, v3)
 
+and map_type_bound (env : env) ((v1, v2, v3) : CST.type_bound) =
+  let v1 = token env v1 (* "extends" *) in
+  let v2 = map_type_ env v2 in
+  let v3 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "&" *) in
+      let v2 = map_type_ env v2 in
+      todo env (v1, v2)
+    ) v3
+  in
+  todo env (v1, v2, v3)
 
-and map_constant_declaration (env : env) ((v1, v2, v3, v4) : CST.constant_declaration) =
+and map_method_declarator (env : env) ((v1, v2, v3) : CST.method_declarator) =
+  let v1 = map_anon_choice_id env v1 in
+  let v2 = map_formal_parameters env v2 in
+  let v3 =
+    (match v3 with
+    | Some x -> map_dimensions env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3)
+
+and map_declaration (env : env) (x : CST.declaration) =
+  (match x with
+  | `Modu_decl (v1, v2, v3, v4, v5) ->
+      let v1 = List.map (map_annotation env) v1 in
+      let v2 =
+        (match v2 with
+        | Some tok -> token env tok (* "open" *)
+        | None -> todo env ())
+      in
+      let v3 = token env v3 (* "module" *) in
+      let v4 = map_anon_choice_id_ env v4 in
+      let v5 = map_module_body env v5 in
+      todo env (v1, v2, v3, v4, v5)
+  | `Pack_decl (v1, v2, v3, v4) ->
+      let v1 = List.map (map_annotation env) v1 in
+      let v2 = token env v2 (* "package" *) in
+      let v3 = map_anon_choice_id_ env v3 in
+      let v4 = token env v4 (* ";" *) in
+      todo env (v1, v2, v3, v4)
+  | `Impo_decl (v1, v2, v3, v4, v5) ->
+      let v1 = token env v1 (* "import" *) in
+      let v2 =
+        (match v2 with
+        | Some tok -> token env tok (* "static" *)
+        | None -> todo env ())
+      in
+      let v3 = map_anon_choice_id_ env v3 in
+      let v4 =
+        (match v4 with
+        | Some (v1, v2) ->
+            let v1 = token env v1 (* "." *) in
+            let v2 = token env v2 (* "*" *) in
+            todo env (v1, v2)
+        | None -> todo env ())
+      in
+      let v5 = token env v5 (* ";" *) in
+      todo env (v1, v2, v3, v4, v5)
+  | `Class_decl x -> map_class_declaration env x
+  | `Inte_decl x -> map_interface_declaration env x
+  | `Anno_type_decl x -> map_annotation_type_declaration env x
+  | `Enum_decl x -> map_enum_declaration env x
+  )
+
+and map_anon_choice_void_type (env : env) (x : CST.anon_choice_void_type) =
+  (match x with
+  | `Void_type tok -> token env tok (* "void" *)
+  | `Inte_type x -> map_integral_type env x
+  | `Floa_point_type x -> map_floating_point_type env x
+  | `Bool_type tok -> token env tok (* "boolean" *)
+  | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
+  | `Scop_type_id x -> map_scoped_type_identifier env x
+  | `Gene_type x -> map_generic_type env x
+  )
+
+and map_resource_specification (env : env) ((v1, v2, v3, v4, v5) : CST.resource_specification) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 = map_resource env v2 in
+  let v3 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* ";" *) in
+      let v2 = map_resource env v2 in
+      todo env (v1, v2)
+    ) v3
+  in
+  let v4 =
+    (match v4 with
+    | Some tok -> token env tok (* ";" *)
+    | None -> todo env ())
+  in
+  let v5 = token env v5 (* ")" *) in
+  todo env (v1, v2, v3, v4, v5)
+
+and map_enum_declaration (env : env) ((v1, v2, v3, v4, v5) : CST.enum_declaration) =
   let v1 =
     (match v1 with
     | Some x -> map_modifiers env x
     | None -> todo env ())
   in
-  let v2 = map_unannotated_type env v2 in
-  let v3 = map_variable_declarator_list env v3 in
-  let v4 = token env v4 (* ";" *) in
-  todo env (v1, v2, v3, v4)
-
-
-and map_variable_declarator_list (env : env) ((v1, v2) : CST.variable_declarator_list) =
-  let v1 = map_variable_declarator env v1 in
-  let v2 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 = map_variable_declarator env v2 in
-      todo env (v1, v2)
-    ) v2
-  in
-  todo env (v1, v2)
-
-
-and map_variable_declarator (env : env) ((v1, v2) : CST.variable_declarator) =
-  let v1 = map_variable_declarator_id env v1 in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) ->
-        let v1 = token env v1 (* "=" *) in
-        let v2 =
-          (match v2 with
-          | `Exp x -> map_expression env x
-          | `Array_init x -> map_array_initializer env x
-          )
-        in
-        todo env (v1, v2)
+  let v2 = token env v2 (* "enum" *) in
+  let v3 = token env v3 (* pattern [a-zA-Z_]\w* *) in
+  let v4 =
+    (match v4 with
+    | Some x -> map_super_interfaces env x
     | None -> todo env ())
   in
-  todo env (v1, v2)
+  let v5 = map_enum_body env v5 in
+  todo env (v1, v2, v3, v4, v5)
 
-
-and map_variable_declarator_id (env : env) ((v1, v2) : CST.variable_declarator_id) =
-  let v1 =
-    (match v1 with
-    | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-    | `Choice_open x ->
-        (match x with
-        | `Open tok -> token env tok (* "open" *)
-        | `Modu tok -> token env tok (* "module" *)
-        )
-    )
-  in
-  let v2 =
-    (match v2 with
-    | Some x -> map_dimensions env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2)
-
-
-and map_array_initializer (env : env) ((v1, v2, v3, v4) : CST.array_initializer) =
-  let v1 = token env v1 (* "{" *) in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) ->
-        let v1 =
-          (match v1 with
-          | `Exp x -> map_expression env x
-          | `Array_init x -> map_array_initializer env x
-          )
-        in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 =
-              (match v2 with
-              | `Exp x -> map_expression env x
-              | `Array_init x -> map_array_initializer env x
-              )
-            in
-            todo env (v1, v2)
-          ) v2
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | Some tok -> token env tok (* "," *)
-    | None -> todo env ())
-  in
-  let v4 = token env v4 (* "}" *) in
-  todo env (v1, v2, v3, v4)
-
-
-and map_type_ (env : env) (x : CST.type_) =
-  (match x with
-  | `Type_unan_type x -> map_unannotated_type env x
-  | `Type_anno_type (v1, v2) ->
-      let v1 = List.map (map_annotation env) v1 in
-      let v2 = map_unannotated_type env v2 in
-      todo env (v1, v2)
-  )
-
-
-and map_unannotated_type (env : env) (x : CST.unannotated_type) =
-  (match x with
-  | `Unan_type_choice_void_type x ->
-      (match x with
-      | `Void_type tok -> token env tok (* "void" *)
-      | `Inte_type x -> map_integral_type env x
-      | `Floa_point_type x -> map_floating_point_type env x
-      | `Bool_type tok -> token env tok (* "boolean" *)
-      | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-      | `Scop_type_id x -> map_scoped_type_identifier env x
-      | `Gene_type x -> map_generic_type env x
-      )
-  | `Unan_type_array_type (v1, v2) ->
-      let v1 = map_unannotated_type env v1 in
-      let v2 = map_dimensions env v2 in
-      todo env (v1, v2)
-  )
-
-
-and map_scoped_type_identifier (env : env) ((v1, v2, v3, v4) : CST.scoped_type_identifier) =
-  let v1 =
-    (match v1 with
-    | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-    | `Scop_type_id x -> map_scoped_type_identifier env x
-    | `Gene_type x -> map_generic_type env x
-    )
-  in
-  let v2 = token env v2 (* "." *) in
-  let v3 = List.map (map_annotation env) v3 in
-  let v4 = token env v4 (* pattern [a-zA-Z_]\w* *) in
-  todo env (v1, v2, v3, v4)
-
-
-and map_generic_type (env : env) ((v1, v2) : CST.generic_type) =
-  let v1 =
-    (match v1 with
-    | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-    | `Scop_type_id x -> map_scoped_type_identifier env x
-    )
-  in
-  let v2 = map_type_arguments env v2 in
-  todo env (v1, v2)
-
+and map_element_value_pair (env : env) ((v1, v2, v3) : CST.element_value_pair) =
+  let v1 = token env v1 (* pattern [a-zA-Z_]\w* *) in
+  let v2 = token env v2 (* "=" *) in
+  let v3 = map_element_value env v3 in
+  todo env (v1, v2, v3)
 
 and map_method_header (env : env) ((v1, v2, v3, v4) : CST.method_header) =
   let v1 =
@@ -1883,141 +1662,3 @@ and map_method_header (env : env) ((v1, v2, v3, v4) : CST.method_header) =
     | None -> todo env ())
   in
   todo env (v1, v2, v3, v4)
-
-
-and map_method_declarator (env : env) ((v1, v2, v3) : CST.method_declarator) =
-  let v1 =
-    (match v1 with
-    | `Id tok -> token env tok (* pattern [a-zA-Z_]\w* *)
-    | `Choice_open x ->
-        (match x with
-        | `Open tok -> token env tok (* "open" *)
-        | `Modu tok -> token env tok (* "module" *)
-        )
-    )
-  in
-  let v2 = map_formal_parameters env v2 in
-  let v3 =
-    (match v3 with
-    | Some x -> map_dimensions env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3)
-
-
-and map_formal_parameters (env : env) ((v1, v2, v3, v4) : CST.formal_parameters) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 =
-    (match v2 with
-    | Some x -> map_receiver_parameter env x
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | Some (v1, v2) ->
-        let v1 =
-          (match v1 with
-          | `Form_param x -> map_formal_parameter env x
-          | `Spre_param x -> map_spread_parameter env x
-          )
-        in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 =
-              (match v2 with
-              | `Form_param x -> map_formal_parameter env x
-              | `Spre_param x -> map_spread_parameter env x
-              )
-            in
-            todo env (v1, v2)
-          ) v2
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v4 = token env v4 (* ")" *) in
-  todo env (v1, v2, v3, v4)
-
-
-and map_formal_parameter (env : env) ((v1, v2, v3) : CST.formal_parameter) =
-  let v1 =
-    (match v1 with
-    | Some x -> map_modifiers env x
-    | None -> todo env ())
-  in
-  let v2 = map_unannotated_type env v2 in
-  let v3 = map_variable_declarator_id env v3 in
-  todo env (v1, v2, v3)
-
-
-and map_receiver_parameter (env : env) ((v1, v2, v3, v4) : CST.receiver_parameter) =
-  let v1 = List.map (map_annotation env) v1 in
-  let v2 = map_unannotated_type env v2 in
-  let v3 =
-    (match v3 with
-    | Some (v1, v2) ->
-        let v1 = token env v1 (* pattern [a-zA-Z_]\w* *) in
-        let v2 = token env v2 (* "." *) in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v4 = token env v4 (* "this" *) in
-  todo env (v1, v2, v3, v4)
-
-
-and map_spread_parameter (env : env) ((v1, v2, v3, v4) : CST.spread_parameter) =
-  let v1 =
-    (match v1 with
-    | Some x -> map_modifiers env x
-    | None -> todo env ())
-  in
-  let v2 = map_unannotated_type env v2 in
-  let v3 = token env v3 (* "..." *) in
-  let v4 = map_variable_declarator env v4 in
-  todo env (v1, v2, v3, v4)
-
-
-and map_throws (env : env) ((v1, v2, v3) : CST.throws) =
-  let v1 = token env v1 (* "throws" *) in
-  let v2 = map_type_ env v2 in
-  let v3 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 = map_type_ env v2 in
-      todo env (v1, v2)
-    ) v3
-  in
-  todo env (v1, v2, v3)
-
-
-and map_local_variable_declaration (env : env) ((v1, v2, v3, v4) : CST.local_variable_declaration) =
-  let v1 =
-    (match v1 with
-    | Some x -> map_modifiers env x
-    | None -> todo env ())
-  in
-  let v2 = map_unannotated_type env v2 in
-  let v3 = map_variable_declarator_list env v3 in
-  let v4 = token env v4 (* ";" *) in
-  todo env (v1, v2, v3, v4)
-
-
-and map_method_declaration (env : env) ((v1, v2, v3) : CST.method_declaration) =
-  let v1 =
-    (match v1 with
-    | Some x -> map_modifiers env x
-    | None -> todo env ())
-  in
-  let v2 = map_method_header env v2 in
-  let v3 =
-    (match v3 with
-    | `Blk x -> map_block env x
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2, v3)
-
-let map_program (env : env) (xs : CST.program) =
-  List.map (map_statement env) xs
-

--- a/java/lib/CST.ml
+++ b/java/lib/CST.ml
@@ -8,22 +8,7 @@
 open! Sexplib.Conv
 open Tree_sitter_run
 
-type floating_point_type = [
-    `Floa_point_type_float of Token.t (* "float" *)
-  | `Floa_point_type_doub of Token.t (* "double" *)
-]
-[@@deriving sexp_of]
-
 type octal_integer_literal = Token.t
-[@@deriving sexp_of]
-
-type binary_integer_literal = Token.t
-[@@deriving sexp_of]
-
-type identifier = Token.t (* pattern [a-zA-Z_]\w* *)
-[@@deriving sexp_of]
-
-type hex_integer_literal = Token.t
 [@@deriving sexp_of]
 
 type integral_type = [
@@ -35,19 +20,22 @@ type integral_type = [
 ]
 [@@deriving sexp_of]
 
-type decimal_floating_point_literal = Token.t
-[@@deriving sexp_of]
-
-type character_literal = Token.t
+type anon_choice_open = [
+    `Open of Token.t (* "open" *)
+  | `Modu of Token.t (* "module" *)
+]
 [@@deriving sexp_of]
 
 type string_literal = Token.t
 [@@deriving sexp_of]
 
-type hex_floating_point_literal = Token.t
+type decimal_integer_literal = Token.t
 [@@deriving sexp_of]
 
-type decimal_integer_literal = Token.t
+type character_literal = Token.t
+[@@deriving sexp_of]
+
+type decimal_floating_point_literal = Token.t
 [@@deriving sexp_of]
 
 type requires_modifier = [
@@ -56,26 +44,22 @@ type requires_modifier = [
 ]
 [@@deriving sexp_of]
 
-type scoped_identifier = (
-    [
-        `Id of identifier (*tok*)
-      | `Choice_open of [
-            `Open of Token.t (* "open" *)
-          | `Modu of Token.t (* "module" *)
-        ]
-      | `Scop_id of scoped_identifier
-    ]
-  * Token.t (* "." *)
-  * identifier (*tok*)
-)
+type hex_integer_literal = Token.t
 [@@deriving sexp_of]
 
-type inferred_parameters = (
-    Token.t (* "(" *)
-  * identifier (*tok*)
-  * (Token.t (* "," *) * identifier (*tok*)) list (* zero or more *)
-  * Token.t (* ")" *)
-)
+type floating_point_type = [
+    `Floa_point_type_float of Token.t (* "float" *)
+  | `Floa_point_type_doub of Token.t (* "double" *)
+]
+[@@deriving sexp_of]
+
+type hex_floating_point_literal = Token.t
+[@@deriving sexp_of]
+
+type binary_integer_literal = Token.t
+[@@deriving sexp_of]
+
+type identifier = Token.t (* pattern [a-zA-Z_]\w* *)
 [@@deriving sexp_of]
 
 type literal = [
@@ -93,128 +77,55 @@ type literal = [
 ]
 [@@deriving sexp_of]
 
+type anon_choice_id = [
+    `Id of identifier (*tok*)
+  | `Choice_open of anon_choice_open
+]
+[@@deriving sexp_of]
+
+type inferred_parameters = (
+    Token.t (* "(" *)
+  * identifier (*tok*)
+  * (Token.t (* "," *) * identifier (*tok*)) list (* zero or more *)
+  * Token.t (* ")" *)
+)
+[@@deriving sexp_of]
+
+type anon_choice_id_ = [
+    `Id of identifier (*tok*)
+  | `Choice_open of anon_choice_open
+  | `Scop_id of (anon_choice_id_ * Token.t (* "." *) * identifier (*tok*))
+]
+[@@deriving sexp_of]
+
 type module_directive = (
     [
         `Requis_rep_requis_modi_choice_id of (
             Token.t (* "requires" *)
           * requires_modifier list (* zero or more *)
-          * [
-                `Id of identifier (*tok*)
-              | `Choice_open of [
-                    `Open of Token.t (* "open" *)
-                  | `Modu of Token.t (* "module" *)
-                ]
-              | `Scop_id of scoped_identifier
-            ]
+          * anon_choice_id_
         )
       | `Expors_choice_id_opt_to_opt_choice_id_rep_COMMA_choice_id of (
             Token.t (* "exports" *)
-          * [
-                `Id of identifier (*tok*)
-              | `Choice_open of [
-                    `Open of Token.t (* "open" *)
-                  | `Modu of Token.t (* "module" *)
-                ]
-              | `Scop_id of scoped_identifier
-            ]
+          * anon_choice_id_
           * Token.t (* "to" *) option
-          * [
-                `Id of identifier (*tok*)
-              | `Choice_open of [
-                    `Open of Token.t (* "open" *)
-                  | `Modu of Token.t (* "module" *)
-                ]
-              | `Scop_id of scoped_identifier
-            ]
-              option
-          * (
-                Token.t (* "," *)
-              * [
-                    `Id of identifier (*tok*)
-                  | `Choice_open of [
-                        `Open of Token.t (* "open" *)
-                      | `Modu of Token.t (* "module" *)
-                    ]
-                  | `Scop_id of scoped_identifier
-                ]
-            )
-              list (* zero or more *)
+          * anon_choice_id_ option
+          * (Token.t (* "," *) * anon_choice_id_) list (* zero or more *)
         )
       | `Opens_choice_id_opt_to_opt_choice_id_rep_COMMA_choice_id of (
             Token.t (* "opens" *)
-          * [
-                `Id of identifier (*tok*)
-              | `Choice_open of [
-                    `Open of Token.t (* "open" *)
-                  | `Modu of Token.t (* "module" *)
-                ]
-              | `Scop_id of scoped_identifier
-            ]
+          * anon_choice_id_
           * Token.t (* "to" *) option
-          * [
-                `Id of identifier (*tok*)
-              | `Choice_open of [
-                    `Open of Token.t (* "open" *)
-                  | `Modu of Token.t (* "module" *)
-                ]
-              | `Scop_id of scoped_identifier
-            ]
-              option
-          * (
-                Token.t (* "," *)
-              * [
-                    `Id of identifier (*tok*)
-                  | `Choice_open of [
-                        `Open of Token.t (* "open" *)
-                      | `Modu of Token.t (* "module" *)
-                    ]
-                  | `Scop_id of scoped_identifier
-                ]
-            )
-              list (* zero or more *)
+          * anon_choice_id_ option
+          * (Token.t (* "," *) * anon_choice_id_) list (* zero or more *)
         )
-      | `Uses_choice_id of (
-            Token.t (* "uses" *)
-          * [
-                `Id of identifier (*tok*)
-              | `Choice_open of [
-                    `Open of Token.t (* "open" *)
-                  | `Modu of Token.t (* "module" *)
-                ]
-              | `Scop_id of scoped_identifier
-            ]
-        )
+      | `Uses_choice_id of (Token.t (* "uses" *) * anon_choice_id_)
       | `Provis_choice_id_with_choice_id_rep_COMMA_choice_id of (
             Token.t (* "provides" *)
-          * [
-                `Id of identifier (*tok*)
-              | `Choice_open of [
-                    `Open of Token.t (* "open" *)
-                  | `Modu of Token.t (* "module" *)
-                ]
-              | `Scop_id of scoped_identifier
-            ]
+          * anon_choice_id_
           * Token.t (* "with" *)
-          * [
-                `Id of identifier (*tok*)
-              | `Choice_open of [
-                    `Open of Token.t (* "open" *)
-                  | `Modu of Token.t (* "module" *)
-                ]
-              | `Scop_id of scoped_identifier
-            ]
-          * (
-                Token.t (* "," *)
-              * [
-                    `Id of identifier (*tok*)
-                  | `Choice_open of [
-                        `Open of Token.t (* "open" *)
-                      | `Modu of Token.t (* "module" *)
-                    ]
-                  | `Scop_id of scoped_identifier
-                ]
-            )
-              list (* zero or more *)
+          * anon_choice_id_
+          * (Token.t (* "," *) * anon_choice_id_) list (* zero or more *)
         )
     ]
   * Token.t (* ";" *)
@@ -228,14 +139,243 @@ type module_body = (
 )
 [@@deriving sexp_of]
 
-type expression = [
+type parenthesized_expression = (
+    Token.t (* "(" *) * expression * Token.t (* ")" *)
+)
+
+and anon_choice_type = [
+    `Type of type_
+  | `Wild of (
+        annotation list (* zero or more *)
+      * Token.t (* "?" *)
+      * wildcard_bounds option
+    )
+]
+
+and generic_type = (
+    [ `Id of identifier (*tok*) | `Scop_type_id of scoped_type_identifier ]
+  * type_arguments
+)
+
+and throws = (
+    Token.t (* "throws" *)
+  * type_
+  * (Token.t (* "," *) * type_) list (* zero or more *)
+)
+
+and anon_choice_exp = [
+    `Exp of expression
+  | `Array_init of array_initializer
+]
+
+and binary_expression = [
+    `Bin_exp_exp_GT_exp of (expression * Token.t (* ">" *) * expression)
+  | `Bin_exp_exp_LT_exp of (expression * Token.t (* "<" *) * expression)
+  | `Bin_exp_exp_EQEQ_exp of (expression * Token.t (* "==" *) * expression)
+  | `Bin_exp_exp_GTEQ_exp of (expression * Token.t (* ">=" *) * expression)
+  | `Bin_exp_exp_LTEQ_exp of (expression * Token.t (* "<=" *) * expression)
+  | `Bin_exp_exp_BANGEQ_exp of (expression * Token.t (* "!=" *) * expression)
+  | `Bin_exp_exp_AMPAMP_exp of (expression * Token.t (* "&&" *) * expression)
+  | `Bin_exp_exp_BARBAR_exp of (expression * Token.t (* "||" *) * expression)
+  | `Bin_exp_exp_PLUS_exp of (expression * Token.t (* "+" *) * expression)
+  | `Bin_exp_exp_DASH_exp of (expression * Token.t (* "-" *) * expression)
+  | `Bin_exp_exp_STAR_exp of (expression * Token.t (* "*" *) * expression)
+  | `Bin_exp_exp_SLASH_exp of (expression * Token.t (* "/" *) * expression)
+  | `Bin_exp_exp_AMP_exp of (expression * Token.t (* "&" *) * expression)
+  | `Bin_exp_exp_BAR_exp of (expression * Token.t (* "|" *) * expression)
+  | `Bin_exp_exp_HAT_exp of (expression * Token.t (* "^" *) * expression)
+  | `Bin_exp_exp_PERC_exp of (expression * Token.t (* "%" *) * expression)
+  | `Bin_exp_exp_LTLT_exp of (expression * Token.t (* "<<" *) * expression)
+  | `Bin_exp_exp_GTGT_exp of (expression * Token.t (* ">>" *) * expression)
+  | `Bin_exp_exp_GTGTGT_exp of (
+        expression * Token.t (* ">>>" *) * expression
+    )
+]
+
+and extends_interfaces = (Token.t (* "extends" *) * interface_type_list)
+
+and block = (Token.t (* "{" *) * program * Token.t (* "}" *))
+
+and variable_declarator = (
+    variable_declarator_id
+  * (Token.t (* "=" *) * anon_choice_exp) option
+)
+
+and type_arguments = (
+    Token.t (* "<" *)
+  * (
+        anon_choice_type
+      * (Token.t (* "," *) * anon_choice_type) list (* zero or more *)
+    )
+      option
+  * Token.t (* ">" *)
+)
+
+and class_body = (
+    Token.t (* "{" *)
+  * anon_choice_field_decl list (* zero or more *)
+  * Token.t (* "}" *)
+)
+
+and type_parameter = (
+    annotation list (* zero or more *)
+  * identifier (*tok*)
+  * type_bound option
+)
+
+and catch_type = (
+    unannotated_type
+  * (Token.t (* "|" *) * unannotated_type) list (* zero or more *)
+)
+
+and interface_type_list = (
+    type_
+  * (Token.t (* "," *) * type_) list (* zero or more *)
+)
+
+and local_variable_declaration = (
+    modifiers option
+  * unannotated_type
+  * variable_declarator_list
+  * Token.t (* ";" *)
+)
+
+and primary = [
+    `Prim_lit of literal
+  | `Prim_class_lit of (
+        unannotated_type * Token.t (* "." *) * Token.t (* "class" *)
+    )
+  | `Prim_this of Token.t (* "this" *)
+  | `Prim_id of identifier (*tok*)
+  | `Prim_choice_open of anon_choice_open
+  | `Prim_paren_exp of parenthesized_expression
+  | `Prim_obj_crea_exp of object_creation_expression
+  | `Prim_field_acce of field_access
+  | `Prim_array_acce of array_access
+  | `Prim_meth_invo of (
+        [
+            `Choice_id of anon_choice_id
+          | `Choice_prim_DOT_opt_super_DOT_opt_type_args_choice_id of (
+                anon_choice_prim
+              * Token.t (* "." *)
+              * (Token.t (* "super" *) * Token.t (* "." *)) option
+              * type_arguments option
+              * anon_choice_id
+            )
+        ]
+      * argument_list
+    )
+  | `Prim_meth_ref of (
+        [
+            `Type of type_
+          | `Prim of primary
+          | `Super of Token.t (* "super" *)
+        ]
+      * Token.t (* "::" *)
+      * type_arguments option
+      * [ `New of Token.t (* "new" *) | `Id of identifier (*tok*) ]
+    )
+  | `Prim_array_crea_exp of (
+        Token.t (* "new" *)
+      * anon_choice_void_type
+      * [
+            `Rep1_dimens_expr_opt_dimens of (
+                dimensions_expr list (* one or more *)
+              * dimensions option
+            )
+          | `Dimens_array_init of (dimensions * array_initializer)
+        ]
+    )
+]
+
+and dimensions =
+  (
+      annotation list (* zero or more *)
+    * Token.t (* "[" *)
+    * Token.t (* "]" *)
+  )
+    list (* one or more *)
+
+and variable_declarator_list = (
+    variable_declarator
+  * (Token.t (* "," *) * variable_declarator) list (* zero or more *)
+)
+
+and switch_label = [
+    `Swit_label_case_exp_COLON of (
+        Token.t (* "case" *) * expression * Token.t (* ":" *)
+    )
+  | `Swit_label_defa_COLON of (Token.t (* "default" *) * Token.t (* ":" *))
+]
+
+and array_initializer = (
+    Token.t (* "{" *)
+  * (
+        anon_choice_exp
+      * (Token.t (* "," *) * anon_choice_exp) list (* zero or more *)
+    )
+      option
+  * Token.t (* "," *) option
+  * Token.t (* "}" *)
+)
+
+and interface_declaration = (
+    modifiers option
+  * Token.t (* "interface" *)
+  * identifier (*tok*)
+  * type_parameters option
+  * extends_interfaces option
+  * interface_body
+)
+
+and annotation_type_declaration = (
+    modifiers option
+  * Token.t (* "@interface" *)
+  * identifier (*tok*)
+  * annotation_type_body
+)
+
+and interface_body = (
+    Token.t (* "{" *)
+  * [
+        `Cst_decl of constant_declaration
+      | `Enum_decl of enum_declaration
+      | `Meth_decl of method_declaration
+      | `Class_decl of class_declaration
+      | `Inte_decl of interface_declaration
+      | `Anno_type_decl of annotation_type_declaration
+      | `SEMI of Token.t (* ";" *)
+    ]
+      list (* zero or more *)
+  * Token.t (* "}" *)
+)
+
+and catch_clause = (
+    Token.t (* "catch" *) * Token.t (* "(" *) * catch_formal_parameter
+  * Token.t (* ")" *) * block
+)
+
+and anon_exp_rep_COMMA_exp = (
+    expression
+  * (Token.t (* "," *) * expression) list (* zero or more *)
+)
+
+and scoped_type_identifier = (
+    [
+        `Id of identifier (*tok*)
+      | `Scop_type_id of scoped_type_identifier
+      | `Gene_type of generic_type
+    ]
+  * Token.t (* "." *)
+  * annotation list (* zero or more *)
+  * identifier (*tok*)
+)
+
+and expression = [
     `Exp_assign_exp of (
         [
             `Id of identifier (*tok*)
-          | `Choice_open of [
-                `Open of Token.t (* "open" *)
-              | `Modu of Token.t (* "module" *)
-            ]
+          | `Choice_open of anon_choice_open
           | `Field_acce of field_access
           | `Array_acce of array_access
         ]
@@ -281,189 +421,64 @@ type expression = [
       * expression
     )
 ]
-and binary_expression = [
-    `Bin_exp_exp_GT_exp of (expression * Token.t (* ">" *) * expression)
-  | `Bin_exp_exp_LT_exp of (expression * Token.t (* "<" *) * expression)
-  | `Bin_exp_exp_EQEQ_exp of (expression * Token.t (* "==" *) * expression)
-  | `Bin_exp_exp_GTEQ_exp of (expression * Token.t (* ">=" *) * expression)
-  | `Bin_exp_exp_LTEQ_exp of (expression * Token.t (* "<=" *) * expression)
-  | `Bin_exp_exp_BANGEQ_exp of (expression * Token.t (* "!=" *) * expression)
-  | `Bin_exp_exp_AMPAMP_exp of (expression * Token.t (* "&&" *) * expression)
-  | `Bin_exp_exp_BARBAR_exp of (expression * Token.t (* "||" *) * expression)
-  | `Bin_exp_exp_PLUS_exp of (expression * Token.t (* "+" *) * expression)
-  | `Bin_exp_exp_DASH_exp of (expression * Token.t (* "-" *) * expression)
-  | `Bin_exp_exp_STAR_exp of (expression * Token.t (* "*" *) * expression)
-  | `Bin_exp_exp_SLASH_exp of (expression * Token.t (* "/" *) * expression)
-  | `Bin_exp_exp_AMP_exp of (expression * Token.t (* "&" *) * expression)
-  | `Bin_exp_exp_BAR_exp of (expression * Token.t (* "|" *) * expression)
-  | `Bin_exp_exp_HAT_exp of (expression * Token.t (* "^" *) * expression)
-  | `Bin_exp_exp_PERC_exp of (expression * Token.t (* "%" *) * expression)
-  | `Bin_exp_exp_LTLT_exp of (expression * Token.t (* "<<" *) * expression)
-  | `Bin_exp_exp_GTGT_exp of (expression * Token.t (* ">>" *) * expression)
-  | `Bin_exp_exp_GTGTGT_exp of (
-        expression * Token.t (* ">>>" *) * expression
-    )
-]
+
+and annotation_type_element_declaration = (
+    modifiers option
+  * unannotated_type
+  * identifier (*tok*)
+  * Token.t (* "(" *)
+  * Token.t (* ")" *)
+  * dimensions option
+  * default_value option
+  * Token.t (* ";" *)
+)
+
 and unary_expression = [
     `Un_exp_PLUS_exp of (Token.t (* "+" *) * expression)
   | `Un_exp_DASH_exp of (Token.t (* "-" *) * expression)
   | `Un_exp_BANG_exp of (Token.t (* "!" *) * expression)
   | `Un_exp_TILDE_exp of (Token.t (* "~" *) * expression)
 ]
-and update_expression = [
-    `Exp_PLUSPLUS of (expression * Token.t (* "++" *))
-  | `Exp_DASHDASH of (expression * Token.t (* "--" *))
-  | `PLUSPLUS_exp of (Token.t (* "++" *) * expression)
-  | `DASHDASH_exp of (Token.t (* "--" *) * expression)
-]
-and primary = [
-    `Prim_lit of literal
-  | `Prim_class_lit of (
-        unannotated_type * Token.t (* "." *) * Token.t (* "class" *)
-    )
-  | `Prim_this of Token.t (* "this" *)
-  | `Prim_id of identifier (*tok*)
-  | `Prim_choice_open of [
-        `Open of Token.t (* "open" *)
-      | `Modu of Token.t (* "module" *)
-    ]
-  | `Prim_paren_exp of parenthesized_expression
-  | `Prim_obj_crea_exp of object_creation_expression
-  | `Prim_field_acce of field_access
-  | `Prim_array_acce of array_access
-  | `Prim_meth_invo of (
-        [
-            `Choice_id of [
-                `Id of identifier (*tok*)
-              | `Choice_open of [
-                    `Open of Token.t (* "open" *)
-                  | `Modu of Token.t (* "module" *)
-                ]
-            ]
-          | `Choice_prim_DOT_opt_super_DOT_opt_type_args_choice_id of (
-                [ `Prim of primary | `Super of Token.t (* "super" *) ]
-              * Token.t (* "." *)
-              * (Token.t (* "super" *) * Token.t (* "." *)) option
-              * type_arguments option
-              * [
-                    `Id of identifier (*tok*)
-                  | `Choice_open of [
-                        `Open of Token.t (* "open" *)
-                      | `Modu of Token.t (* "module" *)
-                    ]
-                ]
-            )
-        ]
-      * argument_list
-    )
-  | `Prim_meth_ref of (
-        [
-            `Type of type_
-          | `Prim of primary
-          | `Super of Token.t (* "super" *)
-        ]
-      * Token.t (* "::" *)
-      * type_arguments option
-      * [ `New of Token.t (* "new" *) | `Id of identifier (*tok*) ]
-    )
-  | `Prim_array_crea_exp of (
-        Token.t (* "new" *)
-      * [
-            `Void_type of Token.t (* "void" *)
-          | `Inte_type of integral_type
-          | `Floa_point_type of floating_point_type
-          | `Bool_type of Token.t (* "boolean" *)
-          | `Id of identifier (*tok*)
-          | `Scop_type_id of scoped_type_identifier
-          | `Gene_type of generic_type
-        ]
-      * [
-            `Rep1_dimens_expr_opt_dimens of (
-                dimensions_expr list (* one or more *)
-              * dimensions option
-            )
-          | `Dimens_array_init of (dimensions * array_initializer)
-        ]
-    )
-]
-and dimensions_expr = (
-    annotation list (* zero or more *)
-  * Token.t (* "[" *)
-  * expression
-  * Token.t (* "]" *)
-)
-and parenthesized_expression = (
-    Token.t (* "(" *) * expression * Token.t (* ")" *)
-)
-and object_creation_expression = [
-    `Obj_crea_exp_unqu_obj_crea_exp of unqualified_object_creation_expression
-  | `Obj_crea_exp_prim_DOT_unqu_obj_crea_exp of (
-        primary * Token.t (* "." *) * unqualified_object_creation_expression
-    )
-]
-and unqualified_object_creation_expression = (
-    Token.t (* "new" *)
-  * type_arguments option
-  * [
-        `Void_type of Token.t (* "void" *)
-      | `Inte_type of integral_type
-      | `Floa_point_type of floating_point_type
-      | `Bool_type of Token.t (* "boolean" *)
-      | `Id of identifier (*tok*)
-      | `Scop_type_id of scoped_type_identifier
-      | `Gene_type of generic_type
-    ]
-  * argument_list
-  * class_body option
-)
-and field_access = (
-    [ `Prim of primary | `Super of Token.t (* "super" *) ]
-  * (Token.t (* "." *) * Token.t (* "super" *)) option
-  * Token.t (* "." *)
-  * [
-        `Id of identifier (*tok*)
-      | `Choice_open of [
-            `Open of Token.t (* "open" *)
-          | `Modu of Token.t (* "module" *)
-        ]
-      | `This of Token.t (* "this" *)
-    ]
-)
-and array_access = (
-    primary * Token.t (* "[" *) * expression * Token.t (* "]" *)
-)
-and argument_list = (
+
+and formal_parameters = (
     Token.t (* "(" *)
-  * (expression * (Token.t (* "," *) * expression) list (* zero or more *))
+  * receiver_parameter option
+  * (
+        anon_choice_form_param
+      * (Token.t (* "," *) * anon_choice_form_param) list (* zero or more *)
+    )
       option
   * Token.t (* ")" *)
 )
-and type_arguments = (
-    Token.t (* "<" *)
-  * (
-        [ `Type of type_ | `Wild of wildcard ]
-      * (Token.t (* "," *) * [ `Type of type_ | `Wild of wildcard ])
-          list (* zero or more *)
-    )
-      option
-  * Token.t (* ">" *)
+
+and array_access = (
+    primary * Token.t (* "[" *) * expression * Token.t (* "]" *)
 )
-and wildcard = (
-    annotation list (* zero or more *)
-  * Token.t (* "?" *)
-  * wildcard_bounds option
-)
-and wildcard_bounds = [
-    `Wild_bounds_extens_type of (Token.t (* "extends" *) * type_)
-  | `Wild_bounds_super_type of (Token.t (* "super" *) * type_)
-]
-and dimensions =
-  (
-      annotation list (* zero or more *)
-    * Token.t (* "[" *)
-    * Token.t (* "]" *)
-  )
+
+and modifiers =
+  [
+      `Anno of annotation
+    | `Publ of Token.t (* "public" *)
+    | `Prot of Token.t (* "protected" *)
+    | `Priv of Token.t (* "private" *)
+    | `Abst of Token.t (* "abstract" *)
+    | `Stat of Token.t (* "static" *)
+    | `Final of Token.t (* "final" *)
+    | `Stri of Token.t (* "strictfp" *)
+    | `Defa of Token.t (* "default" *)
+    | `Sync of Token.t (* "synchronized" *)
+    | `Nati of Token.t (* "native" *)
+    | `Tran of Token.t (* "transient" *)
+    | `Vola of Token.t (* "volatile" *)
+  ]
     list (* one or more *)
+
+and catch_formal_parameter = (
+    modifiers option
+  * catch_type
+  * variable_declarator_id
+)
+
 and statement = [
     `Stmt_decl of declaration
   | `Stmt_exp_stmt of (expression * Token.t (* ";" *))
@@ -483,21 +498,13 @@ and statement = [
       * [
             `Local_var_decl of local_variable_declaration
           | `Opt_exp_rep_COMMA_exp_SEMI of (
-                (
-                    expression
-                  * (Token.t (* "," *) * expression) list (* zero or more *)
-                )
-                  option
+                anon_exp_rep_COMMA_exp option
               * Token.t (* ";" *)
             )
         ]
       * expression option
       * Token.t (* ";" *)
-      * (
-            expression
-          * (Token.t (* "," *) * expression) list (* zero or more *)
-        )
-          option
+      * anon_exp_rep_COMMA_exp option
       * Token.t (* ")" *)
       * statement
     )
@@ -563,89 +570,26 @@ and statement = [
       * finally_clause option
     )
 ]
-and block = (
-    Token.t (* "{" *)
-  * statement list (* zero or more *)
-  * Token.t (* "}" *)
+
+and enum_body_declarations = (
+    Token.t (* ";" *)
+  * anon_choice_field_decl list (* zero or more *)
 )
-and assert_statement = [
-    `Asse_stmt_asse_exp_SEMI of (
-        Token.t (* "assert" *) * expression * Token.t (* ";" *)
-    )
-  | `Asse_stmt_asse_exp_COLON_exp_SEMI of (
-        Token.t (* "assert" *) * expression * Token.t (* ":" *) * expression
-      * Token.t (* ";" *)
-    )
+
+and anon_choice_prim = [ `Prim of primary | `Super of Token.t (* "super" *) ]
+
+and unannotated_type = [
+    `Unan_type_choice_void_type of anon_choice_void_type
+  | `Unan_type_array_type of (unannotated_type * dimensions)
 ]
-and switch_block = (
-    Token.t (* "{" *)
-  * [ `Swit_label of switch_label | `Stmt of statement ]
-      list (* zero or more *)
-  * Token.t (* "}" *)
+
+and receiver_parameter = (
+    annotation list (* zero or more *)
+  * unannotated_type
+  * (identifier (*tok*) * Token.t (* "." *)) option
+  * Token.t (* "this" *)
 )
-and switch_label = [
-    `Swit_label_case_exp_COLON of (
-        Token.t (* "case" *) * expression * Token.t (* ":" *)
-    )
-  | `Swit_label_defa_COLON of (Token.t (* "default" *) * Token.t (* ":" *))
-]
-and catch_clause = (
-    Token.t (* "catch" *) * Token.t (* "(" *) * catch_formal_parameter
-  * Token.t (* ")" *) * block
-)
-and catch_formal_parameter = (
-    modifiers option
-  * catch_type
-  * variable_declarator_id
-)
-and catch_type = (
-    unannotated_type
-  * (Token.t (* "|" *) * unannotated_type) list (* zero or more *)
-)
-and finally_clause = (Token.t (* "finally" *) * block)
-and resource_specification = (
-    Token.t (* "(" *)
-  * resource
-  * (Token.t (* ";" *) * resource) list (* zero or more *)
-  * Token.t (* ";" *) option
-  * Token.t (* ")" *)
-)
-and resource = [
-    `Reso_opt_modifs_unan_type_var_decl_id_EQ_exp of (
-        modifiers option
-      * unannotated_type
-      * variable_declarator_id
-      * Token.t (* "=" *)
-      * expression
-    )
-  | `Reso_id of identifier (*tok*)
-  | `Reso_field_acce of field_access
-]
-and annotation = [
-    `Anno_mark_anno of (
-        Token.t (* "@" *)
-      * [
-            `Id of identifier (*tok*)
-          | `Choice_open of [
-                `Open of Token.t (* "open" *)
-              | `Modu of Token.t (* "module" *)
-            ]
-          | `Scop_id of scoped_identifier
-        ]
-    )
-  | `Anno_anno_ of (
-        Token.t (* "@" *)
-      * [
-            `Id of identifier (*tok*)
-          | `Choice_open of [
-                `Open of Token.t (* "open" *)
-              | `Modu of Token.t (* "module" *)
-            ]
-          | `Scop_id of scoped_identifier
-        ]
-      * annotation_argument_list
-    )
-]
+
 and annotation_argument_list = (
     Token.t (* "(" *)
   * [
@@ -660,9 +604,124 @@ and annotation_argument_list = (
     ]
   * Token.t (* ")" *)
 )
-and element_value_pair = (
-    identifier (*tok*) * Token.t (* "=" *) * element_value
+
+and enum_constant = (
+    modifiers option
+  * identifier (*tok*)
+  * argument_list option
+  * class_body option
 )
+
+and class_declaration = (
+    modifiers option
+  * Token.t (* "class" *)
+  * identifier (*tok*)
+  * type_parameters option
+  * superclass option
+  * super_interfaces option
+  * class_body
+)
+
+and annotation = [
+    `Anno_mark_anno of (Token.t (* "@" *) * anon_choice_id_)
+  | `Anno_anno_ of (
+        Token.t (* "@" *) * anon_choice_id_ * annotation_argument_list
+    )
+]
+
+and annotation_type_body = (
+    Token.t (* "{" *)
+  * [
+        `Anno_type_elem_decl of annotation_type_element_declaration
+      | `Cst_decl of constant_declaration
+      | `Class_decl of class_declaration
+      | `Inte_decl of interface_declaration
+      | `Anno_type_decl of annotation_type_declaration
+    ]
+      list (* zero or more *)
+  * Token.t (* "}" *)
+)
+
+and object_creation_expression = [
+    `Obj_crea_exp_unqu_obj_crea_exp of unqualified_object_creation_expression
+  | `Obj_crea_exp_prim_DOT_unqu_obj_crea_exp of (
+        primary * Token.t (* "." *) * unqualified_object_creation_expression
+    )
+]
+
+and update_expression = [
+    `Exp_PLUSPLUS of (expression * Token.t (* "++" *))
+  | `Exp_DASHDASH of (expression * Token.t (* "--" *))
+  | `PLUSPLUS_exp of (Token.t (* "++" *) * expression)
+  | `DASHDASH_exp of (Token.t (* "--" *) * expression)
+]
+
+and wildcard_bounds = [
+    `Wild_bounds_extens_type of superclass
+  | `Wild_bounds_super_type of (Token.t (* "super" *) * type_)
+]
+
+and anon_choice_form_param = [
+    `Form_param of (
+        modifiers option
+      * unannotated_type
+      * variable_declarator_id
+    )
+  | `Spre_param of (
+        modifiers option
+      * unannotated_type
+      * Token.t (* "..." *)
+      * variable_declarator
+    )
+]
+
+and program = statement list (* zero or more *)
+
+and constant_declaration = (
+    modifiers option
+  * unannotated_type
+  * variable_declarator_list
+  * Token.t (* ";" *)
+)
+
+and enum_body = (
+    Token.t (* "{" *)
+  * (
+        enum_constant
+      * (Token.t (* "," *) * enum_constant) list (* zero or more *)
+    )
+      option
+  * Token.t (* "," *) option
+  * enum_body_declarations option
+  * Token.t (* "}" *)
+)
+
+and variable_declarator_id = (anon_choice_id * dimensions option)
+
+and assert_statement = [
+    `Asse_stmt_asse_exp_SEMI of (
+        Token.t (* "assert" *) * expression * Token.t (* ";" *)
+    )
+  | `Asse_stmt_asse_exp_COLON_exp_SEMI of (
+        Token.t (* "assert" *) * expression * Token.t (* ":" *) * expression
+      * Token.t (* ";" *)
+    )
+]
+
+and resource = [
+    `Reso_opt_modifs_unan_type_var_decl_id_EQ_exp of (
+        modifiers option
+      * unannotated_type
+      * variable_declarator_id
+      * Token.t (* "=" *)
+      * expression
+    )
+  | `Reso_id of identifier (*tok*)
+  | `Reso_field_acce of field_access
+]
+
+and superclass = (Token.t (* "extends" *) * type_)
+
 and element_value = [
     `Exp of expression
   | `Elem_value_array_init of (
@@ -677,176 +736,100 @@ and element_value = [
     )
   | `Anno of annotation
 ]
-and declaration = [
-    `Modu_decl of (
-        annotation list (* zero or more *)
-      * Token.t (* "open" *) option
-      * Token.t (* "module" *)
-      * [
-            `Id of identifier (*tok*)
-          | `Choice_open of [
-                `Open of Token.t (* "open" *)
-              | `Modu of Token.t (* "module" *)
-            ]
-          | `Scop_id of scoped_identifier
-        ]
-      * module_body
-    )
-  | `Pack_decl of (
-        annotation list (* zero or more *)
-      * Token.t (* "package" *)
-      * [
-            `Id of identifier (*tok*)
-          | `Choice_open of [
-                `Open of Token.t (* "open" *)
-              | `Modu of Token.t (* "module" *)
-            ]
-          | `Scop_id of scoped_identifier
-        ]
-      * Token.t (* ";" *)
-    )
-  | `Impo_decl of (
-        Token.t (* "import" *)
-      * Token.t (* "static" *) option
-      * [
-            `Id of identifier (*tok*)
-          | `Choice_open of [
-                `Open of Token.t (* "open" *)
-              | `Modu of Token.t (* "module" *)
-            ]
-          | `Scop_id of scoped_identifier
-        ]
-      * (Token.t (* "." *) * Token.t (* "*" *)) option
-      * Token.t (* ";" *)
-    )
-  | `Class_decl of class_declaration
-  | `Inte_decl of interface_declaration
-  | `Anno_type_decl of annotation_type_declaration
-  | `Enum_decl of enum_declaration
-]
-and enum_declaration = (
-    modifiers option
-  * Token.t (* "enum" *)
-  * identifier (*tok*)
-  * super_interfaces option
-  * enum_body
-)
-and enum_body = (
+
+and finally_clause = (Token.t (* "finally" *) * block)
+
+and constructor_body = (
     Token.t (* "{" *)
-  * (
-        enum_constant
-      * (Token.t (* "," *) * enum_constant) list (* zero or more *)
-    )
-      option
-  * Token.t (* "," *) option
-  * enum_body_declarations option
+  * explicit_constructor_invocation option
+  * program
   * Token.t (* "}" *)
 )
-and enum_body_declarations = (
-    Token.t (* ";" *)
-  * [
-        `Field_decl of field_declaration
-      | `Meth_decl of method_declaration
-      | `Class_decl of class_declaration
-      | `Inte_decl of interface_declaration
-      | `Anno_type_decl of annotation_type_declaration
-      | `Enum_decl of enum_declaration
-      | `Blk of block
-      | `Stat_init of static_initializer
-      | `Cons_decl of constructor_declaration
-      | `SEMI of Token.t (* ";" *)
-    ]
-      list (* zero or more *)
-)
-and enum_constant = (
-    modifiers option
-  * identifier (*tok*)
-  * argument_list option
+
+and unqualified_object_creation_expression = (
+    Token.t (* "new" *)
+  * type_arguments option
+  * anon_choice_void_type
+  * argument_list
   * class_body option
 )
-and class_declaration = (
-    modifiers option
-  * Token.t (* "class" *)
-  * identifier (*tok*)
-  * type_parameters option
-  * superclass option
-  * super_interfaces option
-  * class_body
+
+and switch_block = (
+    Token.t (* "{" *)
+  * [ `Swit_label of switch_label | `Stmt of statement ]
+      list (* zero or more *)
+  * Token.t (* "}" *)
 )
-and modifiers =
-  [
-      `Anno of annotation
-    | `Publ of Token.t (* "public" *)
-    | `Prot of Token.t (* "protected" *)
-    | `Priv of Token.t (* "private" *)
-    | `Abst of Token.t (* "abstract" *)
-    | `Stat of Token.t (* "static" *)
-    | `Final of Token.t (* "final" *)
-    | `Stri of Token.t (* "strictfp" *)
-    | `Defa of Token.t (* "default" *)
-    | `Sync of Token.t (* "synchronized" *)
-    | `Nati of Token.t (* "native" *)
-    | `Tran of Token.t (* "transient" *)
-    | `Vola of Token.t (* "volatile" *)
-  ]
-    list (* one or more *)
+
+and default_value = (Token.t (* "default" *) * element_value)
+
+and method_declaration = (
+    modifiers option
+  * method_header
+  * [ `Blk of block | `SEMI of Token.t (* ";" *) ]
+)
+
+and field_access = (
+    anon_choice_prim
+  * (Token.t (* "." *) * Token.t (* "super" *)) option
+  * Token.t (* "." *)
+  * [
+        `Id of identifier (*tok*)
+      | `Choice_open of anon_choice_open
+      | `This of Token.t (* "this" *)
+    ]
+)
+
+and argument_list = (
+    Token.t (* "(" *)
+  * anon_exp_rep_COMMA_exp option
+  * Token.t (* ")" *)
+)
+
+and type_ = [
+    `Type_unan_type of unannotated_type
+  | `Type_anno_type of (annotation list (* one or more *) * unannotated_type)
+]
+
 and type_parameters = (
     Token.t (* "<" *)
   * type_parameter
   * (Token.t (* "," *) * type_parameter) list (* zero or more *)
   * Token.t (* ">" *)
 )
-and type_parameter = (
-    annotation list (* zero or more *)
-  * identifier (*tok*)
-  * type_bound option
-)
-and type_bound = (
-    Token.t (* "extends" *)
-  * type_
-  * (Token.t (* "&" *) * type_) list (* zero or more *)
-)
-and superclass = (Token.t (* "extends" *) * type_)
+
+and anon_choice_field_decl = [
+    `Field_decl of (
+        modifiers option
+      * unannotated_type
+      * variable_declarator_list
+      * Token.t (* ";" *)
+    )
+  | `Meth_decl of method_declaration
+  | `Class_decl of class_declaration
+  | `Inte_decl of interface_declaration
+  | `Anno_type_decl of annotation_type_declaration
+  | `Enum_decl of enum_declaration
+  | `Blk of block
+  | `Stat_init of (Token.t (* "static" *) * block)
+  | `Cons_decl of (
+        modifiers option
+      * constructor_declarator
+      * throws option
+      * constructor_body
+    )
+  | `SEMI of Token.t (* ";" *)
+]
+
 and super_interfaces = (Token.t (* "implements" *) * interface_type_list)
-and interface_type_list = (
-    type_
-  * (Token.t (* "," *) * type_) list (* zero or more *)
+
+and dimensions_expr = (
+    annotation list (* zero or more *)
+  * Token.t (* "[" *)
+  * expression
+  * Token.t (* "]" *)
 )
-and class_body = (
-    Token.t (* "{" *)
-  * [
-        `Field_decl of field_declaration
-      | `Meth_decl of method_declaration
-      | `Class_decl of class_declaration
-      | `Inte_decl of interface_declaration
-      | `Anno_type_decl of annotation_type_declaration
-      | `Enum_decl of enum_declaration
-      | `Blk of block
-      | `Stat_init of static_initializer
-      | `Cons_decl of constructor_declaration
-      | `SEMI of Token.t (* ";" *)
-    ]
-      list (* zero or more *)
-  * Token.t (* "}" *)
-)
-and static_initializer = (Token.t (* "static" *) * block)
-and constructor_declaration = (
-    modifiers option
-  * constructor_declarator
-  * throws option
-  * constructor_body
-)
-and constructor_declarator = (
-    type_parameters option
-  * identifier (*tok*)
-  * formal_parameters
-)
-and constructor_body = (
-    Token.t (* "{" *)
-  * explicit_constructor_invocation option
-  * statement list (* zero or more *)
-  * Token.t (* "}" *)
-)
+
 and explicit_constructor_invocation = (
     [
         `Opt_type_args_choice_this of (
@@ -866,221 +849,103 @@ and explicit_constructor_invocation = (
   * argument_list
   * Token.t (* ";" *)
 )
-and field_declaration = (
-    modifiers option
-  * unannotated_type
-  * variable_declarator_list
-  * Token.t (* ";" *)
-)
-and annotation_type_declaration = (
-    modifiers option
-  * Token.t (* "@interface" *)
+
+and constructor_declarator = (
+    type_parameters option
   * identifier (*tok*)
-  * annotation_type_body
+  * formal_parameters
 )
-and annotation_type_body = (
-    Token.t (* "{" *)
-  * [
-        `Anno_type_elem_decl of annotation_type_element_declaration
-      | `Cst_decl of constant_declaration
-      | `Class_decl of class_declaration
-      | `Inte_decl of interface_declaration
-      | `Anno_type_decl of annotation_type_declaration
-    ]
-      list (* zero or more *)
-  * Token.t (* "}" *)
+
+and type_bound = (
+    Token.t (* "extends" *)
+  * type_
+  * (Token.t (* "&" *) * type_) list (* zero or more *)
 )
-and annotation_type_element_declaration = (
-    modifiers option
-  * unannotated_type
-  * identifier (*tok*)
-  * Token.t (* "(" *)
+
+and method_declarator = (
+    anon_choice_id
+  * formal_parameters
+  * dimensions option
+)
+
+and declaration = [
+    `Modu_decl of (
+        annotation list (* zero or more *)
+      * Token.t (* "open" *) option
+      * Token.t (* "module" *)
+      * anon_choice_id_
+      * module_body
+    )
+  | `Pack_decl of (
+        annotation list (* zero or more *)
+      * Token.t (* "package" *)
+      * anon_choice_id_
+      * Token.t (* ";" *)
+    )
+  | `Impo_decl of (
+        Token.t (* "import" *)
+      * Token.t (* "static" *) option
+      * anon_choice_id_
+      * (Token.t (* "." *) * Token.t (* "*" *)) option
+      * Token.t (* ";" *)
+    )
+  | `Class_decl of class_declaration
+  | `Inte_decl of interface_declaration
+  | `Anno_type_decl of annotation_type_declaration
+  | `Enum_decl of enum_declaration
+]
+
+and anon_choice_void_type = [
+    `Void_type of Token.t (* "void" *)
+  | `Inte_type of integral_type
+  | `Floa_point_type of floating_point_type
+  | `Bool_type of Token.t (* "boolean" *)
+  | `Id of identifier (*tok*)
+  | `Scop_type_id of scoped_type_identifier
+  | `Gene_type of generic_type
+]
+
+and resource_specification = (
+    Token.t (* "(" *)
+  * resource
+  * (Token.t (* ";" *) * resource) list (* zero or more *)
+  * Token.t (* ";" *) option
   * Token.t (* ")" *)
-  * dimensions option
-  * default_value option
-  * Token.t (* ";" *)
 )
-and default_value = (Token.t (* "default" *) * element_value)
-and interface_declaration = (
+
+and enum_declaration = (
     modifiers option
-  * Token.t (* "interface" *)
+  * Token.t (* "enum" *)
   * identifier (*tok*)
-  * type_parameters option
-  * extends_interfaces option
-  * interface_body
+  * super_interfaces option
+  * enum_body
 )
-and extends_interfaces = (Token.t (* "extends" *) * interface_type_list)
-and interface_body = (
-    Token.t (* "{" *)
-  * [
-        `Cst_decl of constant_declaration
-      | `Enum_decl of enum_declaration
-      | `Meth_decl of method_declaration
-      | `Class_decl of class_declaration
-      | `Inte_decl of interface_declaration
-      | `Anno_type_decl of annotation_type_declaration
-      | `SEMI of Token.t (* ";" *)
-    ]
-      list (* zero or more *)
-  * Token.t (* "}" *)
+
+and element_value_pair = (
+    identifier (*tok*) * Token.t (* "=" *) * element_value
 )
-and constant_declaration = (
-    modifiers option
-  * unannotated_type
-  * variable_declarator_list
-  * Token.t (* ";" *)
-)
-and variable_declarator_list = (
-    variable_declarator
-  * (Token.t (* "," *) * variable_declarator) list (* zero or more *)
-)
-and variable_declarator = (
-    variable_declarator_id
-  * (
-        Token.t (* "=" *)
-      * [ `Exp of expression | `Array_init of array_initializer ]
-    )
-      option
-)
-and variable_declarator_id = (
-    [
-        `Id of identifier (*tok*)
-      | `Choice_open of [
-            `Open of Token.t (* "open" *)
-          | `Modu of Token.t (* "module" *)
-        ]
-    ]
-  * dimensions option
-)
-and array_initializer = (
-    Token.t (* "{" *)
-  * (
-        [ `Exp of expression | `Array_init of array_initializer ]
-      * (
-            Token.t (* "," *)
-          * [ `Exp of expression | `Array_init of array_initializer ]
-        )
-          list (* zero or more *)
-    )
-      option
-  * Token.t (* "," *) option
-  * Token.t (* "}" *)
-)
-and type_ = [
-    `Type_unan_type of unannotated_type
-  | `Type_anno_type of (annotation list (* one or more *) * unannotated_type)
-]
-and unannotated_type = [
-    `Unan_type_choice_void_type of [
-        `Void_type of Token.t (* "void" *)
-      | `Inte_type of integral_type
-      | `Floa_point_type of floating_point_type
-      | `Bool_type of Token.t (* "boolean" *)
-      | `Id of identifier (*tok*)
-      | `Scop_type_id of scoped_type_identifier
-      | `Gene_type of generic_type
-    ]
-  | `Unan_type_array_type of (unannotated_type * dimensions)
-]
-and scoped_type_identifier = (
-    [
-        `Id of identifier (*tok*)
-      | `Scop_type_id of scoped_type_identifier
-      | `Gene_type of generic_type
-    ]
-  * Token.t (* "." *)
-  * annotation list (* zero or more *)
-  * identifier (*tok*)
-)
-and generic_type = (
-    [ `Id of identifier (*tok*) | `Scop_type_id of scoped_type_identifier ]
-  * type_arguments
-)
+
 and method_header = (
     (type_parameters * annotation list (* zero or more *)) option
   * unannotated_type
   * method_declarator
   * throws option
 )
-and method_declarator = (
-    [
-        `Id of identifier (*tok*)
-      | `Choice_open of [
-            `Open of Token.t (* "open" *)
-          | `Modu of Token.t (* "module" *)
-        ]
-    ]
-  * formal_parameters
-  * dimensions option
-)
-and formal_parameters = (
-    Token.t (* "(" *)
-  * receiver_parameter option
-  * (
-        [ `Form_param of formal_parameter | `Spre_param of spread_parameter ]
-      * (
-            Token.t (* "," *)
-          * [
-                `Form_param of formal_parameter
-              | `Spre_param of spread_parameter
-            ]
-        )
-          list (* zero or more *)
-    )
-      option
-  * Token.t (* ")" *)
-)
-and formal_parameter = (
-    modifiers option
-  * unannotated_type
-  * variable_declarator_id
-)
-and receiver_parameter = (
-    annotation list (* zero or more *)
-  * unannotated_type
-  * (identifier (*tok*) * Token.t (* "." *)) option
-  * Token.t (* "this" *)
-)
-and spread_parameter = (
-    modifiers option
-  * unannotated_type
-  * Token.t (* "..." *)
-  * variable_declarator
-)
-and throws = (
-    Token.t (* "throws" *)
-  * type_
-  * (Token.t (* "," *) * type_) list (* zero or more *)
-)
-and local_variable_declaration = (
-    modifiers option
-  * unannotated_type
-  * variable_declarator_list
-  * Token.t (* ";" *)
-)
-and method_declaration = (
-    modifiers option
-  * method_header
-  * [ `Blk of block | `SEMI of Token.t (* ";" *) ]
-)
-[@@deriving sexp_of]
-
-type program = statement list (* zero or more *)
-[@@deriving sexp_of]
-
-type asterisk (* inlined *) = Token.t (* "*" *)
-[@@deriving sexp_of]
-
-type this (* inlined *) = Token.t (* "this" *)
 [@@deriving sexp_of]
 
 type void_type (* inlined *) = Token.t (* "void" *)
 [@@deriving sexp_of]
 
-type boolean_type (* inlined *) = Token.t (* "boolean" *)
+type asterisk (* inlined *) = Token.t (* "*" *)
+[@@deriving sexp_of]
+
+type super (* inlined *) = Token.t (* "super" *)
 [@@deriving sexp_of]
 
 type comment (* inlined *) = Token.t
+[@@deriving sexp_of]
+
+type true_ (* inlined *) = Token.t (* "true" *)
 [@@deriving sexp_of]
 
 type false_ (* inlined *) = Token.t (* "false" *)
@@ -1089,17 +954,10 @@ type false_ (* inlined *) = Token.t (* "false" *)
 type null_literal (* inlined *) = Token.t (* "null" *)
 [@@deriving sexp_of]
 
-type true_ (* inlined *) = Token.t (* "true" *)
+type this (* inlined *) = Token.t (* "this" *)
 [@@deriving sexp_of]
 
-type super (* inlined *) = Token.t (* "super" *)
-[@@deriving sexp_of]
-
-type continue_statement (* inlined *) = (
-    Token.t (* "continue" *)
-  * identifier (*tok*) option
-  * Token.t (* ";" *)
-)
+type boolean_type (* inlined *) = Token.t (* "boolean" *)
 [@@deriving sexp_of]
 
 type break_statement (* inlined *) = (
@@ -1109,51 +967,77 @@ type break_statement (* inlined *) = (
 )
 [@@deriving sexp_of]
 
-type marker_annotation (* inlined *) = (
-    Token.t (* "@" *)
-  * [
-        `Id of identifier (*tok*)
-      | `Choice_open of [
-            `Open of Token.t (* "open" *)
-          | `Modu of Token.t (* "module" *)
-        ]
-      | `Scop_id of scoped_identifier
-    ]
+type continue_statement (* inlined *) = (
+    Token.t (* "continue" *)
+  * identifier (*tok*) option
+  * Token.t (* ";" *)
+)
+[@@deriving sexp_of]
+
+type scoped_identifier (* inlined *) = (
+    anon_choice_id_ * Token.t (* "." *) * identifier (*tok*)
 )
 [@@deriving sexp_of]
 
 type import_declaration (* inlined *) = (
     Token.t (* "import" *)
   * Token.t (* "static" *) option
-  * [
-        `Id of identifier (*tok*)
-      | `Choice_open of [
-            `Open of Token.t (* "open" *)
-          | `Modu of Token.t (* "module" *)
-        ]
-      | `Scop_id of scoped_identifier
-    ]
+  * anon_choice_id_
   * (Token.t (* "." *) * Token.t (* "*" *)) option
   * Token.t (* ";" *)
 )
 [@@deriving sexp_of]
 
-type cast_expression (* inlined *) = (
-    Token.t (* "(" *)
-  * type_
-  * (Token.t (* "&" *) * type_) list (* zero or more *)
-  * Token.t (* ")" *)
-  * expression
+type marker_annotation (* inlined *) = (Token.t (* "@" *) * anon_choice_id_)
+[@@deriving sexp_of]
+
+type annotation_ (* inlined *) = (
+    Token.t (* "@" *) * anon_choice_id_ * annotation_argument_list
+)
+[@@deriving sexp_of]
+
+type constructor_declaration (* inlined *) = (
+    modifiers option
+  * constructor_declarator
+  * throws option
+  * constructor_body
+)
+[@@deriving sexp_of]
+
+type instanceof_expression (* inlined *) = (
+    expression * Token.t (* "instanceof" *) * type_
+)
+[@@deriving sexp_of]
+
+type element_value_array_initializer (* inlined *) = (
+    Token.t (* "{" *)
+  * (
+        element_value
+      * (Token.t (* "," *) * element_value) list (* zero or more *)
+    )
+      option
+  * Token.t (* "," *) option
+  * Token.t (* "}" *)
+)
+[@@deriving sexp_of]
+
+type labeled_statement (* inlined *) = (
+    identifier (*tok*) * Token.t (* ":" *) * statement
+)
+[@@deriving sexp_of]
+
+type spread_parameter (* inlined *) = (
+    modifiers option
+  * unannotated_type
+  * Token.t (* "..." *)
+  * variable_declarator
 )
 [@@deriving sexp_of]
 
 type assignment_expression (* inlined *) = (
     [
         `Id of identifier (*tok*)
-      | `Choice_open of [
-            `Open of Token.t (* "open" *)
-          | `Modu of Token.t (* "module" *)
-        ]
+      | `Choice_open of anon_choice_open
       | `Field_acce of field_access
       | `Array_acce of array_access
     ]
@@ -1175,99 +1059,11 @@ type assignment_expression (* inlined *) = (
 )
 [@@deriving sexp_of]
 
-type instanceof_expression (* inlined *) = (
-    expression * Token.t (* "instanceof" *) * type_
-)
-[@@deriving sexp_of]
-
-type lambda_expression (* inlined *) = (
-    [
-        `Id of identifier (*tok*)
-      | `Form_params of formal_parameters
-      | `Infe_params of inferred_parameters
-    ]
-  * Token.t (* "->" *)
-  * [ `Exp of expression | `Blk of block ]
-)
-[@@deriving sexp_of]
-
-type ternary_expression (* inlined *) = (
-    expression * Token.t (* "?" *) * expression * Token.t (* ":" *)
-  * expression
-)
-[@@deriving sexp_of]
-
-type array_creation_expression (* inlined *) = (
-    Token.t (* "new" *)
-  * [
-        `Void_type of Token.t (* "void" *)
-      | `Inte_type of integral_type
-      | `Floa_point_type of floating_point_type
-      | `Bool_type of Token.t (* "boolean" *)
-      | `Id of identifier (*tok*)
-      | `Scop_type_id of scoped_type_identifier
-      | `Gene_type of generic_type
-    ]
-  * [
-        `Rep1_dimens_expr_opt_dimens of (
-            dimensions_expr list (* one or more *)
-          * dimensions option
-        )
-      | `Dimens_array_init of (dimensions * array_initializer)
-    ]
-)
-[@@deriving sexp_of]
-
-type class_literal (* inlined *) = (
-    unannotated_type * Token.t (* "." *) * Token.t (* "class" *)
-)
-[@@deriving sexp_of]
-
-type method_invocation (* inlined *) = (
-    [
-        `Choice_id of [
-            `Id of identifier (*tok*)
-          | `Choice_open of [
-                `Open of Token.t (* "open" *)
-              | `Modu of Token.t (* "module" *)
-            ]
-        ]
-      | `Choice_prim_DOT_opt_super_DOT_opt_type_args_choice_id of (
-            [ `Prim of primary | `Super of Token.t (* "super" *) ]
-          * Token.t (* "." *)
-          * (Token.t (* "super" *) * Token.t (* "." *)) option
-          * type_arguments option
-          * [
-                `Id of identifier (*tok*)
-              | `Choice_open of [
-                    `Open of Token.t (* "open" *)
-                  | `Modu of Token.t (* "module" *)
-                ]
-            ]
-        )
-    ]
-  * argument_list
-)
-[@@deriving sexp_of]
-
-type method_reference (* inlined *) = (
-    [ `Type of type_ | `Prim of primary | `Super of Token.t (* "super" *) ]
-  * Token.t (* "::" *)
-  * type_arguments option
-  * [ `New of Token.t (* "new" *) | `Id of identifier (*tok*) ]
-)
-[@@deriving sexp_of]
-
-type expression_statement (* inlined *) = (expression * Token.t (* ";" *))
-[@@deriving sexp_of]
-
-type labeled_statement (* inlined *) = (
-    identifier (*tok*) * Token.t (* ":" *) * statement
-)
-[@@deriving sexp_of]
-
-type switch_statement (* inlined *) = (
-    Token.t (* "switch" *) * parenthesized_expression * switch_block
+type field_declaration (* inlined *) = (
+    modifiers option
+  * unannotated_type
+  * variable_declarator_list
+  * Token.t (* ";" *)
 )
 [@@deriving sexp_of]
 
@@ -1277,20 +1073,65 @@ type do_statement (* inlined *) = (
 )
 [@@deriving sexp_of]
 
-type return_statement (* inlined *) = (
-    Token.t (* "return" *)
-  * expression option
-  * Token.t (* ";" *)
+type array_type (* inlined *) = (unannotated_type * dimensions)
+[@@deriving sexp_of]
+
+type module_declaration (* inlined *) = (
+    annotation list (* zero or more *)
+  * Token.t (* "open" *) option
+  * Token.t (* "module" *)
+  * anon_choice_id_
+  * module_body
 )
 [@@deriving sexp_of]
 
-type synchronized_statement (* inlined *) = (
-    Token.t (* "synchronized" *) * parenthesized_expression * block
+type try_with_resources_statement (* inlined *) = (
+    Token.t (* "try" *)
+  * resource_specification
+  * block
+  * catch_clause list (* zero or more *)
+  * finally_clause option
 )
+[@@deriving sexp_of]
+
+type expression_statement (* inlined *) = (expression * Token.t (* ";" *))
+[@@deriving sexp_of]
+
+type cast_expression (* inlined *) = (
+    Token.t (* "(" *)
+  * type_
+  * (Token.t (* "&" *) * type_) list (* zero or more *)
+  * Token.t (* ")" *)
+  * expression
+)
+[@@deriving sexp_of]
+
+type static_initializer (* inlined *) = (Token.t (* "static" *) * block)
 [@@deriving sexp_of]
 
 type throw_statement (* inlined *) = (
     Token.t (* "throw" *) * expression * Token.t (* ";" *)
+)
+[@@deriving sexp_of]
+
+type package_declaration (* inlined *) = (
+    annotation list (* zero or more *)
+  * Token.t (* "package" *)
+  * anon_choice_id_
+  * Token.t (* ";" *)
+)
+[@@deriving sexp_of]
+
+type array_creation_expression (* inlined *) = (
+    Token.t (* "new" *)
+  * anon_choice_void_type
+  * [
+        `Rep1_dimens_expr_opt_dimens of (
+            dimensions_expr list (* one or more *)
+          * dimensions option
+        )
+      | `Dimens_array_init of (dimensions * array_initializer)
+    ]
 )
 [@@deriving sexp_of]
 
@@ -1307,15 +1148,6 @@ type try_statement (* inlined *) = (
 )
 [@@deriving sexp_of]
 
-type try_with_resources_statement (* inlined *) = (
-    Token.t (* "try" *)
-  * resource_specification
-  * block
-  * catch_clause list (* zero or more *)
-  * finally_clause option
-)
-[@@deriving sexp_of]
-
 type if_statement (* inlined *) = (
     Token.t (* "if" *)
   * parenthesized_expression
@@ -1324,31 +1156,67 @@ type if_statement (* inlined *) = (
 )
 [@@deriving sexp_of]
 
+type lambda_expression (* inlined *) = (
+    [
+        `Id of identifier (*tok*)
+      | `Form_params of formal_parameters
+      | `Infe_params of inferred_parameters
+    ]
+  * Token.t (* "->" *)
+  * [ `Exp of expression | `Blk of block ]
+)
+[@@deriving sexp_of]
+
 type while_statement (* inlined *) = (
     Token.t (* "while" *) * parenthesized_expression * statement
 )
 [@@deriving sexp_of]
 
-type for_statement (* inlined *) = (
-    Token.t (* "for" *)
-  * Token.t (* "(" *)
-  * [
-        `Local_var_decl of local_variable_declaration
-      | `Opt_exp_rep_COMMA_exp_SEMI of (
-            (
-                expression
-              * (Token.t (* "," *) * expression) list (* zero or more *)
-            )
-              option
-          * Token.t (* ";" *)
+type wildcard (* inlined *) = (
+    annotation list (* zero or more *)
+  * Token.t (* "?" *)
+  * wildcard_bounds option
+)
+[@@deriving sexp_of]
+
+type annotated_type (* inlined *) = (
+    annotation list (* one or more *)
+  * unannotated_type
+)
+[@@deriving sexp_of]
+
+type method_reference (* inlined *) = (
+    [ `Type of type_ | `Prim of primary | `Super of Token.t (* "super" *) ]
+  * Token.t (* "::" *)
+  * type_arguments option
+  * [ `New of Token.t (* "new" *) | `Id of identifier (*tok*) ]
+)
+[@@deriving sexp_of]
+
+type method_invocation (* inlined *) = (
+    [
+        `Choice_id of anon_choice_id
+      | `Choice_prim_DOT_opt_super_DOT_opt_type_args_choice_id of (
+            anon_choice_prim
+          * Token.t (* "." *)
+          * (Token.t (* "super" *) * Token.t (* "." *)) option
+          * type_arguments option
+          * anon_choice_id
         )
     ]
+  * argument_list
+)
+[@@deriving sexp_of]
+
+type switch_statement (* inlined *) = (
+    Token.t (* "switch" *) * parenthesized_expression * switch_block
+)
+[@@deriving sexp_of]
+
+type return_statement (* inlined *) = (
+    Token.t (* "return" *)
   * expression option
   * Token.t (* ";" *)
-  * (expression * (Token.t (* "," *) * expression) list (* zero or more *))
-      option
-  * Token.t (* ")" *)
-  * statement
 )
 [@@deriving sexp_of]
 
@@ -1365,70 +1233,45 @@ type enhanced_for_statement (* inlined *) = (
 )
 [@@deriving sexp_of]
 
-type annotation_ (* inlined *) = (
-    Token.t (* "@" *)
-  * [
-        `Id of identifier (*tok*)
-      | `Choice_open of [
-            `Open of Token.t (* "open" *)
-          | `Modu of Token.t (* "module" *)
-        ]
-      | `Scop_id of scoped_identifier
-    ]
-  * annotation_argument_list
+type synchronized_statement (* inlined *) = (
+    Token.t (* "synchronized" *) * parenthesized_expression * block
 )
 [@@deriving sexp_of]
 
-type element_value_array_initializer (* inlined *) = (
-    Token.t (* "{" *)
-  * (
-        element_value
-      * (Token.t (* "," *) * element_value) list (* zero or more *)
-    )
-      option
-  * Token.t (* "," *) option
-  * Token.t (* "}" *)
+type class_literal (* inlined *) = (
+    unannotated_type * Token.t (* "." *) * Token.t (* "class" *)
 )
 [@@deriving sexp_of]
 
-type module_declaration (* inlined *) = (
-    annotation list (* zero or more *)
-  * Token.t (* "open" *) option
-  * Token.t (* "module" *)
-  * [
-        `Id of identifier (*tok*)
-      | `Choice_open of [
-            `Open of Token.t (* "open" *)
-          | `Modu of Token.t (* "module" *)
-        ]
-      | `Scop_id of scoped_identifier
-    ]
-  * module_body
+type ternary_expression (* inlined *) = (
+    expression * Token.t (* "?" *) * expression * Token.t (* ":" *)
+  * expression
 )
 [@@deriving sexp_of]
 
-type package_declaration (* inlined *) = (
-    annotation list (* zero or more *)
-  * Token.t (* "package" *)
+type for_statement (* inlined *) = (
+    Token.t (* "for" *)
+  * Token.t (* "(" *)
   * [
-        `Id of identifier (*tok*)
-      | `Choice_open of [
-            `Open of Token.t (* "open" *)
-          | `Modu of Token.t (* "module" *)
-        ]
-      | `Scop_id of scoped_identifier
+        `Local_var_decl of local_variable_declaration
+      | `Opt_exp_rep_COMMA_exp_SEMI of (
+            anon_exp_rep_COMMA_exp option
+          * Token.t (* ";" *)
+        )
     ]
+  * expression option
   * Token.t (* ";" *)
+  * anon_exp_rep_COMMA_exp option
+  * Token.t (* ")" *)
+  * statement
 )
 [@@deriving sexp_of]
 
-type annotated_type (* inlined *) = (
-    annotation list (* one or more *)
+type formal_parameter (* inlined *) = (
+    modifiers option
   * unannotated_type
+  * variable_declarator_id
 )
-[@@deriving sexp_of]
-
-type array_type (* inlined *) = (unannotated_type * dimensions)
 [@@deriving sexp_of]
 
 let dump_tree root =

--- a/javascript/lib/Boilerplate.ml
+++ b/javascript/lib/Boilerplate.ml
@@ -20,6 +20,18 @@ let blank (env : env) () =
 let todo (env : env) _ =
    failwith "not implemented"
 
+let map_anon_choice_PLUSPLUS (env : env) (x : CST.anon_choice_PLUSPLUS) =
+  (match x with
+  | `PLUSPLUS tok -> token env tok (* "++" *)
+  | `DASHDASH tok -> token env tok (* "--" *)
+  )
+
+let map_number (env : env) (tok : CST.number) =
+  token env tok (* number *)
+
+let map_automatic_semicolon (env : env) (tok : CST.automatic_semicolon) =
+  token env tok (* automatic_semicolon *)
+
 let map_jsx_identifier (env : env) (tok : CST.jsx_identifier) =
   token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
 
@@ -29,131 +41,37 @@ let map_jsx_text (env : env) (tok : CST.jsx_text) =
 let map_template_chars (env : env) (tok : CST.template_chars) =
   token env tok (* template_chars *)
 
-let map_number (env : env) (tok : CST.number) =
-  token env tok (* number *)
-
-let map_escape_sequence (env : env) (tok : CST.escape_sequence) =
-  token env tok (* escape_sequence *)
-
-let map_meta_property (env : env) ((v1, v2, v3) : CST.meta_property) =
-  let v1 = token env v1 (* "new" *) in
-  let v2 = token env v2 (* "." *) in
-  let v3 = token env v3 (* "target" *) in
-  todo env (v1, v2, v3)
-
-let map_hash_bang_line (env : env) (tok : CST.hash_bang_line) =
-  token env tok (* pattern #!.* *)
-
-let map_regex_flags (env : env) (tok : CST.regex_flags) =
-  token env tok (* pattern [a-z]+ *)
-
-let map_regex_pattern (env : env) (tok : CST.regex_pattern) =
-  token env tok (* regex_pattern *)
-
-let map_automatic_semicolon (env : env) (tok : CST.automatic_semicolon) =
-  token env tok (* automatic_semicolon *)
-
 let map_import (env : env) (tok : CST.import) =
   token env tok (* import *)
 
 let map_identifier (env : env) (tok : CST.identifier) =
   token env tok (* identifier *)
 
-let map_string_ (env : env) (x : CST.string_) =
+let map_hash_bang_line (env : env) (tok : CST.hash_bang_line) =
+  token env tok (* pattern #!.* *)
+
+let map_anon_choice_get (env : env) (x : CST.anon_choice_get) =
   (match x with
-  | `Str_DQUOT_rep_choice_blank_DQUOT (v1, v2, v3) ->
-      let v1 = token env v1 (* "\"" *) in
-      let v2 =
-        List.map (fun x ->
-          (match x with
-          | `Blank () -> todo env ()
-          | `Esc_seq tok -> token env tok (* escape_sequence *)
-          )
-        ) v2
-      in
-      let v3 = token env v3 (* "\"" *) in
-      todo env (v1, v2, v3)
-  | `Str_SQUOT_rep_choice_blank_SQUOT (v1, v2, v3) ->
-      let v1 = token env v1 (* "'" *) in
-      let v2 =
-        List.map (fun x ->
-          (match x with
-          | `Blank () -> todo env ()
-          | `Esc_seq tok -> token env tok (* escape_sequence *)
-          )
-        ) v2
-      in
-      let v3 = token env v3 (* "'" *) in
-      todo env (v1, v2, v3)
+  | `Get tok -> token env tok (* "get" *)
+  | `Set tok -> token env tok (* "set" *)
+  | `Async tok -> token env tok (* "async" *)
+  | `Stat tok -> token env tok (* "static" *)
   )
 
-let map_regex (env : env) ((v1, v2, v3, v4) : CST.regex) =
-  let v1 = token env v1 (* "/" *) in
-  let v2 = token env v2 (* regex_pattern *) in
-  let v3 = token env v3 (* "/" *) in
-  let v4 =
-    (match v4 with
-    | Some tok -> token env tok (* pattern [a-z]+ *)
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3, v4)
+let map_regex_flags (env : env) (tok : CST.regex_flags) =
+  token env tok (* pattern [a-z]+ *)
 
-let map_debugger_statement (env : env) ((v1, v2) : CST.debugger_statement) =
-  let v1 = token env v1 (* "debugger" *) in
-  let v2 =
-    (match v2 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2)
+let map_escape_sequence (env : env) (tok : CST.escape_sequence) =
+  token env tok (* escape_sequence *)
 
-let rec map_nested_identifier (env : env) ((v1, v2, v3) : CST.nested_identifier) =
-  let v1 =
-    (match v1 with
-    | `Id tok -> token env tok (* identifier *)
-    | `Nest_id x -> map_nested_identifier env x
-    )
-  in
-  let v2 = token env v2 (* "." *) in
-  let v3 = token env v3 (* identifier *) in
-  todo env (v1, v2, v3)
+let map_regex_pattern (env : env) (tok : CST.regex_pattern) =
+  token env tok (* regex_pattern *)
 
-let map_continue_statement (env : env) ((v1, v2, v3) : CST.continue_statement) =
-  let v1 = token env v1 (* "continue" *) in
-  let v2 =
-    (match v2 with
-    | Some tok -> token env tok (* identifier *)
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2, v3)
-
-let rec map_decorator_member_expression (env : env) ((v1, v2, v3) : CST.decorator_member_expression) =
-  let v1 =
-    (match v1 with
-    | `Choice_id x ->
-        (match x with
-        | `Id tok -> token env tok (* identifier *)
-        | `Choice_get x ->
-            (match x with
-            | `Get tok -> token env tok (* "get" *)
-            | `Set tok -> token env tok (* "set" *)
-            | `Async tok -> token env tok (* "async" *)
-            | `Stat tok -> token env tok (* "static" *)
-            )
-        )
-    | `Deco_memb_exp x -> map_decorator_member_expression env x
-    )
-  in
-  let v2 = token env v2 (* "." *) in
-  let v3 = token env v3 (* identifier *) in
-  todo env (v1, v2, v3)
+let map_anon_choice_auto_semi (env : env) (x : CST.anon_choice_auto_semi) =
+  (match x with
+  | `Auto_semi tok -> token env tok (* automatic_semicolon *)
+  | `SEMI tok -> token env tok (* ";" *)
+  )
 
 let map_import_export_specifier (env : env) ((v1, v2) : CST.import_export_specifier) =
   let v1 = token env v1 (* identifier *) in
@@ -167,64 +85,97 @@ let map_import_export_specifier (env : env) ((v1, v2) : CST.import_export_specif
   in
   todo env (v1, v2)
 
+let map_anon_choice_jsx_id (env : env) (x : CST.anon_choice_jsx_id) =
+  (match x with
+  | `Jsx_id tok ->
+      token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
+  | `Id tok -> token env tok (* identifier *)
+  )
+
 let map_namespace_import (env : env) ((v1, v2, v3) : CST.namespace_import) =
   let v1 = token env v1 (* "*" *) in
   let v2 = token env v2 (* "as" *) in
   let v3 = token env v3 (* identifier *) in
   todo env (v1, v2, v3)
 
-let map_break_statement (env : env) ((v1, v2, v3) : CST.break_statement) =
-  let v1 = token env v1 (* "break" *) in
-  let v2 =
-    (match v2 with
-    | Some tok -> token env tok (* identifier *)
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2, v3)
-
-let map_jsx_namespace_name (env : env) ((v1, v2, v3) : CST.jsx_namespace_name) =
+let rec map_nested_identifier (env : env) ((v1, v2, v3) : CST.nested_identifier) =
   let v1 =
     (match v1 with
-    | `Jsx_id tok ->
-        token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
     | `Id tok -> token env tok (* identifier *)
+    | `Nest_id x -> map_nested_identifier env x
     )
   in
-  let v2 = token env v2 (* ":" *) in
-  let v3 =
-    (match v3 with
-    | `Jsx_id tok ->
-        token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
-    | `Id tok -> token env tok (* identifier *)
-    )
-  in
+  let v2 = token env v2 (* "." *) in
+  let v3 = token env v3 (* identifier *) in
   todo env (v1, v2, v3)
 
-let map_from_clause (env : env) ((v1, v2) : CST.from_clause) =
-  let v1 = token env v1 (* "from" *) in
-  let v2 = map_string_ env v2 in
+let map_anon_choice_choice_get (env : env) (x : CST.anon_choice_choice_get) =
+  (match x with
+  | `Choice_get x -> map_anon_choice_get env x
+  | `Id tok -> token env tok (* identifier *)
+  )
+
+let map_anon_choice_id_ (env : env) (x : CST.anon_choice_id_) =
+  (match x with
+  | `Id tok -> token env tok (* identifier *)
+  | `Choice_get x -> map_anon_choice_get env x
+  )
+
+let map_anon_choice_blank (env : env) (x : CST.anon_choice_blank) =
+  (match x with
+  | `Blank () -> todo env ()
+  | `Esc_seq tok -> token env tok (* escape_sequence *)
+  )
+
+let map_anon_impo_expo_spec_rep_COMMA_impo_expo_spec (env : env) ((v1, v2) : CST.anon_impo_expo_spec_rep_COMMA_impo_expo_spec) =
+  let v1 = map_import_export_specifier env v1 in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_import_export_specifier env v2 in
+      todo env (v1, v2)
+    ) v2
+  in
   todo env (v1, v2)
+
+let map_jsx_namespace_name (env : env) ((v1, v2, v3) : CST.jsx_namespace_name) =
+  let v1 = map_anon_choice_jsx_id env v1 in
+  let v2 = token env v2 (* ":" *) in
+  let v3 = map_anon_choice_jsx_id env v3 in
+  todo env (v1, v2, v3)
+
+let rec map_decorator_member_expression (env : env) ((v1, v2, v3) : CST.decorator_member_expression) =
+  let v1 = map_anon_choice_choice_id env v1 in
+  let v2 = token env v2 (* "." *) in
+  let v3 = token env v3 (* identifier *) in
+  todo env (v1, v2, v3)
+
+and map_anon_choice_choice_id (env : env) (x : CST.anon_choice_choice_id) =
+  (match x with
+  | `Choice_id x -> map_anon_choice_id_ env x
+  | `Deco_memb_exp x -> map_decorator_member_expression env x
+  )
+
+let map_string_ (env : env) (x : CST.string_) =
+  (match x with
+  | `Str_DQUOT_rep_choice_blank_DQUOT (v1, v2, v3) ->
+      let v1 = token env v1 (* "\"" *) in
+      let v2 = List.map (map_anon_choice_blank env) v2 in
+      let v3 = token env v3 (* "\"" *) in
+      todo env (v1, v2, v3)
+  | `Str_SQUOT_rep_choice_blank_SQUOT (v1, v2, v3) ->
+      let v1 = token env v1 (* "'" *) in
+      let v2 = List.map (map_anon_choice_blank env) v2 in
+      let v3 = token env v3 (* "'" *) in
+      todo env (v1, v2, v3)
+  )
 
 let map_export_clause (env : env) ((v1, v2, v3, v4) : CST.export_clause) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     (match v2 with
-    | Some (v1, v2) ->
-        let v1 = map_import_export_specifier env v1 in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 = map_import_export_specifier env v2 in
-            todo env (v1, v2)
-          ) v2
-        in
-        todo env (v1, v2)
+    | Some x ->
+        map_anon_impo_expo_spec_rep_COMMA_impo_expo_spec env x
     | None -> todo env ())
   in
   let v3 =
@@ -239,16 +190,8 @@ let map_named_imports (env : env) ((v1, v2, v3, v4) : CST.named_imports) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     (match v2 with
-    | Some (v1, v2) ->
-        let v1 = map_import_export_specifier env v1 in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 = map_import_export_specifier env v2 in
-            todo env (v1, v2)
-          ) v2
-        in
-        todo env (v1, v2)
+    | Some x ->
+        map_anon_impo_expo_spec_rep_COMMA_impo_expo_spec env x
     | None -> todo env ())
   in
   let v3 =
@@ -259,23 +202,17 @@ let map_named_imports (env : env) ((v1, v2, v3, v4) : CST.named_imports) =
   let v4 = token env v4 (* "}" *) in
   todo env (v1, v2, v3, v4)
 
-let map_jsx_closing_element (env : env) ((v1, v2, v3, v4) : CST.jsx_closing_element) =
-  let v1 = token env v1 (* "<" *) in
-  let v2 = token env v2 (* "/" *) in
-  let v3 =
-    (match v3 with
-    | `Choice_jsx_id x ->
-        (match x with
-        | `Jsx_id tok ->
-            token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
-        | `Id tok -> token env tok (* identifier *)
-        )
-    | `Nest_id x -> map_nested_identifier env x
-    | `Jsx_name_name x -> map_jsx_namespace_name env x
-    )
-  in
-  let v4 = token env v4 (* ">" *) in
-  todo env (v1, v2, v3, v4)
+let map_anon_choice_choice_jsx_id (env : env) (x : CST.anon_choice_choice_jsx_id) =
+  (match x with
+  | `Choice_jsx_id x -> map_anon_choice_jsx_id env x
+  | `Nest_id x -> map_nested_identifier env x
+  | `Jsx_name_name x -> map_jsx_namespace_name env x
+  )
+
+let map_from_clause (env : env) ((v1, v2) : CST.from_clause) =
+  let v1 = token env v1 (* "from" *) in
+  let v2 = map_string_ env v2 in
+  todo env (v1, v2)
 
 let map_import_clause (env : env) (x : CST.import_clause) =
   (match x with
@@ -299,156 +236,25 @@ let map_import_clause (env : env) (x : CST.import_clause) =
       todo env (v1, v2)
   )
 
-let map_import_statement (env : env) ((v1, v2, v3) : CST.import_statement) =
-  let v1 = token env v1 (* "import" *) in
-  let v2 =
-    (match v2 with
-    | `Impo_clau_from_clau (v1, v2) ->
-        let v1 = map_import_clause env v1 in
-        let v2 = map_from_clause env v2 in
-        todo env (v1, v2)
-    | `Str x -> map_string_ env x
-    )
-  in
-  let v3 =
-    (match v3 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
+let map_jsx_closing_element (env : env) ((v1, v2, v3, v4) : CST.jsx_closing_element) =
+  let v1 = token env v1 (* "<" *) in
+  let v2 = token env v2 (* "/" *) in
+  let v3 = map_anon_choice_choice_jsx_id env v3 in
+  let v4 = token env v4 (* ">" *) in
+  todo env (v1, v2, v3, v4)
+
+let rec map_parenthesized_expression (env : env) ((v1, v2, v3) : CST.parenthesized_expression) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 = map_anon_choice_exp env v2 in
+  let v3 = token env v3 (* ")" *) in
   todo env (v1, v2, v3)
 
-let rec map_export_statement (env : env) (x : CST.export_statement) =
-  (match x with
-  | `Expo_stmt_expo_choice_STAR_from_clau_choice_auto_semi (v1, v2) ->
-      let v1 = token env v1 (* "export" *) in
-      let v2 =
-        (match v2 with
-        | `STAR_from_clau_choice_auto_semi (v1, v2, v3) ->
-            let v1 = token env v1 (* "*" *) in
-            let v2 = map_from_clause env v2 in
-            let v3 =
-              (match v3 with
-              | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-              | `SEMI tok -> token env tok (* ";" *)
-              )
-            in
-            todo env (v1, v2, v3)
-        | `Expo_clau_from_clau_choice_auto_semi (v1, v2, v3) ->
-            let v1 = map_export_clause env v1 in
-            let v2 = map_from_clause env v2 in
-            let v3 =
-              (match v3 with
-              | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-              | `SEMI tok -> token env tok (* ";" *)
-              )
-            in
-            todo env (v1, v2, v3)
-        | `Expo_clau_choice_auto_semi (v1, v2) ->
-            let v1 = map_export_clause env v1 in
-            let v2 =
-              (match v2 with
-              | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-              | `SEMI tok -> token env tok (* ";" *)
-              )
-            in
-            todo env (v1, v2)
-        )
-      in
-      todo env (v1, v2)
-  | `Expo_stmt_rep_deco_expo_choice_decl (v1, v2, v3) ->
-      let v1 = List.map (map_decorator env) v1 in
-      let v2 = token env v2 (* "export" *) in
-      let v3 =
-        (match v3 with
-        | `Decl x -> map_declaration env x
-        | `Defa_exp_choice_auto_semi (v1, v2, v3) ->
-            let v1 = token env v1 (* "default" *) in
-            let v2 = map_expression env v2 in
-            let v3 =
-              (match v3 with
-              | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-              | `SEMI tok -> token env tok (* ";" *)
-              )
-            in
-            todo env (v1, v2, v3)
-        )
-      in
-      todo env (v1, v2, v3)
-  )
-
-
-and map_declaration (env : env) (x : CST.declaration) =
-  (match x with
-  | `Decl_func_decl (v1, v2, v3, v4, v5, v6) ->
-      let v1 =
-        (match v1 with
-        | Some tok -> token env tok (* "async" *)
-        | None -> todo env ())
-      in
-      let v2 = token env v2 (* "function" *) in
-      let v3 = token env v3 (* identifier *) in
-      let v4 = map_formal_parameters env v4 in
-      let v5 = map_statement_block env v5 in
-      let v6 =
-        (match v6 with
-        | Some tok -> token env tok (* automatic_semicolon *)
-        | None -> todo env ())
-      in
-      todo env (v1, v2, v3, v4, v5, v6)
-  | `Decl_gene_func_decl (v1, v2, v3, v4, v5, v6, v7) ->
-      let v1 =
-        (match v1 with
-        | Some tok -> token env tok (* "async" *)
-        | None -> todo env ())
-      in
-      let v2 = token env v2 (* "function" *) in
-      let v3 = token env v3 (* "*" *) in
-      let v4 = token env v4 (* identifier *) in
-      let v5 = map_formal_parameters env v5 in
-      let v6 = map_statement_block env v6 in
-      let v7 =
-        (match v7 with
-        | Some tok -> token env tok (* automatic_semicolon *)
-        | None -> todo env ())
-      in
-      todo env (v1, v2, v3, v4, v5, v6, v7)
-  | `Decl_class_decl (v1, v2, v3, v4, v5, v6) ->
-      let v1 = List.map (map_decorator env) v1 in
-      let v2 = token env v2 (* "class" *) in
-      let v3 = token env v3 (* identifier *) in
-      let v4 =
-        (match v4 with
-        | Some x -> map_class_heritage env x
-        | None -> todo env ())
-      in
-      let v5 = map_class_body env v5 in
-      let v6 =
-        (match v6 with
-        | Some tok -> token env tok (* automatic_semicolon *)
-        | None -> todo env ())
-      in
-      todo env (v1, v2, v3, v4, v5, v6)
-  | `Decl_lexi_decl x -> map_lexical_declaration env x
-  | `Decl_var_decl x -> map_variable_declaration env x
-  )
-
-
-and map_expression_statement (env : env) ((v1, v2) : CST.expression_statement) =
-  let v1 =
-    (match v1 with
-    | `Exp x -> map_expression env x
-    | `Seq_exp x -> map_sequence_expression env x
-    )
-  in
-  let v2 =
-    (match v2 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2)
-
+and map_jsx_opening_element (env : env) ((v1, v2, v3, v4) : CST.jsx_opening_element) =
+  let v1 = token env v1 (* "<" *) in
+  let v2 = map_anon_choice_choice_jsx_id env v2 in
+  let v3 = List.map (map_anon_choice_jsx_attr env) v3 in
+  let v4 = token env v4 (* ">" *) in
+  todo env (v1, v2, v3, v4)
 
 and map_variable_declaration (env : env) ((v1, v2, v3, v4) : CST.variable_declaration) =
   let v1 = token env v1 (* "var" *) in
@@ -460,1062 +266,36 @@ and map_variable_declaration (env : env) ((v1, v2, v3, v4) : CST.variable_declar
       todo env (v1, v2)
     ) v3
   in
-  let v4 =
-    (match v4 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
+  let v4 = map_anon_choice_auto_semi env v4 in
   todo env (v1, v2, v3, v4)
 
-
-and map_lexical_declaration (env : env) ((v1, v2, v3, v4) : CST.lexical_declaration) =
-  let v1 =
-    (match v1 with
-    | `Let tok -> token env tok (* "let" *)
-    | `Const tok -> token env tok (* "const" *)
-    )
-  in
-  let v2 = map_variable_declarator env v2 in
-  let v3 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 = map_variable_declarator env v2 in
-      todo env (v1, v2)
-    ) v3
-  in
-  let v4 =
-    (match v4 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_variable_declarator (env : env) ((v1, v2) : CST.variable_declarator) =
-  let v1 =
-    (match v1 with
-    | `Id tok -> token env tok (* identifier *)
-    | `Choice_obj x ->
-        (match x with
-        | `Obj x -> map_object_ env x
-        | `Array x -> map_array_ env x
-        )
-    )
-  in
-  let v2 =
-    (match v2 with
-    | Some x -> map_initializer_ env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2)
-
-
-and map_statement_block (env : env) ((v1, v2, v3, v4) : CST.statement_block) =
-  let v1 = token env v1 (* "{" *) in
-  let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Expo_stmt x -> map_export_statement env x
-      | `Impo_stmt x -> map_import_statement env x
-      | `Debu_stmt x -> map_debugger_statement env x
-      | `Exp_stmt x -> map_expression_statement env x
-      | `Decl x -> map_declaration env x
-      | `Stmt_blk x -> map_statement_block env x
-      | `If_stmt x -> map_if_statement env x
-      | `Swit_stmt x -> map_switch_statement env x
-      | `For_stmt x -> map_for_statement env x
-      | `For_in_stmt x -> map_for_in_statement env x
-      | `While_stmt x -> map_while_statement env x
-      | `Do_stmt x -> map_do_statement env x
-      | `Try_stmt x -> map_try_statement env x
-      | `With_stmt x -> map_with_statement env x
-      | `Brk_stmt x -> map_break_statement env x
-      | `Cont_stmt x -> map_continue_statement env x
-      | `Ret_stmt x -> map_return_statement env x
-      | `Throw_stmt x -> map_throw_statement env x
-      | `Empty_stmt tok -> token env tok (* ";" *)
-      | `Labe_stmt x -> map_labeled_statement env x
-      )
-    ) v2
-  in
-  let v3 = token env v3 (* "}" *) in
-  let v4 =
-    (match v4 with
-    | Some tok -> token env tok (* automatic_semicolon *)
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_if_statement (env : env) ((v1, v2, v3, v4) : CST.if_statement) =
-  let v1 = token env v1 (* "if" *) in
-  let v2 = map_parenthesized_expression env v2 in
-  let v3 =
-    (match v3 with
-    | `Expo_stmt x -> map_export_statement env x
-    | `Impo_stmt x -> map_import_statement env x
-    | `Debu_stmt x -> map_debugger_statement env x
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Decl x -> map_declaration env x
-    | `Stmt_blk x -> map_statement_block env x
-    | `If_stmt x -> map_if_statement env x
-    | `Swit_stmt x -> map_switch_statement env x
-    | `For_stmt x -> map_for_statement env x
-    | `For_in_stmt x -> map_for_in_statement env x
-    | `While_stmt x -> map_while_statement env x
-    | `Do_stmt x -> map_do_statement env x
-    | `Try_stmt x -> map_try_statement env x
-    | `With_stmt x -> map_with_statement env x
-    | `Brk_stmt x -> map_break_statement env x
-    | `Cont_stmt x -> map_continue_statement env x
-    | `Ret_stmt x -> map_return_statement env x
-    | `Throw_stmt x -> map_throw_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    | `Labe_stmt x -> map_labeled_statement env x
-    )
-  in
-  let v4 =
-    (match v4 with
-    | Some (v1, v2) ->
-        let v1 = token env v1 (* "else" *) in
-        let v2 =
-          (match v2 with
-          | `Expo_stmt x -> map_export_statement env x
-          | `Impo_stmt x -> map_import_statement env x
-          | `Debu_stmt x -> map_debugger_statement env x
-          | `Exp_stmt x -> map_expression_statement env x
-          | `Decl x -> map_declaration env x
-          | `Stmt_blk x -> map_statement_block env x
-          | `If_stmt x -> map_if_statement env x
-          | `Swit_stmt x -> map_switch_statement env x
-          | `For_stmt x -> map_for_statement env x
-          | `For_in_stmt x -> map_for_in_statement env x
-          | `While_stmt x -> map_while_statement env x
-          | `Do_stmt x -> map_do_statement env x
-          | `Try_stmt x -> map_try_statement env x
-          | `With_stmt x -> map_with_statement env x
-          | `Brk_stmt x -> map_break_statement env x
-          | `Cont_stmt x -> map_continue_statement env x
-          | `Ret_stmt x -> map_return_statement env x
-          | `Throw_stmt x -> map_throw_statement env x
-          | `Empty_stmt tok -> token env tok (* ";" *)
-          | `Labe_stmt x -> map_labeled_statement env x
-          )
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_switch_statement (env : env) ((v1, v2, v3) : CST.switch_statement) =
-  let v1 = token env v1 (* "switch" *) in
-  let v2 = map_parenthesized_expression env v2 in
-  let v3 = map_switch_body env v3 in
-  todo env (v1, v2, v3)
-
-
-and map_for_statement (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.for_statement) =
-  let v1 = token env v1 (* "for" *) in
-  let v2 = token env v2 (* "(" *) in
-  let v3 =
-    (match v3 with
-    | `Lexi_decl x -> map_lexical_declaration env x
-    | `Var_decl x -> map_variable_declaration env x
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    )
-  in
-  let v4 =
-    (match v4 with
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    )
-  in
-  let v5 =
-    (match v5 with
-    | Some x ->
-        (match x with
-        | `Exp x -> map_expression env x
-        | `Seq_exp x -> map_sequence_expression env x
-        )
-    | None -> todo env ())
-  in
-  let v6 = token env v6 (* ")" *) in
-  let v7 =
-    (match v7 with
-    | `Expo_stmt x -> map_export_statement env x
-    | `Impo_stmt x -> map_import_statement env x
-    | `Debu_stmt x -> map_debugger_statement env x
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Decl x -> map_declaration env x
-    | `Stmt_blk x -> map_statement_block env x
-    | `If_stmt x -> map_if_statement env x
-    | `Swit_stmt x -> map_switch_statement env x
-    | `For_stmt x -> map_for_statement env x
-    | `For_in_stmt x -> map_for_in_statement env x
-    | `While_stmt x -> map_while_statement env x
-    | `Do_stmt x -> map_do_statement env x
-    | `Try_stmt x -> map_try_statement env x
-    | `With_stmt x -> map_with_statement env x
-    | `Brk_stmt x -> map_break_statement env x
-    | `Cont_stmt x -> map_continue_statement env x
-    | `Ret_stmt x -> map_return_statement env x
-    | `Throw_stmt x -> map_throw_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    | `Labe_stmt x -> map_labeled_statement env x
-    )
-  in
-  todo env (v1, v2, v3, v4, v5, v6, v7)
-
-
-and map_for_in_statement (env : env) ((v1, v2, v3, v4) : CST.for_in_statement) =
-  let v1 = token env v1 (* "for" *) in
-  let v2 =
-    (match v2 with
-    | Some tok -> token env tok (* "await" *)
-    | None -> todo env ())
-  in
-  let v3 = map_for_header env v3 in
-  let v4 =
-    (match v4 with
-    | `Expo_stmt x -> map_export_statement env x
-    | `Impo_stmt x -> map_import_statement env x
-    | `Debu_stmt x -> map_debugger_statement env x
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Decl x -> map_declaration env x
-    | `Stmt_blk x -> map_statement_block env x
-    | `If_stmt x -> map_if_statement env x
-    | `Swit_stmt x -> map_switch_statement env x
-    | `For_stmt x -> map_for_statement env x
-    | `For_in_stmt x -> map_for_in_statement env x
-    | `While_stmt x -> map_while_statement env x
-    | `Do_stmt x -> map_do_statement env x
-    | `Try_stmt x -> map_try_statement env x
-    | `With_stmt x -> map_with_statement env x
-    | `Brk_stmt x -> map_break_statement env x
-    | `Cont_stmt x -> map_continue_statement env x
-    | `Ret_stmt x -> map_return_statement env x
-    | `Throw_stmt x -> map_throw_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    | `Labe_stmt x -> map_labeled_statement env x
-    )
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_for_header (env : env) ((v1, v2, v3, v4, v5, v6) : CST.for_header) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 =
-    (match v2 with
-    | Some x ->
-        (match x with
-        | `Var tok -> token env tok (* "var" *)
-        | `Let tok -> token env tok (* "let" *)
-        | `Const tok -> token env tok (* "const" *)
-        )
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | `Paren_exp x -> map_parenthesized_expression env x
-    | `Choice_memb_exp x ->
-        (match x with
-        | `Memb_exp x -> map_member_expression env x
-        | `Subs_exp x -> map_subscript_expression env x
-        | `Id tok -> token env tok (* identifier *)
-        | `Choice_get x ->
-            (match x with
-            | `Get tok -> token env tok (* "get" *)
-            | `Set tok -> token env tok (* "set" *)
-            | `Async tok -> token env tok (* "async" *)
-            | `Stat tok -> token env tok (* "static" *)
-            )
-        | `Choice_obj x ->
-            (match x with
-            | `Obj x -> map_object_ env x
-            | `Array x -> map_array_ env x
-            )
-        )
-    )
-  in
-  let v4 =
-    (match v4 with
-    | `In tok -> token env tok (* "in" *)
-    | `Of tok -> token env tok (* "of" *)
-    )
-  in
-  let v5 =
-    (match v5 with
-    | `Exp x -> map_expression env x
-    | `Seq_exp x -> map_sequence_expression env x
-    )
-  in
-  let v6 = token env v6 (* ")" *) in
-  todo env (v1, v2, v3, v4, v5, v6)
-
-
-and map_while_statement (env : env) ((v1, v2, v3) : CST.while_statement) =
-  let v1 = token env v1 (* "while" *) in
-  let v2 = map_parenthesized_expression env v2 in
-  let v3 =
-    (match v3 with
-    | `Expo_stmt x -> map_export_statement env x
-    | `Impo_stmt x -> map_import_statement env x
-    | `Debu_stmt x -> map_debugger_statement env x
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Decl x -> map_declaration env x
-    | `Stmt_blk x -> map_statement_block env x
-    | `If_stmt x -> map_if_statement env x
-    | `Swit_stmt x -> map_switch_statement env x
-    | `For_stmt x -> map_for_statement env x
-    | `For_in_stmt x -> map_for_in_statement env x
-    | `While_stmt x -> map_while_statement env x
-    | `Do_stmt x -> map_do_statement env x
-    | `Try_stmt x -> map_try_statement env x
-    | `With_stmt x -> map_with_statement env x
-    | `Brk_stmt x -> map_break_statement env x
-    | `Cont_stmt x -> map_continue_statement env x
-    | `Ret_stmt x -> map_return_statement env x
-    | `Throw_stmt x -> map_throw_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    | `Labe_stmt x -> map_labeled_statement env x
-    )
-  in
-  todo env (v1, v2, v3)
-
-
-and map_do_statement (env : env) ((v1, v2, v3, v4, v5) : CST.do_statement) =
-  let v1 = token env v1 (* "do" *) in
-  let v2 =
-    (match v2 with
-    | `Expo_stmt x -> map_export_statement env x
-    | `Impo_stmt x -> map_import_statement env x
-    | `Debu_stmt x -> map_debugger_statement env x
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Decl x -> map_declaration env x
-    | `Stmt_blk x -> map_statement_block env x
-    | `If_stmt x -> map_if_statement env x
-    | `Swit_stmt x -> map_switch_statement env x
-    | `For_stmt x -> map_for_statement env x
-    | `For_in_stmt x -> map_for_in_statement env x
-    | `While_stmt x -> map_while_statement env x
-    | `Do_stmt x -> map_do_statement env x
-    | `Try_stmt x -> map_try_statement env x
-    | `With_stmt x -> map_with_statement env x
-    | `Brk_stmt x -> map_break_statement env x
-    | `Cont_stmt x -> map_continue_statement env x
-    | `Ret_stmt x -> map_return_statement env x
-    | `Throw_stmt x -> map_throw_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    | `Labe_stmt x -> map_labeled_statement env x
-    )
-  in
-  let v3 = token env v3 (* "while" *) in
-  let v4 = map_parenthesized_expression env v4 in
-  let v5 =
-    (match v5 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2, v3, v4, v5)
-
-
-and map_try_statement (env : env) ((v1, v2, v3, v4) : CST.try_statement) =
-  let v1 = token env v1 (* "try" *) in
-  let v2 = map_statement_block env v2 in
-  let v3 =
-    (match v3 with
-    | Some x -> map_catch_clause env x
-    | None -> todo env ())
-  in
-  let v4 =
-    (match v4 with
-    | Some x -> map_finally_clause env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_with_statement (env : env) ((v1, v2, v3) : CST.with_statement) =
-  let v1 = token env v1 (* "with" *) in
-  let v2 = map_parenthesized_expression env v2 in
-  let v3 =
-    (match v3 with
-    | `Expo_stmt x -> map_export_statement env x
-    | `Impo_stmt x -> map_import_statement env x
-    | `Debu_stmt x -> map_debugger_statement env x
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Decl x -> map_declaration env x
-    | `Stmt_blk x -> map_statement_block env x
-    | `If_stmt x -> map_if_statement env x
-    | `Swit_stmt x -> map_switch_statement env x
-    | `For_stmt x -> map_for_statement env x
-    | `For_in_stmt x -> map_for_in_statement env x
-    | `While_stmt x -> map_while_statement env x
-    | `Do_stmt x -> map_do_statement env x
-    | `Try_stmt x -> map_try_statement env x
-    | `With_stmt x -> map_with_statement env x
-    | `Brk_stmt x -> map_break_statement env x
-    | `Cont_stmt x -> map_continue_statement env x
-    | `Ret_stmt x -> map_return_statement env x
-    | `Throw_stmt x -> map_throw_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    | `Labe_stmt x -> map_labeled_statement env x
-    )
-  in
-  todo env (v1, v2, v3)
-
-
-and map_return_statement (env : env) ((v1, v2, v3) : CST.return_statement) =
-  let v1 = token env v1 (* "return" *) in
-  let v2 =
-    (match v2 with
-    | Some x ->
-        (match x with
-        | `Exp x -> map_expression env x
-        | `Seq_exp x -> map_sequence_expression env x
-        )
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2, v3)
-
-
-and map_throw_statement (env : env) ((v1, v2, v3) : CST.throw_statement) =
-  let v1 = token env v1 (* "throw" *) in
-  let v2 =
-    (match v2 with
-    | `Exp x -> map_expression env x
-    | `Seq_exp x -> map_sequence_expression env x
-    )
-  in
-  let v3 =
-    (match v3 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2, v3)
-
-
-and map_labeled_statement (env : env) ((v1, v2, v3) : CST.labeled_statement) =
-  let v1 =
-    (match v1 with
-    | `Id tok -> token env tok (* identifier *)
-    | `Choice_get x ->
-        (match x with
-        | `Get tok -> token env tok (* "get" *)
-        | `Set tok -> token env tok (* "set" *)
-        | `Async tok -> token env tok (* "async" *)
-        | `Stat tok -> token env tok (* "static" *)
-        )
-    )
-  in
-  let v2 = token env v2 (* ":" *) in
-  let v3 =
-    (match v3 with
-    | `Expo_stmt x -> map_export_statement env x
-    | `Impo_stmt x -> map_import_statement env x
-    | `Debu_stmt x -> map_debugger_statement env x
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Decl x -> map_declaration env x
-    | `Stmt_blk x -> map_statement_block env x
-    | `If_stmt x -> map_if_statement env x
-    | `Swit_stmt x -> map_switch_statement env x
-    | `For_stmt x -> map_for_statement env x
-    | `For_in_stmt x -> map_for_in_statement env x
-    | `While_stmt x -> map_while_statement env x
-    | `Do_stmt x -> map_do_statement env x
-    | `Try_stmt x -> map_try_statement env x
-    | `With_stmt x -> map_with_statement env x
-    | `Brk_stmt x -> map_break_statement env x
-    | `Cont_stmt x -> map_continue_statement env x
-    | `Ret_stmt x -> map_return_statement env x
-    | `Throw_stmt x -> map_throw_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    | `Labe_stmt x -> map_labeled_statement env x
-    )
-  in
-  todo env (v1, v2, v3)
-
-
-and map_switch_body (env : env) ((v1, v2, v3) : CST.switch_body) =
-  let v1 = token env v1 (* "{" *) in
-  let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Swit_case x -> map_switch_case env x
-      | `Swit_defa x -> map_switch_default env x
-      )
-    ) v2
-  in
-  let v3 = token env v3 (* "}" *) in
-  todo env (v1, v2, v3)
-
-
-and map_switch_case (env : env) ((v1, v2, v3, v4) : CST.switch_case) =
-  let v1 = token env v1 (* "case" *) in
-  let v2 =
-    (match v2 with
-    | `Exp x -> map_expression env x
-    | `Seq_exp x -> map_sequence_expression env x
-    )
-  in
-  let v3 = token env v3 (* ":" *) in
-  let v4 =
-    List.map (fun x ->
-      (match x with
-      | `Expo_stmt x -> map_export_statement env x
-      | `Impo_stmt x -> map_import_statement env x
-      | `Debu_stmt x -> map_debugger_statement env x
-      | `Exp_stmt x -> map_expression_statement env x
-      | `Decl x -> map_declaration env x
-      | `Stmt_blk x -> map_statement_block env x
-      | `If_stmt x -> map_if_statement env x
-      | `Swit_stmt x -> map_switch_statement env x
-      | `For_stmt x -> map_for_statement env x
-      | `For_in_stmt x -> map_for_in_statement env x
-      | `While_stmt x -> map_while_statement env x
-      | `Do_stmt x -> map_do_statement env x
-      | `Try_stmt x -> map_try_statement env x
-      | `With_stmt x -> map_with_statement env x
-      | `Brk_stmt x -> map_break_statement env x
-      | `Cont_stmt x -> map_continue_statement env x
-      | `Ret_stmt x -> map_return_statement env x
-      | `Throw_stmt x -> map_throw_statement env x
-      | `Empty_stmt tok -> token env tok (* ";" *)
-      | `Labe_stmt x -> map_labeled_statement env x
-      )
-    ) v4
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_switch_default (env : env) ((v1, v2, v3) : CST.switch_default) =
-  let v1 = token env v1 (* "default" *) in
-  let v2 = token env v2 (* ":" *) in
-  let v3 =
-    List.map (fun x ->
-      (match x with
-      | `Expo_stmt x -> map_export_statement env x
-      | `Impo_stmt x -> map_import_statement env x
-      | `Debu_stmt x -> map_debugger_statement env x
-      | `Exp_stmt x -> map_expression_statement env x
-      | `Decl x -> map_declaration env x
-      | `Stmt_blk x -> map_statement_block env x
-      | `If_stmt x -> map_if_statement env x
-      | `Swit_stmt x -> map_switch_statement env x
-      | `For_stmt x -> map_for_statement env x
-      | `For_in_stmt x -> map_for_in_statement env x
-      | `While_stmt x -> map_while_statement env x
-      | `Do_stmt x -> map_do_statement env x
-      | `Try_stmt x -> map_try_statement env x
-      | `With_stmt x -> map_with_statement env x
-      | `Brk_stmt x -> map_break_statement env x
-      | `Cont_stmt x -> map_continue_statement env x
-      | `Ret_stmt x -> map_return_statement env x
-      | `Throw_stmt x -> map_throw_statement env x
-      | `Empty_stmt tok -> token env tok (* ";" *)
-      | `Labe_stmt x -> map_labeled_statement env x
-      )
-    ) v3
-  in
-  todo env (v1, v2, v3)
-
-
-and map_catch_clause (env : env) ((v1, v2, v3) : CST.catch_clause) =
-  let v1 = token env v1 (* "catch" *) in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2, v3) ->
-        let v1 = token env v1 (* "(" *) in
-        let v2 =
-          (match v2 with
-          | `Id tok -> token env tok (* identifier *)
-          | `Choice_obj x ->
-              (match x with
-              | `Obj x -> map_object_ env x
-              | `Array x -> map_array_ env x
-              )
-          )
-        in
-        let v3 = token env v3 (* ")" *) in
-        todo env (v1, v2, v3)
-    | None -> todo env ())
-  in
-  let v3 = map_statement_block env v3 in
-  todo env (v1, v2, v3)
-
-
-and map_finally_clause (env : env) ((v1, v2) : CST.finally_clause) =
-  let v1 = token env v1 (* "finally" *) in
-  let v2 = map_statement_block env v2 in
-  todo env (v1, v2)
-
-
-and map_parenthesized_expression (env : env) ((v1, v2, v3) : CST.parenthesized_expression) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 =
-    (match v2 with
-    | `Exp x -> map_expression env x
-    | `Seq_exp x -> map_sequence_expression env x
-    )
-  in
-  let v3 = token env v3 (* ")" *) in
-  todo env (v1, v2, v3)
-
-
-and map_expression (env : env) (x : CST.expression) =
+and map_anon_choice_jsx_attr (env : env) (x : CST.anon_choice_jsx_attr) =
   (match x with
-  | `Exp_choice_this x ->
-      (match x with
-      | `This tok -> token env tok (* "this" *)
-      | `Id tok -> token env tok (* identifier *)
-      | `Choice_get x ->
-          (match x with
-          | `Get tok -> token env tok (* "get" *)
-          | `Set tok -> token env tok (* "set" *)
-          | `Async tok -> token env tok (* "async" *)
-          | `Stat tok -> token env tok (* "static" *)
-          )
-      | `Num tok -> token env tok (* number *)
-      | `Str x -> map_string_ env x
-      | `Temp_str x -> map_template_string env x
-      | `Regex x -> map_regex env x
-      | `True tok -> token env tok (* "true" *)
-      | `False tok -> token env tok (* "false" *)
-      | `Null tok -> token env tok (* "null" *)
-      | `Unde tok -> token env tok (* "undefined" *)
-      | `Impo tok -> token env tok (* import *)
-      | `Obj x -> map_object_ env x
-      | `Array x -> map_array_ env x
-      | `Func x -> map_function_ env x
-      | `Arrow_func x -> map_arrow_function env x
-      | `Gene_func x -> map_generator_function env x
-      | `Class x -> map_class_ env x
-      | `Paren_exp x -> map_parenthesized_expression env x
-      | `Subs_exp x -> map_subscript_expression env x
-      | `Memb_exp x -> map_member_expression env x
-      | `Meta_prop x -> map_meta_property env x
-      | `New_exp x -> map_new_expression env x
-      )
-  | `Exp_choice_jsx_elem x ->
-      (match x with
-      | `Jsx_elem x -> map_jsx_element env x
-      | `Jsx_self_clos_elem x ->
-          map_jsx_self_closing_element env x
-      )
-  | `Exp_jsx_frag x -> map_jsx_fragment env x
-  | `Exp_assign_exp (v1, v2, v3) ->
+  | `Jsx_attr (v1, v2) ->
       let v1 =
         (match v1 with
-        | `Paren_exp x -> map_parenthesized_expression env x
-        | `Choice_memb_exp x ->
-            (match x with
-            | `Memb_exp x -> map_member_expression env x
-            | `Subs_exp x -> map_subscript_expression env x
-            | `Id tok -> token env tok (* identifier *)
-            | `Choice_get x ->
-                (match x with
-                | `Get tok -> token env tok (* "get" *)
-                | `Set tok -> token env tok (* "set" *)
-                | `Async tok -> token env tok (* "async" *)
-                | `Stat tok -> token env tok (* "static" *)
-                )
-            | `Choice_obj x ->
-                (match x with
-                | `Obj x -> map_object_ env x
-                | `Array x -> map_array_ env x
-                )
-            )
-        )
-      in
-      let v2 = token env v2 (* "=" *) in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  | `Exp_augm_assign_exp (v1, v2, v3) ->
-      let v1 =
-        (match v1 with
-        | `Memb_exp x -> map_member_expression env x
-        | `Subs_exp x -> map_subscript_expression env x
-        | `Choice_get x ->
-            (match x with
-            | `Get tok -> token env tok (* "get" *)
-            | `Set tok -> token env tok (* "set" *)
-            | `Async tok -> token env tok (* "async" *)
-            | `Stat tok -> token env tok (* "static" *)
-            )
-        | `Id tok -> token env tok (* identifier *)
-        | `Paren_exp x -> map_parenthesized_expression env x
+        | `Choice_jsx_id x -> map_anon_choice_jsx_id env x
+        | `Jsx_name_name x -> map_jsx_namespace_name env x
         )
       in
       let v2 =
         (match v2 with
-        | `PLUSEQ tok -> token env tok (* "+=" *)
-        | `DASHEQ tok -> token env tok (* "-=" *)
-        | `STAREQ tok -> token env tok (* "*=" *)
-        | `SLASHEQ tok -> token env tok (* "/=" *)
-        | `PERCEQ tok -> token env tok (* "%=" *)
-        | `HATEQ tok -> token env tok (* "^=" *)
-        | `AMPEQ tok -> token env tok (* "&=" *)
-        | `BAREQ tok -> token env tok (* "|=" *)
-        | `GTGTEQ tok -> token env tok (* ">>=" *)
-        | `GTGTGTEQ tok -> token env tok (* ">>>=" *)
-        | `LTLTEQ tok -> token env tok (* "<<=" *)
-        | `STARSTAREQ tok -> token env tok (* "**=" *)
-        )
-      in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  | `Exp_await_exp (v1, v2) ->
-      let v1 = token env v1 (* "await" *) in
-      let v2 = map_expression env v2 in
-      todo env (v1, v2)
-  | `Exp_un_exp x -> map_unary_expression env x
-  | `Exp_bin_exp x -> map_binary_expression env x
-  | `Exp_tern_exp (v1, v2, v3, v4, v5) ->
-      let v1 = map_expression env v1 in
-      let v2 = token env v2 (* "?" *) in
-      let v3 = map_expression env v3 in
-      let v4 = token env v4 (* ":" *) in
-      let v5 = map_expression env v5 in
-      todo env (v1, v2, v3, v4, v5)
-  | `Exp_upda_exp x -> map_update_expression env x
-  | `Exp_call_exp (v1, v2) ->
-      let v1 =
-        (match v1 with
-        | `Exp x -> map_expression env x
-        | `Super tok -> token env tok (* "super" *)
-        | `Func x -> map_function_ env x
-        )
-      in
-      let v2 =
-        (match v2 with
-        | `Args x -> map_arguments env x
-        | `Temp_str x -> map_template_string env x
-        )
-      in
-      todo env (v1, v2)
-  | `Exp_yield_exp (v1, v2) ->
-      let v1 = token env v1 (* "yield" *) in
-      let v2 =
-        (match v2 with
-        | `STAR_exp (v1, v2) ->
-            let v1 = token env v1 (* "*" *) in
-            let v2 = map_expression env v2 in
+        | Some (v1, v2) ->
+            let v1 = token env v1 (* "=" *) in
+            let v2 =
+              (match v2 with
+              | `Str x -> map_string_ env x
+              | `Jsx_exp x -> map_jsx_expression env x
+              | `Choice_jsx_elem x -> map_anon_choice_jsx_elem env x
+              | `Jsx_frag x -> map_jsx_fragment env x
+              )
+            in
             todo env (v1, v2)
-        | `Opt_exp opt ->
-            (match opt with
-            | Some x -> map_expression env x
-            | None -> todo env ())
-        )
+        | None -> todo env ())
       in
       todo env (v1, v2)
+  | `Jsx_exp x -> map_jsx_expression env x
   )
-
-
-and map_object_ (env : env) ((v1, v2, v3) : CST.object_) =
-  let v1 = token env v1 (* "{" *) in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) ->
-        let v1 =
-          (match v1 with
-          | Some x ->
-              (match x with
-              | `Pair x -> map_pair env x
-              | `Spre_elem x -> map_spread_element env x
-              | `Meth_defi x -> map_method_definition env x
-              | `Assign_pat x -> map_assignment_pattern env x
-              | `Choice_id x ->
-                  (match x with
-                  | `Id tok -> token env tok (* identifier *)
-                  | `Choice_get x ->
-                      (match x with
-                      | `Get tok -> token env tok (* "get" *)
-                      | `Set tok -> token env tok (* "set" *)
-                      | `Async tok -> token env tok (* "async" *)
-                      | `Stat tok -> token env tok (* "static" *)
-                      )
-                  )
-              )
-          | None -> todo env ())
-        in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 =
-              (match v2 with
-              | Some x ->
-                  (match x with
-                  | `Pair x -> map_pair env x
-                  | `Spre_elem x -> map_spread_element env x
-                  | `Meth_defi x -> map_method_definition env x
-                  | `Assign_pat x -> map_assignment_pattern env x
-                  | `Choice_id x ->
-                      (match x with
-                      | `Id tok -> token env tok (* identifier *)
-                      | `Choice_get x ->
-                          (match x with
-                          | `Get tok -> token env tok (* "get" *)
-                          | `Set tok -> token env tok (* "set" *)
-                          | `Async tok -> token env tok (* "async" *)
-                          | `Stat tok -> token env tok (* "static" *)
-                          )
-                      )
-                  )
-              | None -> todo env ())
-            in
-            todo env (v1, v2)
-          ) v2
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v3 = token env v3 (* "}" *) in
-  todo env (v1, v2, v3)
-
-
-and map_assignment_pattern (env : env) ((v1, v2, v3) : CST.assignment_pattern) =
-  let v1 =
-    (match v1 with
-    | `Choice_choice_get x ->
-        (match x with
-        | `Choice_get x ->
-            (match x with
-            | `Get tok -> token env tok (* "get" *)
-            | `Set tok -> token env tok (* "set" *)
-            | `Async tok -> token env tok (* "async" *)
-            | `Stat tok -> token env tok (* "static" *)
-            )
-        | `Id tok -> token env tok (* identifier *)
-        )
-    | `Choice_obj x ->
-        (match x with
-        | `Obj x -> map_object_ env x
-        | `Array x -> map_array_ env x
-        )
-    )
-  in
-  let v2 = token env v2 (* "=" *) in
-  let v3 = map_expression env v3 in
-  todo env (v1, v2, v3)
-
-
-and map_array_ (env : env) ((v1, v2, v3) : CST.array_) =
-  let v1 = token env v1 (* "[" *) in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) ->
-        let v1 =
-          (match v1 with
-          | Some x ->
-              (match x with
-              | `Exp x -> map_expression env x
-              | `Spre_elem x -> map_spread_element env x
-              )
-          | None -> todo env ())
-        in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 =
-              (match v2 with
-              | Some x ->
-                  (match x with
-                  | `Exp x -> map_expression env x
-                  | `Spre_elem x -> map_spread_element env x
-                  )
-              | None -> todo env ())
-            in
-            todo env (v1, v2)
-          ) v2
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v3 = token env v3 (* "]" *) in
-  todo env (v1, v2, v3)
-
-
-and map_jsx_element (env : env) ((v1, v2, v3) : CST.jsx_element) =
-  let v1 = map_jsx_opening_element env v1 in
-  let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Jsx_text tok -> token env tok (* pattern [^{}<>]+ *)
-      | `Choice_jsx_elem x ->
-          (match x with
-          | `Jsx_elem x -> map_jsx_element env x
-          | `Jsx_self_clos_elem x ->
-              map_jsx_self_closing_element env x
-          )
-      | `Jsx_exp x -> map_jsx_expression env x
-      )
-    ) v2
-  in
-  let v3 = map_jsx_closing_element env v3 in
-  todo env (v1, v2, v3)
-
-
-and map_jsx_fragment (env : env) ((v1, v2, v3, v4, v5, v6) : CST.jsx_fragment) =
-  let v1 = token env v1 (* "<" *) in
-  let v2 = token env v2 (* ">" *) in
-  let v3 =
-    List.map (fun x ->
-      (match x with
-      | `Jsx_text tok -> token env tok (* pattern [^{}<>]+ *)
-      | `Choice_jsx_elem x ->
-          (match x with
-          | `Jsx_elem x -> map_jsx_element env x
-          | `Jsx_self_clos_elem x ->
-              map_jsx_self_closing_element env x
-          )
-      | `Jsx_exp x -> map_jsx_expression env x
-      )
-    ) v3
-  in
-  let v4 = token env v4 (* "<" *) in
-  let v5 = token env v5 (* "/" *) in
-  let v6 = token env v6 (* ">" *) in
-  todo env (v1, v2, v3, v4, v5, v6)
-
-
-and map_jsx_expression (env : env) ((v1, v2, v3) : CST.jsx_expression) =
-  let v1 = token env v1 (* "{" *) in
-  let v2 =
-    (match v2 with
-    | Some x ->
-        (match x with
-        | `Exp x -> map_expression env x
-        | `Seq_exp x -> map_sequence_expression env x
-        | `Spre_elem x -> map_spread_element env x
-        )
-    | None -> todo env ())
-  in
-  let v3 = token env v3 (* "}" *) in
-  todo env (v1, v2, v3)
-
-
-and map_jsx_opening_element (env : env) ((v1, v2, v3, v4) : CST.jsx_opening_element) =
-  let v1 = token env v1 (* "<" *) in
-  let v2 =
-    (match v2 with
-    | `Choice_jsx_id x ->
-        (match x with
-        | `Jsx_id tok ->
-            token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
-        | `Id tok -> token env tok (* identifier *)
-        )
-    | `Nest_id x -> map_nested_identifier env x
-    | `Jsx_name_name x -> map_jsx_namespace_name env x
-    )
-  in
-  let v3 =
-    List.map (fun x ->
-      (match x with
-      | `Jsx_attr x -> map_jsx_attribute env x
-      | `Jsx_exp x -> map_jsx_expression env x
-      )
-    ) v3
-  in
-  let v4 = token env v4 (* ">" *) in
-  todo env (v1, v2, v3, v4)
-
-
-and map_jsx_self_closing_element (env : env) ((v1, v2, v3, v4, v5) : CST.jsx_self_closing_element) =
-  let v1 = token env v1 (* "<" *) in
-  let v2 =
-    (match v2 with
-    | `Choice_jsx_id x ->
-        (match x with
-        | `Jsx_id tok ->
-            token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
-        | `Id tok -> token env tok (* identifier *)
-        )
-    | `Nest_id x -> map_nested_identifier env x
-    | `Jsx_name_name x -> map_jsx_namespace_name env x
-    )
-  in
-  let v3 =
-    List.map (fun x ->
-      (match x with
-      | `Jsx_attr x -> map_jsx_attribute env x
-      | `Jsx_exp x -> map_jsx_expression env x
-      )
-    ) v3
-  in
-  let v4 = token env v4 (* "/" *) in
-  let v5 = token env v5 (* ">" *) in
-  todo env (v1, v2, v3, v4, v5)
-
-
-and map_jsx_attribute (env : env) ((v1, v2) : CST.jsx_attribute) =
-  let v1 =
-    (match v1 with
-    | `Choice_jsx_id x ->
-        (match x with
-        | `Jsx_id tok ->
-            token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
-        | `Id tok -> token env tok (* identifier *)
-        )
-    | `Jsx_name_name x -> map_jsx_namespace_name env x
-    )
-  in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) ->
-        let v1 = token env v1 (* "=" *) in
-        let v2 =
-          (match v2 with
-          | `Str x -> map_string_ env x
-          | `Jsx_exp x -> map_jsx_expression env x
-          | `Choice_jsx_elem x ->
-              (match x with
-              | `Jsx_elem x -> map_jsx_element env x
-              | `Jsx_self_clos_elem x ->
-                  map_jsx_self_closing_element env x
-              )
-          | `Jsx_frag x -> map_jsx_fragment env x
-          )
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  todo env (v1, v2)
-
-
-and map_class_ (env : env) ((v1, v2, v3, v4, v5) : CST.class_) =
-  let v1 = List.map (map_decorator env) v1 in
-  let v2 = token env v2 (* "class" *) in
-  let v3 =
-    (match v3 with
-    | Some tok -> token env tok (* identifier *)
-    | None -> todo env ())
-  in
-  let v4 =
-    (match v4 with
-    | Some x -> map_class_heritage env x
-    | None -> todo env ())
-  in
-  let v5 = map_class_body env v5 in
-  todo env (v1, v2, v3, v4, v5)
-
-
-and map_class_heritage (env : env) ((v1, v2) : CST.class_heritage) =
-  let v1 = token env v1 (* "extends" *) in
-  let v2 = map_expression env v2 in
-  todo env (v1, v2)
-
 
 and map_function_ (env : env) ((v1, v2, v3, v4, v5) : CST.function_) =
   let v1 =
@@ -1533,149 +313,164 @@ and map_function_ (env : env) ((v1, v2, v3, v4, v5) : CST.function_) =
   let v5 = map_statement_block env v5 in
   todo env (v1, v2, v3, v4, v5)
 
-
-and map_generator_function (env : env) ((v1, v2, v3, v4, v5, v6) : CST.generator_function) =
-  let v1 =
-    (match v1 with
-    | Some tok -> token env tok (* "async" *)
-    | None -> todo env ())
-  in
-  let v2 = token env v2 (* "function" *) in
-  let v3 = token env v3 (* "*" *) in
-  let v4 =
-    (match v4 with
-    | Some tok -> token env tok (* identifier *)
-    | None -> todo env ())
-  in
-  let v5 = map_formal_parameters env v5 in
-  let v6 = map_statement_block env v6 in
-  todo env (v1, v2, v3, v4, v5, v6)
-
-
-and map_arrow_function (env : env) ((v1, v2, v3, v4) : CST.arrow_function) =
-  let v1 =
-    (match v1 with
-    | Some tok -> token env tok (* "async" *)
-    | None -> todo env ())
-  in
-  let v2 =
-    (match v2 with
-    | `Choice_choice_get x ->
-        (match x with
-        | `Choice_get x ->
-            (match x with
-            | `Get tok -> token env tok (* "get" *)
-            | `Set tok -> token env tok (* "set" *)
-            | `Async tok -> token env tok (* "async" *)
-            | `Stat tok -> token env tok (* "static" *)
-            )
-        | `Id tok -> token env tok (* identifier *)
+and map_anon_choice_expo_stmt (env : env) (x : CST.anon_choice_expo_stmt) =
+  (match x with
+  | `Expo_stmt x -> map_export_statement env x
+  | `Impo_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "import" *) in
+      let v2 =
+        (match v2 with
+        | `Impo_clau_from_clau (v1, v2) ->
+            let v1 = map_import_clause env v1 in
+            let v2 = map_from_clause env v2 in
+            todo env (v1, v2)
+        | `Str x -> map_string_ env x
         )
-    | `Form_params v1 -> map_formal_parameters env v1
-    )
-  in
-  let v3 = token env v3 (* "=>" *) in
-  let v4 =
-    (match v4 with
-    | `Exp x -> map_expression env x
-    | `Stmt_blk x -> map_statement_block env x
-    )
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_new_expression (env : env) ((v1, v2, v3) : CST.new_expression) =
-  let v1 = token env v1 (* "new" *) in
-  let v2 =
-    (match v2 with
-    | `This tok -> token env tok (* "this" *)
-    | `Id tok -> token env tok (* identifier *)
-    | `Choice_get x ->
-        (match x with
-        | `Get tok -> token env tok (* "get" *)
-        | `Set tok -> token env tok (* "set" *)
-        | `Async tok -> token env tok (* "async" *)
-        | `Stat tok -> token env tok (* "static" *)
+      in
+      let v3 = map_anon_choice_auto_semi env v3 in
+      todo env (v1, v2, v3)
+  | `Debu_stmt (v1, v2) ->
+      let v1 = token env v1 (* "debugger" *) in
+      let v2 = map_anon_choice_auto_semi env v2 in
+      todo env (v1, v2)
+  | `Exp_stmt x -> map_expression_statement env x
+  | `Decl x -> map_declaration env x
+  | `Stmt_blk x -> map_statement_block env x
+  | `If_stmt (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "if" *) in
+      let v2 = map_parenthesized_expression env v2 in
+      let v3 = map_anon_choice_expo_stmt env v3 in
+      let v4 =
+        (match v4 with
+        | Some (v1, v2) ->
+            let v1 = token env v1 (* "else" *) in
+            let v2 = map_anon_choice_expo_stmt env v2 in
+            todo env (v1, v2)
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4)
+  | `Swit_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "switch" *) in
+      let v2 = map_parenthesized_expression env v2 in
+      let v3 = map_switch_body env v3 in
+      todo env (v1, v2, v3)
+  | `For_stmt (v1, v2, v3, v4, v5, v6, v7) ->
+      let v1 = token env v1 (* "for" *) in
+      let v2 = token env v2 (* "(" *) in
+      let v3 =
+        (match v3 with
+        | `Lexi_decl x -> map_lexical_declaration env x
+        | `Var_decl x -> map_variable_declaration env x
+        | `Exp_stmt x -> map_expression_statement env x
+        | `Empty_stmt tok -> token env tok (* ";" *)
         )
-    | `Num tok -> token env tok (* number *)
-    | `Str x -> map_string_ env x
-    | `Temp_str x -> map_template_string env x
-    | `Regex x -> map_regex env x
-    | `True tok -> token env tok (* "true" *)
-    | `False tok -> token env tok (* "false" *)
-    | `Null tok -> token env tok (* "null" *)
-    | `Unde tok -> token env tok (* "undefined" *)
-    | `Impo tok -> token env tok (* import *)
-    | `Obj x -> map_object_ env x
-    | `Array x -> map_array_ env x
-    | `Func x -> map_function_ env x
-    | `Arrow_func x -> map_arrow_function env x
-    | `Gene_func x -> map_generator_function env x
-    | `Class x -> map_class_ env x
-    | `Paren_exp x -> map_parenthesized_expression env x
-    | `Subs_exp x -> map_subscript_expression env x
-    | `Memb_exp x -> map_member_expression env x
-    | `Meta_prop x -> map_meta_property env x
-    | `New_exp x -> map_new_expression env x
-    )
-  in
-  let v3 =
-    (match v3 with
-    | Some x -> map_arguments env x
-    | None -> todo env ())
-  in
+      in
+      let v4 =
+        (match v4 with
+        | `Exp_stmt x -> map_expression_statement env x
+        | `Empty_stmt tok -> token env tok (* ";" *)
+        )
+      in
+      let v5 =
+        (match v5 with
+        | Some x -> map_anon_choice_exp env x
+        | None -> todo env ())
+      in
+      let v6 = token env v6 (* ")" *) in
+      let v7 = map_anon_choice_expo_stmt env v7 in
+      todo env (v1, v2, v3, v4, v5, v6, v7)
+  | `For_in_stmt (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "for" *) in
+      let v2 =
+        (match v2 with
+        | Some tok -> token env tok (* "await" *)
+        | None -> todo env ())
+      in
+      let v3 = map_for_header env v3 in
+      let v4 = map_anon_choice_expo_stmt env v4 in
+      todo env (v1, v2, v3, v4)
+  | `While_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "while" *) in
+      let v2 = map_parenthesized_expression env v2 in
+      let v3 = map_anon_choice_expo_stmt env v3 in
+      todo env (v1, v2, v3)
+  | `Do_stmt (v1, v2, v3, v4, v5) ->
+      let v1 = token env v1 (* "do" *) in
+      let v2 = map_anon_choice_expo_stmt env v2 in
+      let v3 = token env v3 (* "while" *) in
+      let v4 = map_parenthesized_expression env v4 in
+      let v5 = map_anon_choice_auto_semi env v5 in
+      todo env (v1, v2, v3, v4, v5)
+  | `Try_stmt (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "try" *) in
+      let v2 = map_statement_block env v2 in
+      let v3 =
+        (match v3 with
+        | Some x -> map_catch_clause env x
+        | None -> todo env ())
+      in
+      let v4 =
+        (match v4 with
+        | Some x -> map_finally_clause env x
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4)
+  | `With_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "with" *) in
+      let v2 = map_parenthesized_expression env v2 in
+      let v3 = map_anon_choice_expo_stmt env v3 in
+      todo env (v1, v2, v3)
+  | `Brk_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "break" *) in
+      let v2 =
+        (match v2 with
+        | Some tok -> token env tok (* identifier *)
+        | None -> todo env ())
+      in
+      let v3 = map_anon_choice_auto_semi env v3 in
+      todo env (v1, v2, v3)
+  | `Cont_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "continue" *) in
+      let v2 =
+        (match v2 with
+        | Some tok -> token env tok (* identifier *)
+        | None -> todo env ())
+      in
+      let v3 = map_anon_choice_auto_semi env v3 in
+      todo env (v1, v2, v3)
+  | `Ret_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "return" *) in
+      let v2 =
+        (match v2 with
+        | Some x -> map_anon_choice_exp env x
+        | None -> todo env ())
+      in
+      let v3 = map_anon_choice_auto_semi env v3 in
+      todo env (v1, v2, v3)
+  | `Throw_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "throw" *) in
+      let v2 = map_anon_choice_exp env v2 in
+      let v3 = map_anon_choice_auto_semi env v3 in
+      todo env (v1, v2, v3)
+  | `Empty_stmt tok -> token env tok (* ";" *)
+  | `Labe_stmt (v1, v2, v3) ->
+      let v1 = map_anon_choice_id_ env v1 in
+      let v2 = token env v2 (* ":" *) in
+      let v3 = map_anon_choice_expo_stmt env v3 in
+      todo env (v1, v2, v3)
+  )
+
+and map_anon_choice_exp (env : env) (x : CST.anon_choice_exp) =
+  (match x with
+  | `Exp x -> map_expression env x
+  | `Seq_exp x -> map_sequence_expression env x
+  )
+
+and map_switch_default (env : env) ((v1, v2, v3) : CST.switch_default) =
+  let v1 = token env v1 (* "default" *) in
+  let v2 = token env v2 (* ":" *) in
+  let v3 = List.map (map_anon_choice_expo_stmt env) v3 in
   todo env (v1, v2, v3)
-
-
-and map_member_expression (env : env) ((v1, v2, v3) : CST.member_expression) =
-  let v1 =
-    (match v1 with
-    | `Exp x -> map_expression env x
-    | `Id tok -> token env tok (* identifier *)
-    | `Super tok -> token env tok (* "super" *)
-    | `Choice_get x ->
-        (match x with
-        | `Get tok -> token env tok (* "get" *)
-        | `Set tok -> token env tok (* "set" *)
-        | `Async tok -> token env tok (* "async" *)
-        | `Stat tok -> token env tok (* "static" *)
-        )
-    )
-  in
-  let v2 = token env v2 (* "." *) in
-  let v3 = token env v3 (* identifier *) in
-  todo env (v1, v2, v3)
-
-
-and map_subscript_expression (env : env) ((v1, v2, v3, v4) : CST.subscript_expression) =
-  let v1 =
-    (match v1 with
-    | `Exp x -> map_expression env x
-    | `Super tok -> token env tok (* "super" *)
-    )
-  in
-  let v2 = token env v2 (* "[" *) in
-  let v3 =
-    (match v3 with
-    | `Exp x -> map_expression env x
-    | `Seq_exp x -> map_sequence_expression env x
-    )
-  in
-  let v4 = token env v4 (* "]" *) in
-  todo env (v1, v2, v3, v4)
-
-
-and map_initializer_ (env : env) ((v1, v2) : CST.initializer_) =
-  let v1 = token env v1 (* "=" *) in
-  let v2 = map_expression env v2 in
-  todo env (v1, v2)
-
-
-and map_spread_element (env : env) ((v1, v2) : CST.spread_element) =
-  let v1 = token env v1 (* "..." *) in
-  let v2 = map_expression env v2 in
-  todo env (v1, v2)
-
 
 and map_binary_expression (env : env) (x : CST.binary_expression) =
   (match x with
@@ -1806,6 +601,437 @@ and map_binary_expression (env : env) (x : CST.binary_expression) =
       todo env (v1, v2, v3)
   )
 
+and map_arguments (env : env) ((v1, v2, v3) : CST.arguments) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    map_anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp env v2
+  in
+  let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
+
+and map_variable_declarator (env : env) ((v1, v2) : CST.variable_declarator) =
+  let v1 = map_anon_choice_id env v1 in
+  let v2 =
+    (match v2 with
+    | Some x -> map_initializer_ env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2)
+
+and map_sequence_expression (env : env) ((v1, v2, v3) : CST.sequence_expression) =
+  let v1 = map_expression env v1 in
+  let v2 = token env v2 (* "," *) in
+  let v3 =
+    (match v3 with
+    | `Seq_exp x -> map_sequence_expression env x
+    | `Exp x -> map_expression env x
+    )
+  in
+  todo env (v1, v2, v3)
+
+and map_jsx_fragment (env : env) ((v1, v2, v3, v4, v5, v6) : CST.jsx_fragment) =
+  let v1 = token env v1 (* "<" *) in
+  let v2 = token env v2 (* ">" *) in
+  let v3 = List.map (map_anon_choice_jsx_text env) v3 in
+  let v4 = token env v4 (* "<" *) in
+  let v5 = token env v5 (* "/" *) in
+  let v6 = token env v6 (* ">" *) in
+  todo env (v1, v2, v3, v4, v5, v6)
+
+and map_class_body (env : env) ((v1, v2, v3) : CST.class_body) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    List.map (fun x ->
+      (match x with
+      | `Meth_defi_opt_SEMI (v1, v2) ->
+          let v1 = map_method_definition env v1 in
+          let v2 =
+            (match v2 with
+            | Some tok -> token env tok (* ";" *)
+            | None -> todo env ())
+          in
+          todo env (v1, v2)
+      | `Publ_field_defi_choice_auto_semi (v1, v2) ->
+          let v1 = map_public_field_definition env v1 in
+          let v2 = map_anon_choice_auto_semi env v2 in
+          todo env (v1, v2)
+      )
+    ) v2
+  in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+and map_anon_choice_obj (env : env) (x : CST.anon_choice_obj) =
+  (match x with
+  | `Obj x -> map_object_ env x
+  | `Array x -> map_array_ env x
+  )
+
+and map_anon_choice_jsx_text (env : env) (x : CST.anon_choice_jsx_text) =
+  (match x with
+  | `Jsx_text tok -> token env tok (* pattern [^{}<>]+ *)
+  | `Choice_jsx_elem x -> map_anon_choice_jsx_elem env x
+  | `Jsx_exp x -> map_jsx_expression env x
+  )
+
+and map_anon_choice_this (env : env) (x : CST.anon_choice_this) =
+  (match x with
+  | `This tok -> token env tok (* "this" *)
+  | `Id tok -> token env tok (* identifier *)
+  | `Choice_get x -> map_anon_choice_get env x
+  | `Num tok -> token env tok (* number *)
+  | `Str x -> map_string_ env x
+  | `Temp_str x -> map_template_string env x
+  | `Regex (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "/" *) in
+      let v2 = token env v2 (* regex_pattern *) in
+      let v3 = token env v3 (* "/" *) in
+      let v4 =
+        (match v4 with
+        | Some tok -> token env tok (* pattern [a-z]+ *)
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4)
+  | `True tok -> token env tok (* "true" *)
+  | `False tok -> token env tok (* "false" *)
+  | `Null tok -> token env tok (* "null" *)
+  | `Unde tok -> token env tok (* "undefined" *)
+  | `Impo tok -> token env tok (* import *)
+  | `Obj x -> map_object_ env x
+  | `Array x -> map_array_ env x
+  | `Func x -> map_function_ env x
+  | `Arrow_func (v1, v2, v3, v4) ->
+      let v1 =
+        (match v1 with
+        | Some tok -> token env tok (* "async" *)
+        | None -> todo env ())
+      in
+      let v2 =
+        (match v2 with
+        | `Choice_choice_get x -> map_anon_choice_choice_get env x
+        | `Form_params v1 -> map_formal_parameters env v1
+        )
+      in
+      let v3 = token env v3 (* "=>" *) in
+      let v4 =
+        (match v4 with
+        | `Exp x -> map_expression env x
+        | `Stmt_blk x -> map_statement_block env x
+        )
+      in
+      todo env (v1, v2, v3, v4)
+  | `Gene_func (v1, v2, v3, v4, v5, v6) ->
+      let v1 =
+        (match v1 with
+        | Some tok -> token env tok (* "async" *)
+        | None -> todo env ())
+      in
+      let v2 = token env v2 (* "function" *) in
+      let v3 = token env v3 (* "*" *) in
+      let v4 =
+        (match v4 with
+        | Some tok -> token env tok (* identifier *)
+        | None -> todo env ())
+      in
+      let v5 = map_formal_parameters env v5 in
+      let v6 = map_statement_block env v6 in
+      todo env (v1, v2, v3, v4, v5, v6)
+  | `Class (v1, v2, v3, v4, v5) ->
+      let v1 = List.map (map_decorator env) v1 in
+      let v2 = token env v2 (* "class" *) in
+      let v3 =
+        (match v3 with
+        | Some tok -> token env tok (* identifier *)
+        | None -> todo env ())
+      in
+      let v4 =
+        (match v4 with
+        | Some x -> map_class_heritage env x
+        | None -> todo env ())
+      in
+      let v5 = map_class_body env v5 in
+      todo env (v1, v2, v3, v4, v5)
+  | `Paren_exp x -> map_parenthesized_expression env x
+  | `Subs_exp x -> map_subscript_expression env x
+  | `Memb_exp x -> map_member_expression env x
+  | `Meta_prop (v1, v2, v3) ->
+      let v1 = token env v1 (* "new" *) in
+      let v2 = token env v2 (* "." *) in
+      let v3 = token env v3 (* "target" *) in
+      todo env (v1, v2, v3)
+  | `New_exp (v1, v2, v3) ->
+      let v1 = token env v1 (* "new" *) in
+      let v2 = map_anon_choice_this env v2 in
+      let v3 =
+        (match v3 with
+        | Some x -> map_arguments env x
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3)
+  )
+
+and map_anon_choice_memb_exp (env : env) (x : CST.anon_choice_memb_exp) =
+  (match x with
+  | `Memb_exp x -> map_member_expression env x
+  | `Subs_exp x -> map_subscript_expression env x
+  | `Id tok -> token env tok (* identifier *)
+  | `Choice_get x -> map_anon_choice_get env x
+  | `Choice_obj x -> map_anon_choice_obj env x
+  )
+
+and map_member_expression (env : env) ((v1, v2, v3) : CST.member_expression) =
+  let v1 =
+    (match v1 with
+    | `Exp x -> map_expression env x
+    | `Id tok -> token env tok (* identifier *)
+    | `Super tok -> token env tok (* "super" *)
+    | `Choice_get x -> map_anon_choice_get env x
+    )
+  in
+  let v2 = token env v2 (* "." *) in
+  let v3 = token env v3 (* identifier *) in
+  todo env (v1, v2, v3)
+
+and map_assignment_pattern (env : env) ((v1, v2, v3) : CST.assignment_pattern) =
+  let v1 =
+    (match v1 with
+    | `Choice_choice_get x -> map_anon_choice_choice_get env x
+    | `Choice_obj x -> map_anon_choice_obj env x
+    )
+  in
+  let v2 = token env v2 (* "=" *) in
+  let v3 = map_expression env v3 in
+  todo env (v1, v2, v3)
+
+and map_jsx_expression (env : env) ((v1, v2, v3) : CST.jsx_expression) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    (match v2 with
+    | Some x ->
+        (match x with
+        | `Exp x -> map_expression env x
+        | `Seq_exp x -> map_sequence_expression env x
+        | `Spre_elem x -> map_spread_element env x
+        )
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+and map_anon_choice_jsx_elem (env : env) (x : CST.anon_choice_jsx_elem) =
+  (match x with
+  | `Jsx_elem (v1, v2, v3) ->
+      let v1 = map_jsx_opening_element env v1 in
+      let v2 = List.map (map_anon_choice_jsx_text env) v2 in
+      let v3 = map_jsx_closing_element env v3 in
+      todo env (v1, v2, v3)
+  | `Jsx_self_clos_elem (v1, v2, v3, v4, v5) ->
+      let v1 = token env v1 (* "<" *) in
+      let v2 = map_anon_choice_choice_jsx_id env v2 in
+      let v3 = List.map (map_anon_choice_jsx_attr env) v3 in
+      let v4 = token env v4 (* "/" *) in
+      let v5 = token env v5 (* ">" *) in
+      todo env (v1, v2, v3, v4, v5)
+  )
+
+and map_anon_choice_pair (env : env) (x : CST.anon_choice_pair) =
+  (match x with
+  | `Pair (v1, v2, v3) ->
+      let v1 = map_property_name env v1 in
+      let v2 = token env v2 (* ":" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Spre_elem x -> map_spread_element env x
+  | `Meth_defi x -> map_method_definition env x
+  | `Assign_pat x -> map_assignment_pattern env x
+  | `Choice_id x -> map_anon_choice_id_ env x
+  )
+
+and map_subscript_expression (env : env) ((v1, v2, v3, v4) : CST.subscript_expression) =
+  let v1 =
+    (match v1 with
+    | `Exp x -> map_expression env x
+    | `Super tok -> token env tok (* "super" *)
+    )
+  in
+  let v2 = token env v2 (* "[" *) in
+  let v3 = map_anon_choice_exp env v3 in
+  let v4 = token env v4 (* "]" *) in
+  todo env (v1, v2, v3, v4)
+
+and map_initializer_ (env : env) ((v1, v2) : CST.initializer_) =
+  let v1 = token env v1 (* "=" *) in
+  let v2 = map_expression env v2 in
+  todo env (v1, v2)
+
+and map_expression_statement (env : env) ((v1, v2) : CST.expression_statement) =
+  let v1 = map_anon_choice_exp env v1 in
+  let v2 = map_anon_choice_auto_semi env v2 in
+  todo env (v1, v2)
+
+and map_catch_clause (env : env) ((v1, v2, v3) : CST.catch_clause) =
+  let v1 = token env v1 (* "catch" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2, v3) ->
+        let v1 = token env v1 (* "(" *) in
+        let v2 = map_anon_choice_id env v2 in
+        let v3 = token env v3 (* ")" *) in
+        todo env (v1, v2, v3)
+    | None -> todo env ())
+  in
+  let v3 = map_statement_block env v3 in
+  todo env (v1, v2, v3)
+
+and map_template_string (env : env) ((v1, v2, v3) : CST.template_string) =
+  let v1 = token env v1 (* "`" *) in
+  let v2 =
+    List.map (fun x ->
+      (match x with
+      | `Temp_chars tok -> token env tok (* template_chars *)
+      | `Esc_seq tok -> token env tok (* escape_sequence *)
+      | `Temp_subs x -> map_template_substitution env x
+      )
+    ) v2
+  in
+  let v3 = token env v3 (* "`" *) in
+  todo env (v1, v2, v3)
+
+and map_decorator (env : env) ((v1, v2) : CST.decorator) =
+  let v1 = token env v1 (* "@" *) in
+  let v2 =
+    (match v2 with
+    | `Choice_id x -> map_anon_choice_id_ env x
+    | `Deco_memb_exp x -> map_decorator_member_expression env x
+    | `Deco_call_exp x -> map_decorator_call_expression env x
+    )
+  in
+  todo env (v1, v2)
+
+and map_anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp (env : env) (opt : CST.anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp) =
+  (match opt with
+  | Some (v1, v2) ->
+      let v1 =
+        (match v1 with
+        | Some x -> map_anon_choice_exp_ env x
+        | None -> todo env ())
+      in
+      let v2 = map_anon_rep_COMMA_opt_choice_exp env v2 in
+      todo env (v1, v2)
+  | None -> todo env ())
+
+and map_for_header (env : env) ((v1, v2, v3, v4, v5, v6) : CST.for_header) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    (match v2 with
+    | Some x ->
+        (match x with
+        | `Var tok -> token env tok (* "var" *)
+        | `Let tok -> token env tok (* "let" *)
+        | `Const tok -> token env tok (* "const" *)
+        )
+    | None -> todo env ())
+  in
+  let v3 = map_anon_choice_paren_exp env v3 in
+  let v4 =
+    (match v4 with
+    | `In tok -> token env tok (* "in" *)
+    | `Of tok -> token env tok (* "of" *)
+    )
+  in
+  let v5 = map_anon_choice_exp env v5 in
+  let v6 = token env v6 (* ")" *) in
+  todo env (v1, v2, v3, v4, v5, v6)
+
+and map_expression (env : env) (x : CST.expression) =
+  (match x with
+  | `Exp_choice_this x -> map_anon_choice_this env x
+  | `Exp_choice_jsx_elem x -> map_anon_choice_jsx_elem env x
+  | `Exp_jsx_frag x -> map_jsx_fragment env x
+  | `Exp_assign_exp (v1, v2, v3) ->
+      let v1 = map_anon_choice_paren_exp env v1 in
+      let v2 = token env v2 (* "=" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_augm_assign_exp (v1, v2, v3) ->
+      let v1 =
+        (match v1 with
+        | `Memb_exp x -> map_member_expression env x
+        | `Subs_exp x -> map_subscript_expression env x
+        | `Choice_get x -> map_anon_choice_get env x
+        | `Id tok -> token env tok (* identifier *)
+        | `Paren_exp x -> map_parenthesized_expression env x
+        )
+      in
+      let v2 =
+        (match v2 with
+        | `PLUSEQ tok -> token env tok (* "+=" *)
+        | `DASHEQ tok -> token env tok (* "-=" *)
+        | `STAREQ tok -> token env tok (* "*=" *)
+        | `SLASHEQ tok -> token env tok (* "/=" *)
+        | `PERCEQ tok -> token env tok (* "%=" *)
+        | `HATEQ tok -> token env tok (* "^=" *)
+        | `AMPEQ tok -> token env tok (* "&=" *)
+        | `BAREQ tok -> token env tok (* "|=" *)
+        | `GTGTEQ tok -> token env tok (* ">>=" *)
+        | `GTGTGTEQ tok -> token env tok (* ">>>=" *)
+        | `LTLTEQ tok -> token env tok (* "<<=" *)
+        | `STARSTAREQ tok -> token env tok (* "**=" *)
+        )
+      in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_await_exp (v1, v2) ->
+      let v1 = token env v1 (* "await" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `Exp_un_exp x -> map_unary_expression env x
+  | `Exp_bin_exp x -> map_binary_expression env x
+  | `Exp_tern_exp (v1, v2, v3, v4, v5) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "?" *) in
+      let v3 = map_expression env v3 in
+      let v4 = token env v4 (* ":" *) in
+      let v5 = map_expression env v5 in
+      todo env (v1, v2, v3, v4, v5)
+  | `Exp_upda_exp x -> map_update_expression env x
+  | `Exp_call_exp (v1, v2) ->
+      let v1 =
+        (match v1 with
+        | `Exp x -> map_expression env x
+        | `Super tok -> token env tok (* "super" *)
+        | `Func x -> map_function_ env x
+        )
+      in
+      let v2 =
+        (match v2 with
+        | `Args x -> map_arguments env x
+        | `Temp_str x -> map_template_string env x
+        )
+      in
+      todo env (v1, v2)
+  | `Exp_yield_exp (v1, v2) ->
+      let v1 = token env v1 (* "yield" *) in
+      let v2 =
+        (match v2 with
+        | `STAR_exp (v1, v2) ->
+            let v1 = token env v1 (* "*" *) in
+            let v2 = map_expression env v2 in
+            todo env (v1, v2)
+        | `Opt_exp opt ->
+            (match opt with
+            | Some x -> map_expression env x
+            | None -> todo env ())
+        )
+      in
+      todo env (v1, v2)
+  )
+
+and map_anon_choice_paren_exp (env : env) (x : CST.anon_choice_paren_exp) =
+  (match x with
+  | `Paren_exp x -> map_parenthesized_expression env x
+  | `Choice_memb_exp x -> map_anon_choice_memb_exp env x
+  )
 
 and map_unary_expression (env : env) (x : CST.unary_expression) =
   (match x with
@@ -1839,238 +1065,16 @@ and map_unary_expression (env : env) (x : CST.unary_expression) =
       todo env (v1, v2)
   )
 
-
-and map_update_expression (env : env) (x : CST.update_expression) =
-  (match x with
-  | `Exp_choice_PLUSPLUS (v1, v2) ->
-      let v1 = map_expression env v1 in
-      let v2 =
-        (match v2 with
-        | `PLUSPLUS tok -> token env tok (* "++" *)
-        | `DASHDASH tok -> token env tok (* "--" *)
-        )
-      in
-      todo env (v1, v2)
-  | `Choice_PLUSPLUS_exp (v1, v2) ->
-      let v1 =
-        (match v1 with
-        | `PLUSPLUS tok -> token env tok (* "++" *)
-        | `DASHDASH tok -> token env tok (* "--" *)
-        )
-      in
-      let v2 = map_expression env v2 in
-      todo env (v1, v2)
-  )
-
-
-and map_sequence_expression (env : env) ((v1, v2, v3) : CST.sequence_expression) =
-  let v1 = map_expression env v1 in
-  let v2 = token env v2 (* "," *) in
-  let v3 =
-    (match v3 with
-    | `Seq_exp x -> map_sequence_expression env x
-    | `Exp x -> map_expression env x
-    )
-  in
-  todo env (v1, v2, v3)
-
-
-and map_template_string (env : env) ((v1, v2, v3) : CST.template_string) =
-  let v1 = token env v1 (* "`" *) in
-  let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Temp_chars tok -> token env tok (* template_chars *)
-      | `Esc_seq tok -> token env tok (* escape_sequence *)
-      | `Temp_subs x -> map_template_substitution env x
-      )
-    ) v2
-  in
-  let v3 = token env v3 (* "`" *) in
-  todo env (v1, v2, v3)
-
-
-and map_template_substitution (env : env) ((v1, v2, v3) : CST.template_substitution) =
-  let v1 = token env v1 (* "${" *) in
-  let v2 =
-    (match v2 with
-    | `Exp x -> map_expression env x
-    | `Seq_exp x -> map_sequence_expression env x
-    )
-  in
-  let v3 = token env v3 (* "}" *) in
-  todo env (v1, v2, v3)
-
-
-and map_arguments (env : env) ((v1, v2, v3) : CST.arguments) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) ->
-        let v1 =
-          (match v1 with
-          | Some x ->
-              (match x with
-              | `Exp x -> map_expression env x
-              | `Spre_elem x -> map_spread_element env x
-              )
-          | None -> todo env ())
-        in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 =
-              (match v2 with
-              | Some x ->
-                  (match x with
-                  | `Exp x -> map_expression env x
-                  | `Spre_elem x -> map_spread_element env x
-                  )
-              | None -> todo env ())
-            in
-            todo env (v1, v2)
-          ) v2
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v3 = token env v3 (* ")" *) in
-  todo env (v1, v2, v3)
-
-
-and map_decorator (env : env) ((v1, v2) : CST.decorator) =
-  let v1 = token env v1 (* "@" *) in
-  let v2 =
-    (match v2 with
-    | `Choice_id x ->
-        (match x with
-        | `Id tok -> token env tok (* identifier *)
-        | `Choice_get x ->
-            (match x with
-            | `Get tok -> token env tok (* "get" *)
-            | `Set tok -> token env tok (* "set" *)
-            | `Async tok -> token env tok (* "async" *)
-            | `Stat tok -> token env tok (* "static" *)
-            )
-        )
-    | `Deco_memb_exp x -> map_decorator_member_expression env x
-    | `Deco_call_exp x -> map_decorator_call_expression env x
-    )
-  in
-  todo env (v1, v2)
-
-
-and map_decorator_call_expression (env : env) ((v1, v2) : CST.decorator_call_expression) =
-  let v1 =
-    (match v1 with
-    | `Choice_id x ->
-        (match x with
-        | `Id tok -> token env tok (* identifier *)
-        | `Choice_get x ->
-            (match x with
-            | `Get tok -> token env tok (* "get" *)
-            | `Set tok -> token env tok (* "set" *)
-            | `Async tok -> token env tok (* "async" *)
-            | `Stat tok -> token env tok (* "static" *)
-            )
-        )
-    | `Deco_memb_exp x -> map_decorator_member_expression env x
-    )
-  in
-  let v2 = map_arguments env v2 in
-  todo env (v1, v2)
-
-
-and map_class_body (env : env) ((v1, v2, v3) : CST.class_body) =
-  let v1 = token env v1 (* "{" *) in
-  let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Meth_defi_opt_SEMI (v1, v2) ->
-          let v1 = map_method_definition env v1 in
-          let v2 =
-            (match v2 with
-            | Some tok -> token env tok (* ";" *)
-            | None -> todo env ())
-          in
-          todo env (v1, v2)
-      | `Publ_field_defi_choice_auto_semi (v1, v2) ->
-          let v1 = map_public_field_definition env v1 in
-          let v2 =
-            (match v2 with
-            | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-            | `SEMI tok -> token env tok (* ";" *)
-            )
-          in
-          todo env (v1, v2)
-      )
-    ) v2
-  in
-  let v3 = token env v3 (* "}" *) in
-  todo env (v1, v2, v3)
-
-
-and map_public_field_definition (env : env) ((v1, v2, v3) : CST.public_field_definition) =
-  let v1 =
-    (match v1 with
-    | Some tok -> token env tok (* "static" *)
-    | None -> todo env ())
-  in
-  let v2 = map_property_name env v2 in
-  let v3 =
-    (match v3 with
-    | Some x -> map_initializer_ env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3)
-
-
 and map_formal_parameters (env : env) ((v1, v2, v3) : CST.formal_parameters) =
   let v1 = token env v1 (* "(" *) in
   let v2 =
     (match v2 with
     | Some (v1, v2, v3) ->
-        let v1 =
-          (match v1 with
-          | `Id tok -> token env tok (* identifier *)
-          | `Choice_get x ->
-              (match x with
-              | `Get tok -> token env tok (* "get" *)
-              | `Set tok -> token env tok (* "set" *)
-              | `Async tok -> token env tok (* "async" *)
-              | `Stat tok -> token env tok (* "static" *)
-              )
-          | `Choice_obj x ->
-              (match x with
-              | `Obj x -> map_object_ env x
-              | `Array x -> map_array_ env x
-              )
-          | `Assign_pat x -> map_assignment_pattern env x
-          | `Rest_param x -> map_rest_parameter env x
-          )
-        in
+        let v1 = map_anon_choice_id2 env v1 in
         let v2 =
           List.map (fun (v1, v2) ->
             let v1 = token env v1 (* "," *) in
-            let v2 =
-              (match v2 with
-              | `Id tok -> token env tok (* identifier *)
-              | `Choice_get x ->
-                  (match x with
-                  | `Get tok -> token env tok (* "get" *)
-                  | `Set tok -> token env tok (* "set" *)
-                  | `Async tok -> token env tok (* "async" *)
-                  | `Stat tok -> token env tok (* "static" *)
-                  )
-              | `Choice_obj x ->
-                  (match x with
-                  | `Obj x -> map_object_ env x
-                  | `Array x -> map_array_ env x
-                  )
-              | `Assign_pat x -> map_assignment_pattern env x
-              | `Rest_param x -> map_rest_parameter env x
-              )
-            in
+            let v2 = map_anon_choice_id2 env v2 in
             todo env (v1, v2)
           ) v2
         in
@@ -2085,21 +1089,18 @@ and map_formal_parameters (env : env) ((v1, v2, v3) : CST.formal_parameters) =
   let v3 = token env v3 (* ")" *) in
   todo env (v1, v2, v3)
 
-
-and map_rest_parameter (env : env) ((v1, v2) : CST.rest_parameter) =
-  let v1 = token env v1 (* "..." *) in
+and map_switch_body (env : env) ((v1, v2, v3) : CST.switch_body) =
+  let v1 = token env v1 (* "{" *) in
   let v2 =
-    (match v2 with
-    | `Id tok -> token env tok (* identifier *)
-    | `Choice_obj x ->
-        (match x with
-        | `Obj x -> map_object_ env x
-        | `Array x -> map_array_ env x
-        )
-    )
+    List.map (fun x ->
+      (match x with
+      | `Swit_case x -> map_switch_case env x
+      | `Swit_defa x -> map_switch_default env x
+      )
+    ) v2
   in
-  todo env (v1, v2)
-
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
 
 and map_method_definition (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.method_definition) =
   let v1 = List.map (map_decorator env) v1 in
@@ -2128,27 +1129,121 @@ and map_method_definition (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.method
   let v7 = map_statement_block env v7 in
   todo env (v1, v2, v3, v4, v5, v6, v7)
 
-
-and map_pair (env : env) ((v1, v2, v3) : CST.pair) =
-  let v1 = map_property_name env v1 in
-  let v2 = token env v2 (* ":" *) in
-  let v3 = map_expression env v3 in
+and map_array_ (env : env) ((v1, v2, v3) : CST.array_) =
+  let v1 = token env v1 (* "[" *) in
+  let v2 =
+    map_anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp env v2
+  in
+  let v3 = token env v3 (* "]" *) in
   todo env (v1, v2, v3)
 
+and map_export_statement (env : env) (x : CST.export_statement) =
+  (match x with
+  | `Expo_stmt_expo_choice_STAR_from_clau_choice_auto_semi (v1, v2) ->
+      let v1 = token env v1 (* "export" *) in
+      let v2 =
+        (match v2 with
+        | `STAR_from_clau_choice_auto_semi (v1, v2, v3) ->
+            let v1 = token env v1 (* "*" *) in
+            let v2 = map_from_clause env v2 in
+            let v3 = map_anon_choice_auto_semi env v3 in
+            todo env (v1, v2, v3)
+        | `Expo_clau_from_clau_choice_auto_semi (v1, v2, v3) ->
+            let v1 = map_export_clause env v1 in
+            let v2 = map_from_clause env v2 in
+            let v3 = map_anon_choice_auto_semi env v3 in
+            todo env (v1, v2, v3)
+        | `Expo_clau_choice_auto_semi (v1, v2) ->
+            let v1 = map_export_clause env v1 in
+            let v2 = map_anon_choice_auto_semi env v2 in
+            todo env (v1, v2)
+        )
+      in
+      todo env (v1, v2)
+  | `Expo_stmt_rep_deco_expo_choice_decl (v1, v2, v3) ->
+      let v1 = List.map (map_decorator env) v1 in
+      let v2 = token env v2 (* "export" *) in
+      let v3 =
+        (match v3 with
+        | `Decl x -> map_declaration env x
+        | `Defa_exp_choice_auto_semi (v1, v2, v3) ->
+            let v1 = token env v1 (* "default" *) in
+            let v2 = map_expression env v2 in
+            let v3 = map_anon_choice_auto_semi env v3 in
+            todo env (v1, v2, v3)
+        )
+      in
+      todo env (v1, v2, v3)
+  )
+
+and map_anon_rep_COMMA_opt_choice_exp (env : env) (xs : CST.anon_rep_COMMA_opt_choice_exp) =
+  List.map (fun (v1, v2) ->
+    let v1 = token env v1 (* "," *) in
+    let v2 =
+      (match v2 with
+      | Some x -> map_anon_choice_exp_ env x
+      | None -> todo env ())
+    in
+    todo env (v1, v2)
+  ) xs
+
+and map_decorator_call_expression (env : env) ((v1, v2) : CST.decorator_call_expression) =
+  let v1 = map_anon_choice_choice_id env v1 in
+  let v2 = map_arguments env v2 in
+  todo env (v1, v2)
+
+and map_update_expression (env : env) (x : CST.update_expression) =
+  (match x with
+  | `Exp_choice_PLUSPLUS (v1, v2) ->
+      let v1 = map_expression env v1 in
+      let v2 = map_anon_choice_PLUSPLUS env v2 in
+      todo env (v1, v2)
+  | `Choice_PLUSPLUS_exp (v1, v2) ->
+      let v1 = map_anon_choice_PLUSPLUS env v1 in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  )
+
+and map_public_field_definition (env : env) ((v1, v2, v3) : CST.public_field_definition) =
+  let v1 =
+    (match v1 with
+    | Some tok -> token env tok (* "static" *)
+    | None -> todo env ())
+  in
+  let v2 = map_property_name env v2 in
+  let v3 =
+    (match v3 with
+    | Some x -> map_initializer_ env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3)
+
+and map_lexical_declaration (env : env) ((v1, v2, v3, v4) : CST.lexical_declaration) =
+  let v1 =
+    (match v1 with
+    | `Let tok -> token env tok (* "let" *)
+    | `Const tok -> token env tok (* "const" *)
+    )
+  in
+  let v2 = map_variable_declarator env v2 in
+  let v3 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_variable_declarator env v2 in
+      todo env (v1, v2)
+    ) v3
+  in
+  let v4 = map_anon_choice_auto_semi env v4 in
+  todo env (v1, v2, v3, v4)
+
+and map_class_heritage (env : env) ((v1, v2) : CST.class_heritage) =
+  let v1 = token env v1 (* "extends" *) in
+  let v2 = map_expression env v2 in
+  todo env (v1, v2)
 
 and map_property_name (env : env) (x : CST.property_name) =
   (match x with
-  | `Prop_name_choice_id x ->
-      (match x with
-      | `Id tok -> token env tok (* identifier *)
-      | `Choice_get x ->
-          (match x with
-          | `Get tok -> token env tok (* "get" *)
-          | `Set tok -> token env tok (* "set" *)
-          | `Async tok -> token env tok (* "async" *)
-          | `Stat tok -> token env tok (* "static" *)
-          )
-      )
+  | `Prop_name_choice_id x -> map_anon_choice_id_ env x
   | `Prop_name_str x -> map_string_ env x
   | `Prop_name_num tok -> token env tok (* number *)
   | `Prop_name_comp_prop_name (v1, v2, v3) ->
@@ -2158,37 +1253,151 @@ and map_property_name (env : env) (x : CST.property_name) =
       todo env (v1, v2, v3)
   )
 
+and map_switch_case (env : env) ((v1, v2, v3, v4) : CST.switch_case) =
+  let v1 = token env v1 (* "case" *) in
+  let v2 = map_anon_choice_exp env v2 in
+  let v3 = token env v3 (* ":" *) in
+  let v4 = List.map (map_anon_choice_expo_stmt env) v4 in
+  todo env (v1, v2, v3, v4)
+
+and map_spread_element (env : env) ((v1, v2) : CST.spread_element) =
+  let v1 = token env v1 (* "..." *) in
+  let v2 = map_expression env v2 in
+  todo env (v1, v2)
+
+and map_finally_clause (env : env) ((v1, v2) : CST.finally_clause) =
+  let v1 = token env v1 (* "finally" *) in
+  let v2 = map_statement_block env v2 in
+  todo env (v1, v2)
+
+and map_anon_choice_id (env : env) (x : CST.anon_choice_id) =
+  (match x with
+  | `Id tok -> token env tok (* identifier *)
+  | `Choice_obj x -> map_anon_choice_obj env x
+  )
+
+and map_object_ (env : env) ((v1, v2, v3) : CST.object_) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2) ->
+        let v1 =
+          (match v1 with
+          | Some x -> map_anon_choice_pair env x
+          | None -> todo env ())
+        in
+        let v2 =
+          List.map (fun (v1, v2) ->
+            let v1 = token env v1 (* "," *) in
+            let v2 =
+              (match v2 with
+              | Some x -> map_anon_choice_pair env x
+              | None -> todo env ())
+            in
+            todo env (v1, v2)
+          ) v2
+        in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+and map_anon_choice_id2 (env : env) (x : CST.anon_choice_id2) =
+  (match x with
+  | `Id tok -> token env tok (* identifier *)
+  | `Choice_get x -> map_anon_choice_get env x
+  | `Choice_obj x -> map_anon_choice_obj env x
+  | `Assign_pat x -> map_assignment_pattern env x
+  | `Rest_param (v1, v2) ->
+      let v1 = token env v1 (* "..." *) in
+      let v2 = map_anon_choice_id env v2 in
+      todo env (v1, v2)
+  )
+
+and map_anon_choice_exp_ (env : env) (x : CST.anon_choice_exp_) =
+  (match x with
+  | `Exp x -> map_expression env x
+  | `Spre_elem x -> map_spread_element env x
+  )
+
+and map_statement_block (env : env) ((v1, v2, v3, v4) : CST.statement_block) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 = List.map (map_anon_choice_expo_stmt env) v2 in
+  let v3 = token env v3 (* "}" *) in
+  let v4 =
+    (match v4 with
+    | Some tok -> token env tok (* automatic_semicolon *)
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3, v4)
+
+and map_template_substitution (env : env) ((v1, v2, v3) : CST.template_substitution) =
+  let v1 = token env v1 (* "${" *) in
+  let v2 = map_anon_choice_exp env v2 in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+and map_declaration (env : env) (x : CST.declaration) =
+  (match x with
+  | `Decl_func_decl (v1, v2, v3, v4, v5, v6) ->
+      let v1 =
+        (match v1 with
+        | Some tok -> token env tok (* "async" *)
+        | None -> todo env ())
+      in
+      let v2 = token env v2 (* "function" *) in
+      let v3 = token env v3 (* identifier *) in
+      let v4 = map_formal_parameters env v4 in
+      let v5 = map_statement_block env v5 in
+      let v6 =
+        (match v6 with
+        | Some tok -> token env tok (* automatic_semicolon *)
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4, v5, v6)
+  | `Decl_gene_func_decl (v1, v2, v3, v4, v5, v6, v7) ->
+      let v1 =
+        (match v1 with
+        | Some tok -> token env tok (* "async" *)
+        | None -> todo env ())
+      in
+      let v2 = token env v2 (* "function" *) in
+      let v3 = token env v3 (* "*" *) in
+      let v4 = token env v4 (* identifier *) in
+      let v5 = map_formal_parameters env v5 in
+      let v6 = map_statement_block env v6 in
+      let v7 =
+        (match v7 with
+        | Some tok -> token env tok (* automatic_semicolon *)
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4, v5, v6, v7)
+  | `Decl_class_decl (v1, v2, v3, v4, v5, v6) ->
+      let v1 = List.map (map_decorator env) v1 in
+      let v2 = token env v2 (* "class" *) in
+      let v3 = token env v3 (* identifier *) in
+      let v4 =
+        (match v4 with
+        | Some x -> map_class_heritage env x
+        | None -> todo env ())
+      in
+      let v5 = map_class_body env v5 in
+      let v6 =
+        (match v6 with
+        | Some tok -> token env tok (* automatic_semicolon *)
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4, v5, v6)
+  | `Decl_lexi_decl x -> map_lexical_declaration env x
+  | `Decl_var_decl x -> map_variable_declaration env x
+  )
+
 let map_program (env : env) ((v1, v2) : CST.program) =
   let v1 =
     (match v1 with
     | Some tok -> token env tok (* pattern #!.* *)
     | None -> todo env ())
   in
-  let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Expo_stmt x -> map_export_statement env x
-      | `Impo_stmt x -> map_import_statement env x
-      | `Debu_stmt x -> map_debugger_statement env x
-      | `Exp_stmt x -> map_expression_statement env x
-      | `Decl x -> map_declaration env x
-      | `Stmt_blk x -> map_statement_block env x
-      | `If_stmt x -> map_if_statement env x
-      | `Swit_stmt x -> map_switch_statement env x
-      | `For_stmt x -> map_for_statement env x
-      | `For_in_stmt x -> map_for_in_statement env x
-      | `While_stmt x -> map_while_statement env x
-      | `Do_stmt x -> map_do_statement env x
-      | `Try_stmt x -> map_try_statement env x
-      | `With_stmt x -> map_with_statement env x
-      | `Brk_stmt x -> map_break_statement env x
-      | `Cont_stmt x -> map_continue_statement env x
-      | `Ret_stmt x -> map_return_statement env x
-      | `Throw_stmt x -> map_throw_statement env x
-      | `Empty_stmt tok -> token env tok (* ";" *)
-      | `Labe_stmt x -> map_labeled_statement env x
-      )
-    ) v2
-  in
+  let v2 = List.map (map_anon_choice_expo_stmt env) v2 in
   todo env (v1, v2)
-

--- a/javascript/lib/CST.ml
+++ b/javascript/lib/CST.ml
@@ -8,6 +8,18 @@
 open! Sexplib.Conv
 open Tree_sitter_run
 
+type anon_choice_PLUSPLUS = [
+    `PLUSPLUS of Token.t (* "++" *)
+  | `DASHDASH of Token.t (* "--" *)
+]
+[@@deriving sexp_of]
+
+type number = Token.t
+[@@deriving sexp_of]
+
+type automatic_semicolon = Token.t
+[@@deriving sexp_of]
+
 type jsx_identifier =
   Token.t (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
 [@@deriving sexp_of]
@@ -18,65 +30,52 @@ type jsx_text = Token.t (* pattern [^{}<>]+ *)
 type template_chars = Token.t
 [@@deriving sexp_of]
 
-type number = Token.t
-[@@deriving sexp_of]
-
-type escape_sequence = Token.t
-[@@deriving sexp_of]
-
-type meta_property = (
-    Token.t (* "new" *) * Token.t (* "." *) * Token.t (* "target" *)
-)
-[@@deriving sexp_of]
-
-type hash_bang_line = Token.t (* pattern #!.* *)
-[@@deriving sexp_of]
-
-type regex_flags = Token.t (* pattern [a-z]+ *)
-[@@deriving sexp_of]
-
-type regex_pattern = Token.t
-[@@deriving sexp_of]
-
-type automatic_semicolon = Token.t
-[@@deriving sexp_of]
-
 type import = Token.t
 [@@deriving sexp_of]
 
 type identifier = Token.t
 [@@deriving sexp_of]
 
-type string_ = [
-    `Str_DQUOT_rep_choice_blank_DQUOT of (
-        Token.t (* "\"" *)
-      * [ `Blank of unit (* blank *) | `Esc_seq of escape_sequence (*tok*) ]
-          list (* zero or more *)
-      * Token.t (* "\"" *)
-    )
-  | `Str_SQUOT_rep_choice_blank_SQUOT of (
-        Token.t (* "'" *)
-      * [ `Blank of unit (* blank *) | `Esc_seq of escape_sequence (*tok*) ]
-          list (* zero or more *)
-      * Token.t (* "'" *)
-    )
+type hash_bang_line = Token.t (* pattern #!.* *)
+[@@deriving sexp_of]
+
+type anon_choice_get = [
+    `Get of Token.t (* "get" *)
+  | `Set of Token.t (* "set" *)
+  | `Async of Token.t (* "async" *)
+  | `Stat of Token.t (* "static" *)
 ]
 [@@deriving sexp_of]
 
-type regex = (
-    Token.t (* "/" *)
-  * regex_pattern (*tok*)
-  * Token.t (* "/" *)
-  * regex_flags (*tok*) option
+type regex_flags = Token.t (* pattern [a-z]+ *)
+[@@deriving sexp_of]
+
+type escape_sequence = Token.t
+[@@deriving sexp_of]
+
+type regex_pattern = Token.t
+[@@deriving sexp_of]
+
+type anon_choice_auto_semi = [
+    `Auto_semi of automatic_semicolon (*tok*)
+  | `SEMI of Token.t (* ";" *)
+]
+[@@deriving sexp_of]
+
+type import_export_specifier = (
+    identifier (*tok*)
+  * (Token.t (* "as" *) * identifier (*tok*)) option
 )
 [@@deriving sexp_of]
 
-type debugger_statement = (
-    Token.t (* "debugger" *)
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
+type anon_choice_jsx_id = [
+    `Jsx_id of jsx_identifier (*tok*)
+  | `Id of identifier (*tok*)
+]
+[@@deriving sexp_of]
+
+type namespace_import = (
+    Token.t (* "*" *) * Token.t (* "as" *) * identifier (*tok*)
 )
 [@@deriving sexp_of]
 
@@ -87,72 +86,62 @@ type nested_identifier = (
 )
 [@@deriving sexp_of]
 
-type continue_statement = (
-    Token.t (* "continue" *)
-  * identifier (*tok*) option
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
-)
+type anon_choice_choice_get = [
+    `Choice_get of anon_choice_get
+  | `Id of identifier (*tok*)
+]
 [@@deriving sexp_of]
 
-type decorator_member_expression = (
-    [
-        `Choice_id of [
-            `Id of identifier (*tok*)
-          | `Choice_get of [
-                `Get of Token.t (* "get" *)
-              | `Set of Token.t (* "set" *)
-              | `Async of Token.t (* "async" *)
-              | `Stat of Token.t (* "static" *)
-            ]
-        ]
-      | `Deco_memb_exp of decorator_member_expression
-    ]
-  * Token.t (* "." *)
-  * identifier (*tok*)
-)
+type anon_choice_id_ = [
+    `Id of identifier (*tok*)
+  | `Choice_get of anon_choice_get
+]
 [@@deriving sexp_of]
 
-type import_export_specifier = (
-    identifier (*tok*)
-  * (Token.t (* "as" *) * identifier (*tok*)) option
-)
+type anon_choice_blank = [
+    `Blank of unit (* blank *)
+  | `Esc_seq of escape_sequence (*tok*)
+]
 [@@deriving sexp_of]
 
-type namespace_import = (
-    Token.t (* "*" *) * Token.t (* "as" *) * identifier (*tok*)
-)
-[@@deriving sexp_of]
-
-type break_statement = (
-    Token.t (* "break" *)
-  * identifier (*tok*) option
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
+type anon_impo_expo_spec_rep_COMMA_impo_expo_spec = (
+    import_export_specifier
+  * (Token.t (* "," *) * import_export_specifier) list (* zero or more *)
 )
 [@@deriving sexp_of]
 
 type jsx_namespace_name = (
-    [ `Jsx_id of jsx_identifier (*tok*) | `Id of identifier (*tok*) ]
-  * Token.t (* ":" *)
-  * [ `Jsx_id of jsx_identifier (*tok*) | `Id of identifier (*tok*) ]
+    anon_choice_jsx_id * Token.t (* ":" *) * anon_choice_jsx_id
 )
 [@@deriving sexp_of]
 
-type from_clause = (Token.t (* "from" *) * string_)
+type decorator_member_expression = (
+    anon_choice_choice_id * Token.t (* "." *) * identifier (*tok*)
+)
+
+and anon_choice_choice_id = [
+    `Choice_id of anon_choice_id_
+  | `Deco_memb_exp of decorator_member_expression
+]
+[@@deriving sexp_of]
+
+type string_ = [
+    `Str_DQUOT_rep_choice_blank_DQUOT of (
+        Token.t (* "\"" *)
+      * anon_choice_blank list (* zero or more *)
+      * Token.t (* "\"" *)
+    )
+  | `Str_SQUOT_rep_choice_blank_SQUOT of (
+        Token.t (* "'" *)
+      * anon_choice_blank list (* zero or more *)
+      * Token.t (* "'" *)
+    )
+]
 [@@deriving sexp_of]
 
 type export_clause = (
     Token.t (* "{" *)
-  * (
-        import_export_specifier
-      * (Token.t (* "," *) * import_export_specifier) list (* zero or more *)
-    )
-      option
+  * anon_impo_expo_spec_rep_COMMA_impo_expo_spec option
   * Token.t (* "," *) option
   * Token.t (* "}" *)
 )
@@ -160,29 +149,20 @@ type export_clause = (
 
 type named_imports = (
     Token.t (* "{" *)
-  * (
-        import_export_specifier
-      * (Token.t (* "," *) * import_export_specifier) list (* zero or more *)
-    )
-      option
+  * anon_impo_expo_spec_rep_COMMA_impo_expo_spec option
   * Token.t (* "," *) option
   * Token.t (* "}" *)
 )
 [@@deriving sexp_of]
 
-type jsx_closing_element = (
-    Token.t (* "<" *)
-  * Token.t (* "/" *)
-  * [
-        `Choice_jsx_id of [
-            `Jsx_id of jsx_identifier (*tok*)
-          | `Id of identifier (*tok*)
-        ]
-      | `Nest_id of nested_identifier
-      | `Jsx_name_name of jsx_namespace_name
-    ]
-  * Token.t (* ">" *)
-)
+type anon_choice_choice_jsx_id = [
+    `Choice_jsx_id of anon_choice_jsx_id
+  | `Nest_id of nested_identifier
+  | `Jsx_name_name of jsx_namespace_name
+]
+[@@deriving sexp_of]
+
+type from_clause = (Token.t (* "from" *) * string_)
 [@@deriving sexp_of]
 
 type import_clause = [
@@ -202,270 +182,395 @@ type import_clause = [
 ]
 [@@deriving sexp_of]
 
-type import_statement = (
-    Token.t (* "import" *)
-  * [
-        `Impo_clau_from_clau of (import_clause * from_clause)
-      | `Str of string_
-    ]
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
+type jsx_closing_element = (
+    Token.t (* "<" *) * Token.t (* "/" *) * anon_choice_choice_jsx_id
+  * Token.t (* ">" *)
 )
 [@@deriving sexp_of]
 
-type export_statement = [
-    `Expo_stmt_expo_choice_STAR_from_clau_choice_auto_semi of (
-        Token.t (* "export" *)
-      * [
-            `STAR_from_clau_choice_auto_semi of (
-                Token.t (* "*" *)
-              * from_clause
-              * [
-                    `Auto_semi of automatic_semicolon (*tok*)
-                  | `SEMI of Token.t (* ";" *)
-                ]
-            )
-          | `Expo_clau_from_clau_choice_auto_semi of (
-                export_clause
-              * from_clause
-              * [
-                    `Auto_semi of automatic_semicolon (*tok*)
-                  | `SEMI of Token.t (* ";" *)
-                ]
-            )
-          | `Expo_clau_choice_auto_semi of (
-                export_clause
-              * [
-                    `Auto_semi of automatic_semicolon (*tok*)
-                  | `SEMI of Token.t (* ";" *)
-                ]
-            )
-        ]
-    )
-  | `Expo_stmt_rep_deco_expo_choice_decl of (
-        decorator list (* zero or more *)
-      * Token.t (* "export" *)
-      * [
-            `Decl of declaration
-          | `Defa_exp_choice_auto_semi of (
-                Token.t (* "default" *)
-              * expression
-              * [
-                    `Auto_semi of automatic_semicolon (*tok*)
-                  | `SEMI of Token.t (* ";" *)
-                ]
-            )
-        ]
-    )
-]
-and declaration = [
-    `Decl_func_decl of (
-        Token.t (* "async" *) option
-      * Token.t (* "function" *)
-      * identifier (*tok*)
-      * formal_parameters
-      * statement_block
-      * automatic_semicolon (*tok*) option
-    )
-  | `Decl_gene_func_decl of (
-        Token.t (* "async" *) option
-      * Token.t (* "function" *)
-      * Token.t (* "*" *)
-      * identifier (*tok*)
-      * formal_parameters
-      * statement_block
-      * automatic_semicolon (*tok*) option
-    )
-  | `Decl_class_decl of (
-        decorator list (* zero or more *)
-      * Token.t (* "class" *)
-      * identifier (*tok*)
-      * class_heritage option
-      * class_body
-      * automatic_semicolon (*tok*) option
-    )
-  | `Decl_lexi_decl of lexical_declaration
-  | `Decl_var_decl of variable_declaration
-]
-and expression_statement = (
-    [ `Exp of expression | `Seq_exp of sequence_expression ]
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
+type parenthesized_expression = (
+    Token.t (* "(" *) * anon_choice_exp * Token.t (* ")" *)
 )
+
+and jsx_opening_element = (
+    Token.t (* "<" *)
+  * anon_choice_choice_jsx_id
+  * anon_choice_jsx_attr list (* zero or more *)
+  * Token.t (* ">" *)
+)
+
 and variable_declaration = (
     Token.t (* "var" *)
   * variable_declarator
   * (Token.t (* "," *) * variable_declarator) list (* zero or more *)
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
+  * anon_choice_auto_semi
 )
-and lexical_declaration = (
-    [ `Let of Token.t (* "let" *) | `Const of Token.t (* "const" *) ]
-  * variable_declarator
-  * (Token.t (* "," *) * variable_declarator) list (* zero or more *)
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
+
+and anon_choice_jsx_attr = [
+    `Jsx_attr of (
+        [
+            `Choice_jsx_id of anon_choice_jsx_id
+          | `Jsx_name_name of jsx_namespace_name
+        ]
+      * (
+            Token.t (* "=" *)
+          * [
+                `Str of string_
+              | `Jsx_exp of jsx_expression
+              | `Choice_jsx_elem of anon_choice_jsx_elem
+              | `Jsx_frag of jsx_fragment
+            ]
+        )
+          option
+    )
+  | `Jsx_exp of jsx_expression
+]
+
+and function_ = (
+    Token.t (* "async" *) option
+  * Token.t (* "function" *)
+  * identifier (*tok*) option
+  * formal_parameters
+  * statement_block
 )
-and variable_declarator = (
-    [
-        `Id of identifier (*tok*)
-      | `Choice_obj of [ `Obj of object_ | `Array of array_ ]
-    ]
-  * initializer_ option
+
+and anon_choice_expo_stmt = [
+    `Expo_stmt of export_statement
+  | `Impo_stmt of (
+        Token.t (* "import" *)
+      * [
+            `Impo_clau_from_clau of (import_clause * from_clause)
+          | `Str of string_
+        ]
+      * anon_choice_auto_semi
+    )
+  | `Debu_stmt of (Token.t (* "debugger" *) * anon_choice_auto_semi)
+  | `Exp_stmt of expression_statement
+  | `Decl of declaration
+  | `Stmt_blk of statement_block
+  | `If_stmt of (
+        Token.t (* "if" *)
+      * parenthesized_expression
+      * anon_choice_expo_stmt
+      * (Token.t (* "else" *) * anon_choice_expo_stmt) option
+    )
+  | `Swit_stmt of (
+        Token.t (* "switch" *) * parenthesized_expression * switch_body
+    )
+  | `For_stmt of (
+        Token.t (* "for" *)
+      * Token.t (* "(" *)
+      * [
+            `Lexi_decl of lexical_declaration
+          | `Var_decl of variable_declaration
+          | `Exp_stmt of expression_statement
+          | `Empty_stmt of Token.t (* ";" *)
+        ]
+      * [
+            `Exp_stmt of expression_statement
+          | `Empty_stmt of Token.t (* ";" *)
+        ]
+      * anon_choice_exp option
+      * Token.t (* ")" *)
+      * anon_choice_expo_stmt
+    )
+  | `For_in_stmt of (
+        Token.t (* "for" *)
+      * Token.t (* "await" *) option
+      * for_header
+      * anon_choice_expo_stmt
+    )
+  | `While_stmt of (
+        Token.t (* "while" *) * parenthesized_expression
+      * anon_choice_expo_stmt
+    )
+  | `Do_stmt of (
+        Token.t (* "do" *) * anon_choice_expo_stmt * Token.t (* "while" *)
+      * parenthesized_expression * anon_choice_auto_semi
+    )
+  | `Try_stmt of (
+        Token.t (* "try" *)
+      * statement_block
+      * catch_clause option
+      * finally_clause option
+    )
+  | `With_stmt of (
+        Token.t (* "with" *) * parenthesized_expression
+      * anon_choice_expo_stmt
+    )
+  | `Brk_stmt of (
+        Token.t (* "break" *)
+      * identifier (*tok*) option
+      * anon_choice_auto_semi
+    )
+  | `Cont_stmt of (
+        Token.t (* "continue" *)
+      * identifier (*tok*) option
+      * anon_choice_auto_semi
+    )
+  | `Ret_stmt of (
+        Token.t (* "return" *)
+      * anon_choice_exp option
+      * anon_choice_auto_semi
+    )
+  | `Throw_stmt of (
+        Token.t (* "throw" *) * anon_choice_exp * anon_choice_auto_semi
+    )
+  | `Empty_stmt of Token.t (* ";" *)
+  | `Labe_stmt of (
+        anon_choice_id_ * Token.t (* ":" *) * anon_choice_expo_stmt
+    )
+]
+
+and anon_choice_exp = [
+    `Exp of expression
+  | `Seq_exp of sequence_expression
+]
+
+and switch_default = (
+    Token.t (* "default" *)
+  * Token.t (* ":" *)
+  * anon_choice_expo_stmt list (* zero or more *)
 )
-and statement_block = (
+
+and binary_expression = [
+    `Bin_exp_exp_AMPAMP_exp of (expression * Token.t (* "&&" *) * expression)
+  | `Bin_exp_exp_BARBAR_exp of (expression * Token.t (* "||" *) * expression)
+  | `Bin_exp_exp_GTGT_exp of (expression * Token.t (* ">>" *) * expression)
+  | `Bin_exp_exp_GTGTGT_exp of (
+        expression * Token.t (* ">>>" *) * expression
+    )
+  | `Bin_exp_exp_LTLT_exp of (expression * Token.t (* "<<" *) * expression)
+  | `Bin_exp_exp_AMP_exp of (expression * Token.t (* "&" *) * expression)
+  | `Bin_exp_exp_HAT_exp of (expression * Token.t (* "^" *) * expression)
+  | `Bin_exp_exp_BAR_exp of (expression * Token.t (* "|" *) * expression)
+  | `Bin_exp_exp_PLUS_exp of (expression * Token.t (* "+" *) * expression)
+  | `Bin_exp_exp_DASH_exp of (expression * Token.t (* "-" *) * expression)
+  | `Bin_exp_exp_STAR_exp of (expression * Token.t (* "*" *) * expression)
+  | `Bin_exp_exp_SLASH_exp of (expression * Token.t (* "/" *) * expression)
+  | `Bin_exp_exp_PERC_exp of (expression * Token.t (* "%" *) * expression)
+  | `Bin_exp_exp_STARSTAR_exp of (
+        expression * Token.t (* "**" *) * expression
+    )
+  | `Bin_exp_exp_LT_exp of (expression * Token.t (* "<" *) * expression)
+  | `Bin_exp_exp_LTEQ_exp of (expression * Token.t (* "<=" *) * expression)
+  | `Bin_exp_exp_EQEQ_exp of (expression * Token.t (* "==" *) * expression)
+  | `Bin_exp_exp_EQEQEQ_exp of (
+        expression * Token.t (* "===" *) * expression
+    )
+  | `Bin_exp_exp_BANGEQ_exp of (expression * Token.t (* "!=" *) * expression)
+  | `Bin_exp_exp_BANGEQEQ_exp of (
+        expression * Token.t (* "!==" *) * expression
+    )
+  | `Bin_exp_exp_GTEQ_exp of (expression * Token.t (* ">=" *) * expression)
+  | `Bin_exp_exp_GT_exp of (expression * Token.t (* ">" *) * expression)
+  | `Bin_exp_exp_QMARKQMARK_exp of (
+        expression * Token.t (* "??" *) * expression
+    )
+  | `Bin_exp_exp_inst_exp of (
+        expression * Token.t (* "instanceof" *) * expression
+    )
+  | `Bin_exp_exp_in_exp of (expression * Token.t (* "in" *) * expression)
+]
+
+and arguments = (
+    Token.t (* "(" *) * anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp
+  * Token.t (* ")" *)
+)
+
+and variable_declarator = (anon_choice_id * initializer_ option)
+
+and sequence_expression = (
+    expression
+  * Token.t (* "," *)
+  * [ `Seq_exp of sequence_expression | `Exp of expression ]
+)
+
+and jsx_fragment = (
+    Token.t (* "<" *)
+  * Token.t (* ">" *)
+  * anon_choice_jsx_text list (* zero or more *)
+  * Token.t (* "<" *)
+  * Token.t (* "/" *)
+  * Token.t (* ">" *)
+)
+
+and class_body = (
     Token.t (* "{" *)
   * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
+        `Meth_defi_opt_SEMI of (method_definition * Token.t (* ";" *) option)
+      | `Publ_field_defi_choice_auto_semi of (
+            public_field_definition * anon_choice_auto_semi
+        )
     ]
       list (* zero or more *)
   * Token.t (* "}" *)
-  * automatic_semicolon (*tok*) option
 )
-and if_statement = (
-    Token.t (* "if" *)
-  * parenthesized_expression
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
-  * (
-        Token.t (* "else" *)
-      * [
-            `Expo_stmt of export_statement
-          | `Impo_stmt of import_statement
-          | `Debu_stmt of debugger_statement
-          | `Exp_stmt of expression_statement
-          | `Decl of declaration
-          | `Stmt_blk of statement_block
-          | `If_stmt of if_statement
-          | `Swit_stmt of switch_statement
-          | `For_stmt of for_statement
-          | `For_in_stmt of for_in_statement
-          | `While_stmt of while_statement
-          | `Do_stmt of do_statement
-          | `Try_stmt of try_statement
-          | `With_stmt of with_statement
-          | `Brk_stmt of break_statement
-          | `Cont_stmt of continue_statement
-          | `Ret_stmt of return_statement
-          | `Throw_stmt of throw_statement
-          | `Empty_stmt of Token.t (* ";" *)
-          | `Labe_stmt of labeled_statement
-        ]
+
+and anon_choice_obj = [ `Obj of object_ | `Array of array_ ]
+
+and anon_choice_jsx_text = [
+    `Jsx_text of jsx_text (*tok*)
+  | `Choice_jsx_elem of anon_choice_jsx_elem
+  | `Jsx_exp of jsx_expression
+]
+
+and anon_choice_this = [
+    `This of Token.t (* "this" *)
+  | `Id of identifier (*tok*)
+  | `Choice_get of anon_choice_get
+  | `Num of number (*tok*)
+  | `Str of string_
+  | `Temp_str of template_string
+  | `Regex of (
+        Token.t (* "/" *)
+      * regex_pattern (*tok*)
+      * Token.t (* "/" *)
+      * regex_flags (*tok*) option
     )
+  | `True of Token.t (* "true" *)
+  | `False of Token.t (* "false" *)
+  | `Null of Token.t (* "null" *)
+  | `Unde of Token.t (* "undefined" *)
+  | `Impo of import (*tok*)
+  | `Obj of object_
+  | `Array of array_
+  | `Func of function_
+  | `Arrow_func of (
+        Token.t (* "async" *) option
+      * [
+            `Choice_choice_get of anon_choice_choice_get
+          | `Form_params of formal_parameters
+        ]
+      * Token.t (* "=>" *)
+      * [ `Exp of expression | `Stmt_blk of statement_block ]
+    )
+  | `Gene_func of (
+        Token.t (* "async" *) option
+      * Token.t (* "function" *)
+      * Token.t (* "*" *)
+      * identifier (*tok*) option
+      * formal_parameters
+      * statement_block
+    )
+  | `Class of (
+        decorator list (* zero or more *)
+      * Token.t (* "class" *)
+      * identifier (*tok*) option
+      * class_heritage option
+      * class_body
+    )
+  | `Paren_exp of parenthesized_expression
+  | `Subs_exp of subscript_expression
+  | `Memb_exp of member_expression
+  | `Meta_prop of (
+        Token.t (* "new" *) * Token.t (* "." *) * Token.t (* "target" *)
+    )
+  | `New_exp of (Token.t (* "new" *) * anon_choice_this * arguments option)
+]
+
+and anon_choice_memb_exp = [
+    `Memb_exp of member_expression
+  | `Subs_exp of subscript_expression
+  | `Id of identifier (*tok*)
+  | `Choice_get of anon_choice_get
+  | `Choice_obj of anon_choice_obj
+]
+
+and member_expression = (
+    [
+        `Exp of expression
+      | `Id of identifier (*tok*)
+      | `Super of Token.t (* "super" *)
+      | `Choice_get of anon_choice_get
+    ]
+  * Token.t (* "." *)
+  * identifier (*tok*)
+)
+
+and assignment_pattern = (
+    [
+        `Choice_choice_get of anon_choice_choice_get
+      | `Choice_obj of anon_choice_obj
+    ]
+  * Token.t (* "=" *)
+  * expression
+)
+
+and jsx_expression = (
+    Token.t (* "{" *)
+  * [
+        `Exp of expression
+      | `Seq_exp of sequence_expression
+      | `Spre_elem of spread_element
+    ]
       option
+  * Token.t (* "}" *)
 )
-and switch_statement = (
-    Token.t (* "switch" *) * parenthesized_expression * switch_body
+
+and anon_choice_jsx_elem = [
+    `Jsx_elem of (
+        jsx_opening_element
+      * anon_choice_jsx_text list (* zero or more *)
+      * jsx_closing_element
+    )
+  | `Jsx_self_clos_elem of (
+        Token.t (* "<" *)
+      * anon_choice_choice_jsx_id
+      * anon_choice_jsx_attr list (* zero or more *)
+      * Token.t (* "/" *)
+      * Token.t (* ">" *)
+    )
+]
+
+and anon_choice_pair = [
+    `Pair of (property_name * Token.t (* ":" *) * expression)
+  | `Spre_elem of spread_element
+  | `Meth_defi of method_definition
+  | `Assign_pat of assignment_pattern
+  | `Choice_id of anon_choice_id_
+]
+
+and subscript_expression = (
+    [ `Exp of expression | `Super of Token.t (* "super" *) ]
+  * Token.t (* "[" *)
+  * anon_choice_exp
+  * Token.t (* "]" *)
 )
-and for_statement = (
-    Token.t (* "for" *)
-  * Token.t (* "(" *)
+
+and initializer_ = (Token.t (* "=" *) * expression)
+
+and expression_statement = (anon_choice_exp * anon_choice_auto_semi)
+
+and catch_clause = (
+    Token.t (* "catch" *)
+  * (Token.t (* "(" *) * anon_choice_id * Token.t (* ")" *)) option
+  * statement_block
+)
+
+and template_string = (
+    Token.t (* "`" *)
   * [
-        `Lexi_decl of lexical_declaration
-      | `Var_decl of variable_declaration
-      | `Exp_stmt of expression_statement
-      | `Empty_stmt of Token.t (* ";" *)
+        `Temp_chars of template_chars (*tok*)
+      | `Esc_seq of escape_sequence (*tok*)
+      | `Temp_subs of template_substitution
     ]
-  * [ `Exp_stmt of expression_statement | `Empty_stmt of Token.t (* ";" *) ]
-  * [ `Exp of expression | `Seq_exp of sequence_expression ] option
-  * Token.t (* ")" *)
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
+      list (* zero or more *)
+  * Token.t (* "`" *)
 )
-and for_in_statement = (
-    Token.t (* "for" *)
-  * Token.t (* "await" *) option
-  * for_header
+
+and decorator = (
+    Token.t (* "@" *)
   * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
+        `Choice_id of anon_choice_id_
+      | `Deco_memb_exp of decorator_member_expression
+      | `Deco_call_exp of decorator_call_expression
     ]
 )
+
+and anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp =
+  (anon_choice_exp_ option * anon_rep_COMMA_opt_choice_exp) option
+
 and for_header = (
     Token.t (* "(" *)
   * [
@@ -474,309 +579,24 @@ and for_header = (
       | `Const of Token.t (* "const" *)
     ]
       option
-  * [
-        `Paren_exp of parenthesized_expression
-      | `Choice_memb_exp of [
-            `Memb_exp of member_expression
-          | `Subs_exp of subscript_expression
-          | `Id of identifier (*tok*)
-          | `Choice_get of [
-                `Get of Token.t (* "get" *)
-              | `Set of Token.t (* "set" *)
-              | `Async of Token.t (* "async" *)
-              | `Stat of Token.t (* "static" *)
-            ]
-          | `Choice_obj of [ `Obj of object_ | `Array of array_ ]
-        ]
-    ]
+  * anon_choice_paren_exp
   * [ `In of Token.t (* "in" *) | `Of of Token.t (* "of" *) ]
-  * [ `Exp of expression | `Seq_exp of sequence_expression ]
+  * anon_choice_exp
   * Token.t (* ")" *)
 )
-and while_statement = (
-    Token.t (* "while" *)
-  * parenthesized_expression
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
-)
-and do_statement = (
-    Token.t (* "do" *)
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
-  * Token.t (* "while" *)
-  * parenthesized_expression
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
-)
-and try_statement = (
-    Token.t (* "try" *)
-  * statement_block
-  * catch_clause option
-  * finally_clause option
-)
-and with_statement = (
-    Token.t (* "with" *)
-  * parenthesized_expression
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
-)
-and return_statement = (
-    Token.t (* "return" *)
-  * [ `Exp of expression | `Seq_exp of sequence_expression ] option
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
-)
-and throw_statement = (
-    Token.t (* "throw" *)
-  * [ `Exp of expression | `Seq_exp of sequence_expression ]
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
-)
-and labeled_statement = (
-    [
-        `Id of identifier (*tok*)
-      | `Choice_get of [
-            `Get of Token.t (* "get" *)
-          | `Set of Token.t (* "set" *)
-          | `Async of Token.t (* "async" *)
-          | `Stat of Token.t (* "static" *)
-        ]
-    ]
-  * Token.t (* ":" *)
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
-)
-and switch_body = (
-    Token.t (* "{" *)
-  * [ `Swit_case of switch_case | `Swit_defa of switch_default ]
-      list (* zero or more *)
-  * Token.t (* "}" *)
-)
-and switch_case = (
-    Token.t (* "case" *)
-  * [ `Exp of expression | `Seq_exp of sequence_expression ]
-  * Token.t (* ":" *)
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
-      list (* zero or more *)
-)
-and switch_default = (
-    Token.t (* "default" *)
-  * Token.t (* ":" *)
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
-      list (* zero or more *)
-)
-and catch_clause = (
-    Token.t (* "catch" *)
-  * (
-        Token.t (* "(" *)
-      * [
-            `Id of identifier (*tok*)
-          | `Choice_obj of [ `Obj of object_ | `Array of array_ ]
-        ]
-      * Token.t (* ")" *)
-    )
-      option
-  * statement_block
-)
-and finally_clause = (Token.t (* "finally" *) * statement_block)
-and parenthesized_expression = (
-    Token.t (* "(" *)
-  * [ `Exp of expression | `Seq_exp of sequence_expression ]
-  * Token.t (* ")" *)
-)
+
 and expression = [
-    `Exp_choice_this of [
-        `This of Token.t (* "this" *)
-      | `Id of identifier (*tok*)
-      | `Choice_get of [
-            `Get of Token.t (* "get" *)
-          | `Set of Token.t (* "set" *)
-          | `Async of Token.t (* "async" *)
-          | `Stat of Token.t (* "static" *)
-        ]
-      | `Num of number (*tok*)
-      | `Str of string_
-      | `Temp_str of template_string
-      | `Regex of regex
-      | `True of Token.t (* "true" *)
-      | `False of Token.t (* "false" *)
-      | `Null of Token.t (* "null" *)
-      | `Unde of Token.t (* "undefined" *)
-      | `Impo of import (*tok*)
-      | `Obj of object_
-      | `Array of array_
-      | `Func of function_
-      | `Arrow_func of arrow_function
-      | `Gene_func of generator_function
-      | `Class of class_
-      | `Paren_exp of parenthesized_expression
-      | `Subs_exp of subscript_expression
-      | `Memb_exp of member_expression
-      | `Meta_prop of meta_property
-      | `New_exp of new_expression
-    ]
-  | `Exp_choice_jsx_elem of [
-        `Jsx_elem of jsx_element
-      | `Jsx_self_clos_elem of jsx_self_closing_element
-    ]
+    `Exp_choice_this of anon_choice_this
+  | `Exp_choice_jsx_elem of anon_choice_jsx_elem
   | `Exp_jsx_frag of jsx_fragment
   | `Exp_assign_exp of (
-        [
-            `Paren_exp of parenthesized_expression
-          | `Choice_memb_exp of [
-                `Memb_exp of member_expression
-              | `Subs_exp of subscript_expression
-              | `Id of identifier (*tok*)
-              | `Choice_get of [
-                    `Get of Token.t (* "get" *)
-                  | `Set of Token.t (* "set" *)
-                  | `Async of Token.t (* "async" *)
-                  | `Stat of Token.t (* "static" *)
-                ]
-              | `Choice_obj of [ `Obj of object_ | `Array of array_ ]
-            ]
-        ]
-      * Token.t (* "=" *)
-      * expression
+        anon_choice_paren_exp * Token.t (* "=" *) * expression
     )
   | `Exp_augm_assign_exp of (
         [
             `Memb_exp of member_expression
           | `Subs_exp of subscript_expression
-          | `Choice_get of [
-                `Get of Token.t (* "get" *)
-              | `Set of Token.t (* "set" *)
-              | `Async of Token.t (* "async" *)
-              | `Stat of Token.t (* "static" *)
-            ]
+          | `Choice_get of anon_choice_get
           | `Id of identifier (*tok*)
           | `Paren_exp of parenthesized_expression
         ]
@@ -820,304 +640,12 @@ and expression = [
         ]
     )
 ]
-and object_ = (
-    Token.t (* "{" *)
-  * (
-        [
-            `Pair of pair
-          | `Spre_elem of spread_element
-          | `Meth_defi of method_definition
-          | `Assign_pat of assignment_pattern
-          | `Choice_id of [
-                `Id of identifier (*tok*)
-              | `Choice_get of [
-                    `Get of Token.t (* "get" *)
-                  | `Set of Token.t (* "set" *)
-                  | `Async of Token.t (* "async" *)
-                  | `Stat of Token.t (* "static" *)
-                ]
-            ]
-        ]
-          option
-      * (
-            Token.t (* "," *)
-          * [
-                `Pair of pair
-              | `Spre_elem of spread_element
-              | `Meth_defi of method_definition
-              | `Assign_pat of assignment_pattern
-              | `Choice_id of [
-                    `Id of identifier (*tok*)
-                  | `Choice_get of [
-                        `Get of Token.t (* "get" *)
-                      | `Set of Token.t (* "set" *)
-                      | `Async of Token.t (* "async" *)
-                      | `Stat of Token.t (* "static" *)
-                    ]
-                ]
-            ]
-              option
-        )
-          list (* zero or more *)
-    )
-      option
-  * Token.t (* "}" *)
-)
-and assignment_pattern = (
-    [
-        `Choice_choice_get of [
-            `Choice_get of [
-                `Get of Token.t (* "get" *)
-              | `Set of Token.t (* "set" *)
-              | `Async of Token.t (* "async" *)
-              | `Stat of Token.t (* "static" *)
-            ]
-          | `Id of identifier (*tok*)
-        ]
-      | `Choice_obj of [ `Obj of object_ | `Array of array_ ]
-    ]
-  * Token.t (* "=" *)
-  * expression
-)
-and array_ = (
-    Token.t (* "[" *)
-  * (
-        [ `Exp of expression | `Spre_elem of spread_element ] option
-      * (
-            Token.t (* "," *)
-          * [ `Exp of expression | `Spre_elem of spread_element ] option
-        )
-          list (* zero or more *)
-    )
-      option
-  * Token.t (* "]" *)
-)
-and jsx_element = (
-    jsx_opening_element
-  * [
-        `Jsx_text of jsx_text (*tok*)
-      | `Choice_jsx_elem of [
-            `Jsx_elem of jsx_element
-          | `Jsx_self_clos_elem of jsx_self_closing_element
-        ]
-      | `Jsx_exp of jsx_expression
-    ]
-      list (* zero or more *)
-  * jsx_closing_element
-)
-and jsx_fragment = (
-    Token.t (* "<" *)
-  * Token.t (* ">" *)
-  * [
-        `Jsx_text of jsx_text (*tok*)
-      | `Choice_jsx_elem of [
-            `Jsx_elem of jsx_element
-          | `Jsx_self_clos_elem of jsx_self_closing_element
-        ]
-      | `Jsx_exp of jsx_expression
-    ]
-      list (* zero or more *)
-  * Token.t (* "<" *)
-  * Token.t (* "/" *)
-  * Token.t (* ">" *)
-)
-and jsx_expression = (
-    Token.t (* "{" *)
-  * [
-        `Exp of expression
-      | `Seq_exp of sequence_expression
-      | `Spre_elem of spread_element
-    ]
-      option
-  * Token.t (* "}" *)
-)
-and jsx_opening_element = (
-    Token.t (* "<" *)
-  * [
-        `Choice_jsx_id of [
-            `Jsx_id of jsx_identifier (*tok*)
-          | `Id of identifier (*tok*)
-        ]
-      | `Nest_id of nested_identifier
-      | `Jsx_name_name of jsx_namespace_name
-    ]
-  * [ `Jsx_attr of jsx_attribute | `Jsx_exp of jsx_expression ]
-      list (* zero or more *)
-  * Token.t (* ">" *)
-)
-and jsx_self_closing_element = (
-    Token.t (* "<" *)
-  * [
-        `Choice_jsx_id of [
-            `Jsx_id of jsx_identifier (*tok*)
-          | `Id of identifier (*tok*)
-        ]
-      | `Nest_id of nested_identifier
-      | `Jsx_name_name of jsx_namespace_name
-    ]
-  * [ `Jsx_attr of jsx_attribute | `Jsx_exp of jsx_expression ]
-      list (* zero or more *)
-  * Token.t (* "/" *)
-  * Token.t (* ">" *)
-)
-and jsx_attribute = (
-    [
-        `Choice_jsx_id of [
-            `Jsx_id of jsx_identifier (*tok*)
-          | `Id of identifier (*tok*)
-        ]
-      | `Jsx_name_name of jsx_namespace_name
-    ]
-  * (
-        Token.t (* "=" *)
-      * [
-            `Str of string_
-          | `Jsx_exp of jsx_expression
-          | `Choice_jsx_elem of [
-                `Jsx_elem of jsx_element
-              | `Jsx_self_clos_elem of jsx_self_closing_element
-            ]
-          | `Jsx_frag of jsx_fragment
-        ]
-    )
-      option
-)
-and class_ = (
-    decorator list (* zero or more *)
-  * Token.t (* "class" *)
-  * identifier (*tok*) option
-  * class_heritage option
-  * class_body
-)
-and class_heritage = (Token.t (* "extends" *) * expression)
-and function_ = (
-    Token.t (* "async" *) option
-  * Token.t (* "function" *)
-  * identifier (*tok*) option
-  * formal_parameters
-  * statement_block
-)
-and generator_function = (
-    Token.t (* "async" *) option
-  * Token.t (* "function" *)
-  * Token.t (* "*" *)
-  * identifier (*tok*) option
-  * formal_parameters
-  * statement_block
-)
-and arrow_function = (
-    Token.t (* "async" *) option
-  * [
-        `Choice_choice_get of [
-            `Choice_get of [
-                `Get of Token.t (* "get" *)
-              | `Set of Token.t (* "set" *)
-              | `Async of Token.t (* "async" *)
-              | `Stat of Token.t (* "static" *)
-            ]
-          | `Id of identifier (*tok*)
-        ]
-      | `Form_params of formal_parameters
-    ]
-  * Token.t (* "=>" *)
-  * [ `Exp of expression | `Stmt_blk of statement_block ]
-)
-and new_expression = (
-    Token.t (* "new" *)
-  * [
-        `This of Token.t (* "this" *)
-      | `Id of identifier (*tok*)
-      | `Choice_get of [
-            `Get of Token.t (* "get" *)
-          | `Set of Token.t (* "set" *)
-          | `Async of Token.t (* "async" *)
-          | `Stat of Token.t (* "static" *)
-        ]
-      | `Num of number (*tok*)
-      | `Str of string_
-      | `Temp_str of template_string
-      | `Regex of regex
-      | `True of Token.t (* "true" *)
-      | `False of Token.t (* "false" *)
-      | `Null of Token.t (* "null" *)
-      | `Unde of Token.t (* "undefined" *)
-      | `Impo of import (*tok*)
-      | `Obj of object_
-      | `Array of array_
-      | `Func of function_
-      | `Arrow_func of arrow_function
-      | `Gene_func of generator_function
-      | `Class of class_
-      | `Paren_exp of parenthesized_expression
-      | `Subs_exp of subscript_expression
-      | `Memb_exp of member_expression
-      | `Meta_prop of meta_property
-      | `New_exp of new_expression
-    ]
-  * arguments option
-)
-and member_expression = (
-    [
-        `Exp of expression
-      | `Id of identifier (*tok*)
-      | `Super of Token.t (* "super" *)
-      | `Choice_get of [
-            `Get of Token.t (* "get" *)
-          | `Set of Token.t (* "set" *)
-          | `Async of Token.t (* "async" *)
-          | `Stat of Token.t (* "static" *)
-        ]
-    ]
-  * Token.t (* "." *)
-  * identifier (*tok*)
-)
-and subscript_expression = (
-    [ `Exp of expression | `Super of Token.t (* "super" *) ]
-  * Token.t (* "[" *)
-  * [ `Exp of expression | `Seq_exp of sequence_expression ]
-  * Token.t (* "]" *)
-)
-and initializer_ = (Token.t (* "=" *) * expression)
-and spread_element = (Token.t (* "..." *) * expression)
-and binary_expression = [
-    `Bin_exp_exp_AMPAMP_exp of (expression * Token.t (* "&&" *) * expression)
-  | `Bin_exp_exp_BARBAR_exp of (expression * Token.t (* "||" *) * expression)
-  | `Bin_exp_exp_GTGT_exp of (expression * Token.t (* ">>" *) * expression)
-  | `Bin_exp_exp_GTGTGT_exp of (
-        expression * Token.t (* ">>>" *) * expression
-    )
-  | `Bin_exp_exp_LTLT_exp of (expression * Token.t (* "<<" *) * expression)
-  | `Bin_exp_exp_AMP_exp of (expression * Token.t (* "&" *) * expression)
-  | `Bin_exp_exp_HAT_exp of (expression * Token.t (* "^" *) * expression)
-  | `Bin_exp_exp_BAR_exp of (expression * Token.t (* "|" *) * expression)
-  | `Bin_exp_exp_PLUS_exp of (expression * Token.t (* "+" *) * expression)
-  | `Bin_exp_exp_DASH_exp of (expression * Token.t (* "-" *) * expression)
-  | `Bin_exp_exp_STAR_exp of (expression * Token.t (* "*" *) * expression)
-  | `Bin_exp_exp_SLASH_exp of (expression * Token.t (* "/" *) * expression)
-  | `Bin_exp_exp_PERC_exp of (expression * Token.t (* "%" *) * expression)
-  | `Bin_exp_exp_STARSTAR_exp of (
-        expression * Token.t (* "**" *) * expression
-    )
-  | `Bin_exp_exp_LT_exp of (expression * Token.t (* "<" *) * expression)
-  | `Bin_exp_exp_LTEQ_exp of (expression * Token.t (* "<=" *) * expression)
-  | `Bin_exp_exp_EQEQ_exp of (expression * Token.t (* "==" *) * expression)
-  | `Bin_exp_exp_EQEQEQ_exp of (
-        expression * Token.t (* "===" *) * expression
-    )
-  | `Bin_exp_exp_BANGEQ_exp of (expression * Token.t (* "!=" *) * expression)
-  | `Bin_exp_exp_BANGEQEQ_exp of (
-        expression * Token.t (* "!==" *) * expression
-    )
-  | `Bin_exp_exp_GTEQ_exp of (expression * Token.t (* ">=" *) * expression)
-  | `Bin_exp_exp_GT_exp of (expression * Token.t (* ">" *) * expression)
-  | `Bin_exp_exp_QMARKQMARK_exp of (
-        expression * Token.t (* "??" *) * expression
-    )
-  | `Bin_exp_exp_inst_exp of (
-        expression * Token.t (* "instanceof" *) * expression
-    )
-  | `Bin_exp_exp_in_exp of (expression * Token.t (* "in" *) * expression)
+
+and anon_choice_paren_exp = [
+    `Paren_exp of parenthesized_expression
+  | `Choice_memb_exp of anon_choice_memb_exp
 ]
+
 and unary_expression = [
     `Un_exp_BANG_exp of (Token.t (* "!" *) * expression)
   | `Un_exp_TILDE_exp of (Token.t (* "~" *) * expression)
@@ -1127,143 +655,25 @@ and unary_expression = [
   | `Un_exp_void_exp of (Token.t (* "void" *) * expression)
   | `Un_exp_dele_exp of (Token.t (* "delete" *) * expression)
 ]
-and update_expression = [
-    `Exp_choice_PLUSPLUS of (
-        expression
-      * [ `PLUSPLUS of Token.t (* "++" *) | `DASHDASH of Token.t (* "--" *) ]
-    )
-  | `Choice_PLUSPLUS_exp of (
-        [ `PLUSPLUS of Token.t (* "++" *) | `DASHDASH of Token.t (* "--" *) ]
-      * expression
-    )
-]
-and sequence_expression = (
-    expression
-  * Token.t (* "," *)
-  * [ `Seq_exp of sequence_expression | `Exp of expression ]
-)
-and template_string = (
-    Token.t (* "`" *)
-  * [
-        `Temp_chars of template_chars (*tok*)
-      | `Esc_seq of escape_sequence (*tok*)
-      | `Temp_subs of template_substitution
-    ]
-      list (* zero or more *)
-  * Token.t (* "`" *)
-)
-and template_substitution = (
-    Token.t (* "${" *)
-  * [ `Exp of expression | `Seq_exp of sequence_expression ]
-  * Token.t (* "}" *)
-)
-and arguments = (
-    Token.t (* "(" *)
-  * (
-        [ `Exp of expression | `Spre_elem of spread_element ] option
-      * (
-            Token.t (* "," *)
-          * [ `Exp of expression | `Spre_elem of spread_element ] option
-        )
-          list (* zero or more *)
-    )
-      option
-  * Token.t (* ")" *)
-)
-and decorator = (
-    Token.t (* "@" *)
-  * [
-        `Choice_id of [
-            `Id of identifier (*tok*)
-          | `Choice_get of [
-                `Get of Token.t (* "get" *)
-              | `Set of Token.t (* "set" *)
-              | `Async of Token.t (* "async" *)
-              | `Stat of Token.t (* "static" *)
-            ]
-        ]
-      | `Deco_memb_exp of decorator_member_expression
-      | `Deco_call_exp of decorator_call_expression
-    ]
-)
-and decorator_call_expression = (
-    [
-        `Choice_id of [
-            `Id of identifier (*tok*)
-          | `Choice_get of [
-                `Get of Token.t (* "get" *)
-              | `Set of Token.t (* "set" *)
-              | `Async of Token.t (* "async" *)
-              | `Stat of Token.t (* "static" *)
-            ]
-        ]
-      | `Deco_memb_exp of decorator_member_expression
-    ]
-  * arguments
-)
-and class_body = (
-    Token.t (* "{" *)
-  * [
-        `Meth_defi_opt_SEMI of (method_definition * Token.t (* ";" *) option)
-      | `Publ_field_defi_choice_auto_semi of (
-            public_field_definition
-          * [
-                `Auto_semi of automatic_semicolon (*tok*)
-              | `SEMI of Token.t (* ";" *)
-            ]
-        )
-    ]
-      list (* zero or more *)
-  * Token.t (* "}" *)
-)
-and public_field_definition = (
-    Token.t (* "static" *) option
-  * property_name
-  * initializer_ option
-)
+
 and formal_parameters = (
     Token.t (* "(" *)
   * (
-        [
-            `Id of identifier (*tok*)
-          | `Choice_get of [
-                `Get of Token.t (* "get" *)
-              | `Set of Token.t (* "set" *)
-              | `Async of Token.t (* "async" *)
-              | `Stat of Token.t (* "static" *)
-            ]
-          | `Choice_obj of [ `Obj of object_ | `Array of array_ ]
-          | `Assign_pat of assignment_pattern
-          | `Rest_param of rest_parameter
-        ]
-      * (
-            Token.t (* "," *)
-          * [
-                `Id of identifier (*tok*)
-              | `Choice_get of [
-                    `Get of Token.t (* "get" *)
-                  | `Set of Token.t (* "set" *)
-                  | `Async of Token.t (* "async" *)
-                  | `Stat of Token.t (* "static" *)
-                ]
-              | `Choice_obj of [ `Obj of object_ | `Array of array_ ]
-              | `Assign_pat of assignment_pattern
-              | `Rest_param of rest_parameter
-            ]
-        )
-          list (* zero or more *)
+        anon_choice_id2
+      * (Token.t (* "," *) * anon_choice_id2) list (* zero or more *)
       * Token.t (* "," *) option
     )
       option
   * Token.t (* ")" *)
 )
-and rest_parameter = (
-    Token.t (* "..." *)
-  * [
-        `Id of identifier (*tok*)
-      | `Choice_obj of [ `Obj of object_ | `Array of array_ ]
-    ]
+
+and switch_body = (
+    Token.t (* "{" *)
+  * [ `Swit_case of switch_case | `Swit_defa of switch_default ]
+      list (* zero or more *)
+  * Token.t (* "}" *)
 )
+
 and method_definition = (
     decorator list (* zero or more *)
   * Token.t (* "static" *) option
@@ -1278,57 +688,158 @@ and method_definition = (
   * formal_parameters
   * statement_block
 )
-and pair = (property_name * Token.t (* ":" *) * expression)
-and property_name = [
-    `Prop_name_choice_id of [
-        `Id of identifier (*tok*)
-      | `Choice_get of [
-            `Get of Token.t (* "get" *)
-          | `Set of Token.t (* "set" *)
-          | `Async of Token.t (* "async" *)
-          | `Stat of Token.t (* "static" *)
+
+and array_ = (
+    Token.t (* "[" *) * anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp
+  * Token.t (* "]" *)
+)
+
+and export_statement = [
+    `Expo_stmt_expo_choice_STAR_from_clau_choice_auto_semi of (
+        Token.t (* "export" *)
+      * [
+            `STAR_from_clau_choice_auto_semi of (
+                Token.t (* "*" *) * from_clause * anon_choice_auto_semi
+            )
+          | `Expo_clau_from_clau_choice_auto_semi of (
+                export_clause * from_clause * anon_choice_auto_semi
+            )
+          | `Expo_clau_choice_auto_semi of (
+                export_clause * anon_choice_auto_semi
+            )
         ]
-    ]
+    )
+  | `Expo_stmt_rep_deco_expo_choice_decl of (
+        decorator list (* zero or more *)
+      * Token.t (* "export" *)
+      * [
+            `Decl of declaration
+          | `Defa_exp_choice_auto_semi of (
+                Token.t (* "default" *) * expression * anon_choice_auto_semi
+            )
+        ]
+    )
+]
+
+and anon_rep_COMMA_opt_choice_exp =
+  (Token.t (* "," *) * anon_choice_exp_ option) list (* zero or more *)
+
+and decorator_call_expression = (anon_choice_choice_id * arguments)
+
+and update_expression = [
+    `Exp_choice_PLUSPLUS of (expression * anon_choice_PLUSPLUS)
+  | `Choice_PLUSPLUS_exp of (anon_choice_PLUSPLUS * expression)
+]
+
+and public_field_definition = (
+    Token.t (* "static" *) option
+  * property_name
+  * initializer_ option
+)
+
+and lexical_declaration = (
+    [ `Let of Token.t (* "let" *) | `Const of Token.t (* "const" *) ]
+  * variable_declarator
+  * (Token.t (* "," *) * variable_declarator) list (* zero or more *)
+  * anon_choice_auto_semi
+)
+
+and class_heritage = (Token.t (* "extends" *) * expression)
+
+and property_name = [
+    `Prop_name_choice_id of anon_choice_id_
   | `Prop_name_str of string_
   | `Prop_name_num of number (*tok*)
   | `Prop_name_comp_prop_name of (
         Token.t (* "[" *) * expression * Token.t (* "]" *)
     )
 ]
+
+and switch_case = (
+    Token.t (* "case" *)
+  * anon_choice_exp
+  * Token.t (* ":" *)
+  * anon_choice_expo_stmt list (* zero or more *)
+)
+
+and spread_element = (Token.t (* "..." *) * expression)
+
+and finally_clause = (Token.t (* "finally" *) * statement_block)
+
+and anon_choice_id = [
+    `Id of identifier (*tok*)
+  | `Choice_obj of anon_choice_obj
+]
+
+and object_ = (
+    Token.t (* "{" *)
+  * (
+        anon_choice_pair option
+      * (Token.t (* "," *) * anon_choice_pair option) list (* zero or more *)
+    )
+      option
+  * Token.t (* "}" *)
+)
+
+and anon_choice_id2 = [
+    `Id of identifier (*tok*)
+  | `Choice_get of anon_choice_get
+  | `Choice_obj of anon_choice_obj
+  | `Assign_pat of assignment_pattern
+  | `Rest_param of (Token.t (* "..." *) * anon_choice_id)
+]
+
+and anon_choice_exp_ = [ `Exp of expression | `Spre_elem of spread_element ]
+
+and statement_block = (
+    Token.t (* "{" *)
+  * anon_choice_expo_stmt list (* zero or more *)
+  * Token.t (* "}" *)
+  * automatic_semicolon (*tok*) option
+)
+
+and template_substitution = (
+    Token.t (* "${" *) * anon_choice_exp * Token.t (* "}" *)
+)
+
+and declaration = [
+    `Decl_func_decl of (
+        Token.t (* "async" *) option
+      * Token.t (* "function" *)
+      * identifier (*tok*)
+      * formal_parameters
+      * statement_block
+      * automatic_semicolon (*tok*) option
+    )
+  | `Decl_gene_func_decl of (
+        Token.t (* "async" *) option
+      * Token.t (* "function" *)
+      * Token.t (* "*" *)
+      * identifier (*tok*)
+      * formal_parameters
+      * statement_block
+      * automatic_semicolon (*tok*) option
+    )
+  | `Decl_class_decl of (
+        decorator list (* zero or more *)
+      * Token.t (* "class" *)
+      * identifier (*tok*)
+      * class_heritage option
+      * class_body
+      * automatic_semicolon (*tok*) option
+    )
+  | `Decl_lexi_decl of lexical_declaration
+  | `Decl_var_decl of variable_declaration
+]
 [@@deriving sexp_of]
 
 type program = (
     hash_bang_line (*tok*) option
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
-      list (* zero or more *)
+  * anon_choice_expo_stmt list (* zero or more *)
 )
 [@@deriving sexp_of]
 
-type super (* inlined *) = Token.t (* "super" *)
-[@@deriving sexp_of]
-
-type empty_statement (* inlined *) = Token.t (* ";" *)
+type this (* inlined *) = Token.t (* "this" *)
 [@@deriving sexp_of]
 
 type comment (* inlined *) = Token.t
@@ -1337,44 +848,67 @@ type comment (* inlined *) = Token.t
 type true_ (* inlined *) = Token.t (* "true" *)
 [@@deriving sexp_of]
 
-type undefined (* inlined *) = Token.t (* "undefined" *)
+type null (* inlined *) = Token.t (* "null" *)
 [@@deriving sexp_of]
 
-type this (* inlined *) = Token.t (* "this" *)
+type undefined (* inlined *) = Token.t (* "undefined" *)
 [@@deriving sexp_of]
 
 type false_ (* inlined *) = Token.t (* "false" *)
 [@@deriving sexp_of]
 
-type null (* inlined *) = Token.t (* "null" *)
+type empty_statement (* inlined *) = Token.t (* ";" *)
 [@@deriving sexp_of]
 
-type yield_expression (* inlined *) = (
-    Token.t (* "yield" *)
+type meta_property (* inlined *) = (
+    Token.t (* "new" *) * Token.t (* "." *) * Token.t (* "target" *)
+)
+[@@deriving sexp_of]
+
+type super (* inlined *) = Token.t (* "super" *)
+[@@deriving sexp_of]
+
+type regex (* inlined *) = (
+    Token.t (* "/" *)
+  * regex_pattern (*tok*)
+  * Token.t (* "/" *)
+  * regex_flags (*tok*) option
+)
+[@@deriving sexp_of]
+
+type debugger_statement (* inlined *) = (
+    Token.t (* "debugger" *) * anon_choice_auto_semi
+)
+[@@deriving sexp_of]
+
+type break_statement (* inlined *) = (
+    Token.t (* "break" *)
+  * identifier (*tok*) option
+  * anon_choice_auto_semi
+)
+[@@deriving sexp_of]
+
+type continue_statement (* inlined *) = (
+    Token.t (* "continue" *)
+  * identifier (*tok*) option
+  * anon_choice_auto_semi
+)
+[@@deriving sexp_of]
+
+type import_statement (* inlined *) = (
+    Token.t (* "import" *)
   * [
-        `STAR_exp of (Token.t (* "*" *) * expression)
-      | `Opt_exp of expression option
+        `Impo_clau_from_clau of (import_clause * from_clause)
+      | `Str of string_
     ]
+  * anon_choice_auto_semi
 )
 [@@deriving sexp_of]
 
-type class_declaration (* inlined *) = (
-    decorator list (* zero or more *)
-  * Token.t (* "class" *)
-  * identifier (*tok*)
-  * class_heritage option
-  * class_body
-  * automatic_semicolon (*tok*) option
-)
-[@@deriving sexp_of]
-
-type function_declaration (* inlined *) = (
-    Token.t (* "async" *) option
-  * Token.t (* "function" *)
-  * identifier (*tok*)
-  * formal_parameters
-  * statement_block
-  * automatic_semicolon (*tok*) option
+type jsx_element (* inlined *) = (
+    jsx_opening_element
+  * anon_choice_jsx_text list (* zero or more *)
+  * jsx_closing_element
 )
 [@@deriving sexp_of]
 
@@ -1389,6 +923,40 @@ type generator_function_declaration (* inlined *) = (
 )
 [@@deriving sexp_of]
 
+type labeled_statement (* inlined *) = (
+    anon_choice_id_ * Token.t (* ":" *) * anon_choice_expo_stmt
+)
+[@@deriving sexp_of]
+
+type assignment_expression (* inlined *) = (
+    anon_choice_paren_exp * Token.t (* "=" *) * expression
+)
+[@@deriving sexp_of]
+
+type do_statement (* inlined *) = (
+    Token.t (* "do" *) * anon_choice_expo_stmt * Token.t (* "while" *)
+  * parenthesized_expression * anon_choice_auto_semi
+)
+[@@deriving sexp_of]
+
+type jsx_attribute (* inlined *) = (
+    [
+        `Choice_jsx_id of anon_choice_jsx_id
+      | `Jsx_name_name of jsx_namespace_name
+    ]
+  * (
+        Token.t (* "=" *)
+      * [
+            `Str of string_
+          | `Jsx_exp of jsx_expression
+          | `Choice_jsx_elem of anon_choice_jsx_elem
+          | `Jsx_frag of jsx_fragment
+        ]
+    )
+      option
+)
+[@@deriving sexp_of]
+
 type call_expression (* inlined *) = (
     [
         `Exp of expression
@@ -1399,27 +967,165 @@ type call_expression (* inlined *) = (
 )
 [@@deriving sexp_of]
 
+type generator_function (* inlined *) = (
+    Token.t (* "async" *) option
+  * Token.t (* "function" *)
+  * Token.t (* "*" *)
+  * identifier (*tok*) option
+  * formal_parameters
+  * statement_block
+)
+[@@deriving sexp_of]
+
+type throw_statement (* inlined *) = (
+    Token.t (* "throw" *) * anon_choice_exp * anon_choice_auto_semi
+)
+[@@deriving sexp_of]
+
+type pair (* inlined *) = (property_name * Token.t (* ":" *) * expression)
+[@@deriving sexp_of]
+
+type try_statement (* inlined *) = (
+    Token.t (* "try" *)
+  * statement_block
+  * catch_clause option
+  * finally_clause option
+)
+[@@deriving sexp_of]
+
+type rest_parameter (* inlined *) = (Token.t (* "..." *) * anon_choice_id)
+[@@deriving sexp_of]
+
+type if_statement (* inlined *) = (
+    Token.t (* "if" *)
+  * parenthesized_expression
+  * anon_choice_expo_stmt
+  * (Token.t (* "else" *) * anon_choice_expo_stmt) option
+)
+[@@deriving sexp_of]
+
+type new_expression (* inlined *) = (
+    Token.t (* "new" *)
+  * anon_choice_this
+  * arguments option
+)
+[@@deriving sexp_of]
+
+type arrow_function (* inlined *) = (
+    Token.t (* "async" *) option
+  * [
+        `Choice_choice_get of anon_choice_choice_get
+      | `Form_params of formal_parameters
+    ]
+  * Token.t (* "=>" *)
+  * [ `Exp of expression | `Stmt_blk of statement_block ]
+)
+[@@deriving sexp_of]
+
+type class_declaration (* inlined *) = (
+    decorator list (* zero or more *)
+  * Token.t (* "class" *)
+  * identifier (*tok*)
+  * class_heritage option
+  * class_body
+  * automatic_semicolon (*tok*) option
+)
+[@@deriving sexp_of]
+
 type await_expression (* inlined *) = (Token.t (* "await" *) * expression)
 [@@deriving sexp_of]
 
-type assignment_expression (* inlined *) = (
-    [
-        `Paren_exp of parenthesized_expression
-      | `Choice_memb_exp of [
-            `Memb_exp of member_expression
-          | `Subs_exp of subscript_expression
-          | `Id of identifier (*tok*)
-          | `Choice_get of [
-                `Get of Token.t (* "get" *)
-              | `Set of Token.t (* "set" *)
-              | `Async of Token.t (* "async" *)
-              | `Stat of Token.t (* "static" *)
-            ]
-          | `Choice_obj of [ `Obj of object_ | `Array of array_ ]
-        ]
-    ]
-  * Token.t (* "=" *)
+type class_ (* inlined *) = (
+    decorator list (* zero or more *)
+  * Token.t (* "class" *)
+  * identifier (*tok*) option
+  * class_heritage option
+  * class_body
+)
+[@@deriving sexp_of]
+
+type computed_property_name (* inlined *) = (
+    Token.t (* "[" *) * expression * Token.t (* "]" *)
+)
+[@@deriving sexp_of]
+
+type while_statement (* inlined *) = (
+    Token.t (* "while" *) * parenthesized_expression * anon_choice_expo_stmt
+)
+[@@deriving sexp_of]
+
+type switch_statement (* inlined *) = (
+    Token.t (* "switch" *) * parenthesized_expression * switch_body
+)
+[@@deriving sexp_of]
+
+type jsx_self_closing_element (* inlined *) = (
+    Token.t (* "<" *)
+  * anon_choice_choice_jsx_id
+  * anon_choice_jsx_attr list (* zero or more *)
+  * Token.t (* "/" *)
+  * Token.t (* ">" *)
+)
+[@@deriving sexp_of]
+
+type return_statement (* inlined *) = (
+    Token.t (* "return" *)
+  * anon_choice_exp option
+  * anon_choice_auto_semi
+)
+[@@deriving sexp_of]
+
+type for_in_statement (* inlined *) = (
+    Token.t (* "for" *)
+  * Token.t (* "await" *) option
+  * for_header
+  * anon_choice_expo_stmt
+)
+[@@deriving sexp_of]
+
+type ternary_expression (* inlined *) = (
+    expression * Token.t (* "?" *) * expression * Token.t (* ":" *)
   * expression
+)
+[@@deriving sexp_of]
+
+type function_declaration (* inlined *) = (
+    Token.t (* "async" *) option
+  * Token.t (* "function" *)
+  * identifier (*tok*)
+  * formal_parameters
+  * statement_block
+  * automatic_semicolon (*tok*) option
+)
+[@@deriving sexp_of]
+
+type with_statement (* inlined *) = (
+    Token.t (* "with" *) * parenthesized_expression * anon_choice_expo_stmt
+)
+[@@deriving sexp_of]
+
+type for_statement (* inlined *) = (
+    Token.t (* "for" *)
+  * Token.t (* "(" *)
+  * [
+        `Lexi_decl of lexical_declaration
+      | `Var_decl of variable_declaration
+      | `Exp_stmt of expression_statement
+      | `Empty_stmt of Token.t (* ";" *)
+    ]
+  * [ `Exp_stmt of expression_statement | `Empty_stmt of Token.t (* ";" *) ]
+  * anon_choice_exp option
+  * Token.t (* ")" *)
+  * anon_choice_expo_stmt
+)
+[@@deriving sexp_of]
+
+type yield_expression (* inlined *) = (
+    Token.t (* "yield" *)
+  * [
+        `STAR_exp of (Token.t (* "*" *) * expression)
+      | `Opt_exp of expression option
+    ]
 )
 [@@deriving sexp_of]
 
@@ -1427,12 +1133,7 @@ type augmented_assignment_expression (* inlined *) = (
     [
         `Memb_exp of member_expression
       | `Subs_exp of subscript_expression
-      | `Choice_get of [
-            `Get of Token.t (* "get" *)
-          | `Set of Token.t (* "set" *)
-          | `Async of Token.t (* "async" *)
-          | `Stat of Token.t (* "static" *)
-        ]
+      | `Choice_get of anon_choice_get
       | `Id of identifier (*tok*)
       | `Paren_exp of parenthesized_expression
     ]
@@ -1451,17 +1152,6 @@ type augmented_assignment_expression (* inlined *) = (
       | `STARSTAREQ of Token.t (* "**=" *)
     ]
   * expression
-)
-[@@deriving sexp_of]
-
-type ternary_expression (* inlined *) = (
-    expression * Token.t (* "?" *) * expression * Token.t (* ":" *)
-  * expression
-)
-[@@deriving sexp_of]
-
-type computed_property_name (* inlined *) = (
-    Token.t (* "[" *) * expression * Token.t (* "]" *)
 )
 [@@deriving sexp_of]
 

--- a/ruby/lib/Boilerplate.ml
+++ b/ruby/lib/Boilerplate.ml
@@ -20,32 +20,8 @@ let blank (env : env) () =
 let todo (env : env) _ =
    failwith "not implemented"
 
-let map_uninterpreted (env : env) (tok : CST.uninterpreted) =
-  token env tok (* pattern (.|\s)* *)
-
-let map_binary_star (env : env) (tok : CST.binary_star) =
-  token env tok (* binary_star *)
-
-let map_singleton_class_left_angle_left_langle (env : env) (tok : CST.singleton_class_left_angle_left_langle) =
-  token env tok (* singleton_class_left_angle_left_langle *)
-
-let map_instance_variable (env : env) (tok : CST.instance_variable) =
-  token env tok (* instance_variable *)
-
-let map_binary_minus (env : env) (tok : CST.binary_minus) =
-  token env tok (* binary_minus *)
-
-let map_simple_symbol (env : env) (tok : CST.simple_symbol) =
-  token env tok (* simple_symbol *)
-
-let map_complex (env : env) (tok : CST.complex) =
-  token env tok (* pattern (\d+)?(\+|-)?(\d+)i *)
-
-let map_character (env : env) (tok : CST.character) =
-  token env tok (* pattern \?(\\\S({[0-9]*}|[0-9]*|-\S([MC]-\S)?)?|\S) *)
-
-let map_escape_sequence (env : env) (tok : CST.escape_sequence) =
-  token env tok (* escape_sequence *)
+let map_heredoc_end (env : env) (tok : CST.heredoc_end) =
+  token env tok (* heredoc_end *)
 
 let map_false_ (env : env) (x : CST.false_) =
   (match x with
@@ -53,53 +29,20 @@ let map_false_ (env : env) (x : CST.false_) =
   | `False_FALSE tok -> token env tok (* "FALSE" *)
   )
 
-let map_subshell_start (env : env) (tok : CST.subshell_start) =
-  token env tok (* subshell_start *)
+let map_escape_sequence (env : env) (tok : CST.escape_sequence) =
+  token env tok (* escape_sequence *)
 
 let map_regex_start (env : env) (tok : CST.regex_start) =
   token env tok (* regex_start *)
 
-let map_constant (env : env) (tok : CST.constant) =
-  token env tok (* constant *)
-
-let map_symbol_start (env : env) (tok : CST.symbol_start) =
-  token env tok (* symbol_start *)
-
-let map_unary_minus (env : env) (tok : CST.unary_minus) =
-  token env tok (* unary_minus *)
-
 let map_block_ampersand (env : env) (tok : CST.block_ampersand) =
   token env tok (* block_ampersand *)
 
-let map_class_variable (env : env) (tok : CST.class_variable) =
-  token env tok (* class_variable *)
+let map_heredoc_beginning (env : env) (tok : CST.heredoc_beginning) =
+  token env tok (* heredoc_beginning *)
 
 let map_string_array_start (env : env) (tok : CST.string_array_start) =
   token env tok (* string_array_start *)
-
-let map_splat_star (env : env) (tok : CST.splat_star) =
-  token env tok (* splat_star *)
-
-let map_integer (env : env) (tok : CST.integer) =
-  token env tok (* pattern 0[bB][01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0[dD])?\d(_?\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])* *)
-
-let map_heredoc_content (env : env) (tok : CST.heredoc_content) =
-  token env tok (* heredoc_content *)
-
-let map_string_end (env : env) (tok : CST.string_end) =
-  token env tok (* string_end *)
-
-let map_line_break (env : env) (tok : CST.line_break) =
-  token env tok (* line_break *)
-
-let map_identifier (env : env) (tok : CST.identifier) =
-  token env tok (* identifier *)
-
-let map_string_content (env : env) (tok : CST.string_content) =
-  token env tok (* string_content *)
-
-let map_heredoc_end (env : env) (tok : CST.heredoc_end) =
-  token env tok (* heredoc_end *)
 
 let map_nil (env : env) (x : CST.nil) =
   (match x with
@@ -107,23 +50,82 @@ let map_nil (env : env) (x : CST.nil) =
   | `Nil_NIL tok -> token env tok (* "NIL" *)
   )
 
-let map_heredoc_beginning (env : env) (tok : CST.heredoc_beginning) =
-  token env tok (* heredoc_beginning *)
+let map_heredoc_content (env : env) (tok : CST.heredoc_content) =
+  token env tok (* heredoc_content *)
+
+let map_string_end (env : env) (tok : CST.string_end) =
+  token env tok (* string_end *)
+
+let map_anon_choice_PLUSEQ (env : env) (x : CST.anon_choice_PLUSEQ) =
+  (match x with
+  | `PLUSEQ tok -> token env tok (* "+=" *)
+  | `DASHEQ tok -> token env tok (* "-=" *)
+  | `STAREQ tok -> token env tok (* "*=" *)
+  | `STARSTAREQ tok -> token env tok (* "**=" *)
+  | `SLASHEQ tok -> token env tok (* "/=" *)
+  | `BARBAREQ tok -> token env tok (* "||=" *)
+  | `BAREQ tok -> token env tok (* "|=" *)
+  | `AMPAMPEQ tok -> token env tok (* "&&=" *)
+  | `AMPEQ tok -> token env tok (* "&=" *)
+  | `PERCEQ tok -> token env tok (* "%=" *)
+  | `GTGTEQ tok -> token env tok (* ">>=" *)
+  | `LTLTEQ tok -> token env tok (* "<<=" *)
+  | `HATEQ tok -> token env tok (* "^=" *)
+  )
+
+let map_instance_variable (env : env) (tok : CST.instance_variable) =
+  token env tok (* instance_variable *)
+
+let map_splat_star (env : env) (tok : CST.splat_star) =
+  token env tok (* splat_star *)
+
+let map_identifier_hash_key (env : env) (tok : CST.identifier_hash_key) =
+  token env tok (* identifier_hash_key *)
 
 let map_float_ (env : env) (tok : CST.float_) =
   token env tok (* pattern \d(_?\d)*(\.\d)?(_?\d)*([eE][\+-]?\d(_?\d)*\
   )? *)
 
-let map_global_variable (env : env) (tok : CST.global_variable) =
-  token env tok (* pattern "\\$-?(([!@&`'+~=\\/\\\\,;.<>*$?:\"])|([0-9]*\
-  )|([a-zA-Z_][a-zA-Z0-9_]*\
-  ))" *)
+let map_heredoc_body_start (env : env) (tok : CST.heredoc_body_start) =
+  token env tok (* heredoc_body_start *)
+
+let map_integer (env : env) (tok : CST.integer) =
+  token env tok (* pattern 0[bB][01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0[dD])?\d(_?\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])* *)
+
+let map_constant (env : env) (tok : CST.constant) =
+  token env tok (* constant *)
+
+let map_unary_minus (env : env) (tok : CST.unary_minus) =
+  token env tok (* unary_minus *)
+
+let map_complex (env : env) (tok : CST.complex) =
+  token env tok (* pattern (\d+)?(\+|-)?(\d+)i *)
+
+let map_string_content (env : env) (tok : CST.string_content) =
+  token env tok (* string_content *)
+
+let map_singleton_class_left_angle_left_langle (env : env) (tok : CST.singleton_class_left_angle_left_langle) =
+  token env tok (* singleton_class_left_angle_left_langle *)
+
+let map_string_start (env : env) (tok : CST.string_start) =
+  token env tok (* string_start *)
+
+let map_binary_minus (env : env) (tok : CST.binary_minus) =
+  token env tok (* binary_minus *)
+
+let map_class_variable (env : env) (tok : CST.class_variable) =
+  token env tok (* class_variable *)
+
+let map_binary_star (env : env) (tok : CST.binary_star) =
+  token env tok (* binary_star *)
 
 let map_symbol_array_start (env : env) (tok : CST.symbol_array_start) =
   token env tok (* symbol_array_start *)
 
-let map_heredoc_body_start (env : env) (tok : CST.heredoc_body_start) =
-  token env tok (* heredoc_body_start *)
+let map_global_variable (env : env) (tok : CST.global_variable) =
+  token env tok (* pattern "\\$-?(([!@&`'+~=\\/\\\\,;.<>*$?:\"])|([0-9]*\
+  )|([a-zA-Z_][a-zA-Z0-9_]*\
+  ))" *)
 
 let map_operator (env : env) (x : CST.operator) =
   (match x with
@@ -163,16 +165,31 @@ let map_true_ (env : env) (x : CST.true_) =
   | `True_TRUE tok -> token env tok (* "TRUE" *)
   )
 
-let map_string_start (env : env) (tok : CST.string_start) =
-  token env tok (* string_start *)
+let map_symbol_start (env : env) (tok : CST.symbol_start) =
+  token env tok (* symbol_start *)
 
-let map_identifier_hash_key (env : env) (tok : CST.identifier_hash_key) =
-  token env tok (* identifier_hash_key *)
+let map_subshell_start (env : env) (tok : CST.subshell_start) =
+  token env tok (* subshell_start *)
 
-let map_terminator (env : env) (x : CST.terminator) =
+let map_character (env : env) (tok : CST.character) =
+  token env tok (* pattern \?(\\\S({[0-9]*}|[0-9]*|-\S([MC]-\S)?)?|\S) *)
+
+let map_identifier (env : env) (tok : CST.identifier) =
+  token env tok (* identifier *)
+
+let map_line_break (env : env) (tok : CST.line_break) =
+  token env tok (* line_break *)
+
+let map_uninterpreted (env : env) (tok : CST.uninterpreted) =
+  token env tok (* pattern (.|\s)* *)
+
+let map_simple_symbol (env : env) (tok : CST.simple_symbol) =
+  token env tok (* simple_symbol *)
+
+let map_anon_choice_un_minus (env : env) (x : CST.anon_choice_un_minus) =
   (match x with
-  | `Term_line_brk tok -> token env tok (* line_break *)
-  | `Term_SEMI tok -> token env tok (* ";" *)
+  | `Un_minus tok -> token env tok (* unary_minus *)
+  | `PLUS tok -> token env tok (* "+" *)
   )
 
 let map_variable (env : env) (x : CST.variable) =
@@ -189,13 +206,103 @@ let map_variable (env : env) (x : CST.variable) =
   | `Cst tok -> token env tok (* constant *)
   )
 
+let map_terminator (env : env) (x : CST.terminator) =
+  (match x with
+  | `Term_line_brk tok -> token env tok (* line_break *)
+  | `Term_SEMI tok -> token env tok (* ";" *)
+  )
+
 let map_do_ (env : env) (x : CST.do_) =
   (match x with
   | `Do_do tok -> token env tok (* "do" *)
   | `Do_term x -> map_terminator env x
   )
 
-let rec map_statements (env : env) (x : CST.statements) =
+let rec map_else_ (env : env) ((v1, v2, v3) : CST.else_) =
+  let v1 = token env v1 (* "else" *) in
+  let v2 =
+    (match v2 with
+    | Some x -> map_terminator env x
+    | None -> todo env ())
+  in
+  let v3 =
+    (match v3 with
+    | Some x -> map_statements env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3)
+
+and map_block (env : env) ((v1, v2, v3, v4) : CST.block) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    (match v2 with
+    | Some x -> map_block_parameters env x
+    | None -> todo env ())
+  in
+  let v3 =
+    (match v3 with
+    | Some x -> map_statements env x
+    | None -> todo env ())
+  in
+  let v4 = token env v4 (* "}" *) in
+  todo env (v1, v2, v3, v4)
+
+and map_in_ (env : env) ((v1, v2) : CST.in_) =
+  let v1 = token env v1 (* "in" *) in
+  let v2 = map_arg env v2 in
+  todo env (v1, v2)
+
+and map_scope_resolution (env : env) ((v1, v2) : CST.scope_resolution) =
+  let v1 =
+    (match v1 with
+    | `COLONCOLON tok -> token env tok (* "::" *)
+    | `Prim_COLONCOLON (v1, v2) ->
+        let v1 = map_primary env v1 in
+        let v2 = token env v2 (* "::" *) in
+        todo env (v1, v2)
+    )
+  in
+  let v2 =
+    (match v2 with
+    | `Id tok -> token env tok (* identifier *)
+    | `Cst tok -> token env tok (* constant *)
+    )
+  in
+  todo env (v1, v2)
+
+and map_argument_list_with_trailing_comma (env : env) ((v1, v2, v3) : CST.argument_list_with_trailing_comma) =
+  let v1 = map_argument env v1 in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_argument env v2 in
+      todo env (v1, v2)
+    ) v2
+  in
+  let v3 =
+    (match v3 with
+    | Some tok -> token env tok (* "," *)
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3)
+
+and map_mlhs (env : env) ((v1, v2, v3) : CST.mlhs) =
+  let v1 = map_anon_choice_lhs_ env v1 in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_anon_choice_lhs_ env v2 in
+      todo env (v1, v2)
+    ) v2
+  in
+  let v3 =
+    (match v3 with
+    | Some tok -> token env tok (* "," *)
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3)
+
+and map_statements (env : env) (x : CST.statements) =
   (match x with
   | `Stmts_rep1_choice_stmt_term_opt_stmt (v1, v2) ->
       let v1 =
@@ -218,73 +325,55 @@ let rec map_statements (env : env) (x : CST.statements) =
   | `Stmts_stmt x -> map_statement env x
   )
 
+and map_call (env : env) ((v1, v2, v3) : CST.call) =
+  let v1 = map_primary env v1 in
+  let v2 =
+    (match v2 with
+    | `DOT tok -> token env tok (* "." *)
+    | `AMPDOT tok -> token env tok (* "&." *)
+    )
+  in
+  let v3 =
+    (match v3 with
+    | `Id tok -> token env tok (* identifier *)
+    | `Op x -> map_operator env x
+    | `Cst tok -> token env tok (* constant *)
+    | `Arg_list x -> map_argument_list env x
+    )
+  in
+  todo env (v1, v2, v3)
 
-and map_statement (env : env) (x : CST.statement) =
+and map_anon_choice_lhs (env : env) (x : CST.anon_choice_lhs) =
   (match x with
-  | `Stmt_undef (v1, v2, v3) ->
-      let v1 = token env v1 (* "undef" *) in
-      let v2 = map_method_name env v2 in
-      let v3 =
-        List.map (fun (v1, v2) ->
-          let v1 = token env v1 (* "," *) in
-          let v2 = map_method_name env v2 in
-          todo env (v1, v2)
-        ) v3
-      in
-      todo env (v1, v2, v3)
-  | `Stmt_alias (v1, v2, v3) ->
-      let v1 = token env v1 (* "alias" *) in
-      let v2 = map_method_name env v2 in
-      let v3 = map_method_name env v3 in
-      todo env (v1, v2, v3)
-  | `Stmt_if_modi (v1, v2, v3) ->
-      let v1 = map_statement env v1 in
-      let v2 = token env v2 (* "if" *) in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  | `Stmt_unle_modi (v1, v2, v3) ->
-      let v1 = map_statement env v1 in
-      let v2 = token env v2 (* "unless" *) in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  | `Stmt_while_modi (v1, v2, v3) ->
-      let v1 = map_statement env v1 in
-      let v2 = token env v2 (* "while" *) in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  | `Stmt_until_modi (v1, v2, v3) ->
-      let v1 = map_statement env v1 in
-      let v2 = token env v2 (* "until" *) in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  | `Stmt_resc_modi (v1, v2, v3) ->
-      let v1 = map_statement env v1 in
-      let v2 = token env v2 (* "rescue" *) in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  | `Stmt_begin_blk (v1, v2, v3, v4) ->
-      let v1 = token env v1 (* "BEGIN" *) in
-      let v2 = token env v2 (* "{" *) in
-      let v3 =
-        (match v3 with
-        | Some x -> map_statements env x
-        | None -> todo env ())
-      in
-      let v4 = token env v4 (* "}" *) in
-      todo env (v1, v2, v3, v4)
-  | `Stmt_end_blk (v1, v2, v3, v4) ->
-      let v1 = token env v1 (* "END" *) in
-      let v2 = token env v2 (* "{" *) in
-      let v3 =
-        (match v3 with
-        | Some x -> map_statements env x
-        | None -> todo env ())
-      in
-      let v4 = token env v4 (* "}" *) in
-      todo env (v1, v2, v3, v4)
-  | `Stmt_exp x -> map_expression env x
+  | `Lhs x -> map_lhs env x
+  | `Left_assign_list x -> map_left_assignment_list env x
   )
 
+and map_method_call (env : env) (x : CST.method_call) =
+  (match x with
+  | `Meth_call_choice_var_arg_list (v1, v2) ->
+      let v1 = map_anon_choice_var env v1 in
+      let v2 = map_argument_list env v2 in
+      todo env (v1, v2)
+  | `Meth_call_choice_var_arg_list_blk (v1, v2, v3) ->
+      let v1 = map_anon_choice_var env v1 in
+      let v2 = map_argument_list env v2 in
+      let v3 = map_block env v3 in
+      todo env (v1, v2, v3)
+  | `Meth_call_choice_var_arg_list_do_blk (v1, v2, v3) ->
+      let v1 = map_anon_choice_var env v1 in
+      let v2 = map_argument_list env v2 in
+      let v3 = map_do_block env v3 in
+      todo env (v1, v2, v3)
+  | `Meth_call_choice_var_blk (v1, v2) ->
+      let v1 = map_anon_choice_var env v1 in
+      let v2 = map_block env v2 in
+      todo env (v1, v2)
+  | `Meth_call_choice_var_do_blk (v1, v2) ->
+      let v1 = map_anon_choice_var env v1 in
+      let v2 = map_do_block env v2 in
+      todo env (v1, v2)
+  )
 
 and map_method_rest (env : env) ((v1, v2, v3) : CST.method_rest) =
   let v1 = map_method_name env v1 in
@@ -311,234 +400,6 @@ and map_method_rest (env : env) ((v1, v2, v3) : CST.method_rest) =
   let v3 = map_body_statement env v3 in
   todo env (v1, v2, v3)
 
-
-and map_parameters (env : env) ((v1, v2, v3) : CST.parameters) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) ->
-        let v1 = map_formal_parameter env v1 in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 = map_formal_parameter env v2 in
-            todo env (v1, v2)
-          ) v2
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v3 = token env v3 (* ")" *) in
-  todo env (v1, v2, v3)
-
-
-and map_bare_parameters (env : env) ((v1, v2) : CST.bare_parameters) =
-  let v1 = map_simple_formal_parameter env v1 in
-  let v2 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 = map_formal_parameter env v2 in
-      todo env (v1, v2)
-    ) v2
-  in
-  todo env (v1, v2)
-
-
-and map_block_parameters (env : env) ((v1, v2, v3, v4, v5) : CST.block_parameters) =
-  let v1 = token env v1 (* "|" *) in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) ->
-        let v1 = map_formal_parameter env v1 in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 = map_formal_parameter env v2 in
-            todo env (v1, v2)
-          ) v2
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | Some tok -> token env tok (* "," *)
-    | None -> todo env ())
-  in
-  let v4 =
-    (match v4 with
-    | Some (v1, v2, v3) ->
-        let v1 = token env v1 (* ";" *) in
-        let v2 = token env v2 (* identifier *) in
-        let v3 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 = token env v2 (* identifier *) in
-            todo env (v1, v2)
-          ) v3
-        in
-        todo env (v1, v2, v3)
-    | None -> todo env ())
-  in
-  let v5 = token env v5 (* "|" *) in
-  todo env (v1, v2, v3, v4, v5)
-
-
-and map_formal_parameter (env : env) (x : CST.formal_parameter) =
-  (match x with
-  | `Form_param_simple_form_param x ->
-      map_simple_formal_parameter env x
-  | `Form_param_params x -> map_parameters env x
-  )
-
-
-and map_simple_formal_parameter (env : env) (x : CST.simple_formal_parameter) =
-  (match x with
-  | `Simple_form_param_id tok ->
-      token env tok (* identifier *)
-  | `Simple_form_param_splat_param (v1, v2) ->
-      let v1 = token env v1 (* "*" *) in
-      let v2 =
-        (match v2 with
-        | Some tok -> token env tok (* identifier *)
-        | None -> todo env ())
-      in
-      todo env (v1, v2)
-  | `Simple_form_param_hash_splat_param (v1, v2) ->
-      let v1 = token env v1 (* "**" *) in
-      let v2 =
-        (match v2 with
-        | Some tok -> token env tok (* identifier *)
-        | None -> todo env ())
-      in
-      todo env (v1, v2)
-  | `Simple_form_param_blk_param (v1, v2) ->
-      let v1 = token env v1 (* "&" *) in
-      let v2 = token env v2 (* identifier *) in
-      todo env (v1, v2)
-  | `Simple_form_param_kw_param (v1, v2, v3) ->
-      let v1 = token env v1 (* identifier *) in
-      let v2 = token env v2 (* ":" *) in
-      let v3 =
-        (match v3 with
-        | Some x -> map_arg env x
-        | None -> todo env ())
-      in
-      todo env (v1, v2, v3)
-  | `Simple_form_param_opt_param (v1, v2, v3) ->
-      let v1 = token env v1 (* identifier *) in
-      let v2 = token env v2 (* "=" *) in
-      let v3 = map_arg env v3 in
-      todo env (v1, v2, v3)
-  )
-
-
-and map_superclass (env : env) ((v1, v2) : CST.superclass) =
-  let v1 = token env v1 (* "<" *) in
-  let v2 = map_arg env v2 in
-  todo env (v1, v2)
-
-
-and map_in_ (env : env) ((v1, v2) : CST.in_) =
-  let v1 = token env v1 (* "in" *) in
-  let v2 = map_arg env v2 in
-  todo env (v1, v2)
-
-
-and map_when_ (env : env) ((v1, v2, v3, v4) : CST.when_) =
-  let v1 = token env v1 (* "when" *) in
-  let v2 = map_pattern env v2 in
-  let v3 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 = map_pattern env v2 in
-      todo env (v1, v2)
-    ) v3
-  in
-  let v4 =
-    (match v4 with
-    | `Term x -> map_terminator env x
-    | `Then x -> map_then_ env x
-    )
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_pattern (env : env) (x : CST.pattern) =
-  (match x with
-  | `Pat_arg x -> map_arg env x
-  | `Pat_splat_arg x -> map_splat_argument env x
-  )
-
-
-and map_elsif (env : env) ((v1, v2, v3, v4) : CST.elsif) =
-  let v1 = token env v1 (* "elsif" *) in
-  let v2 = map_statement env v2 in
-  let v3 =
-    (match v3 with
-    | `Term x -> map_terminator env x
-    | `Then x -> map_then_ env x
-    )
-  in
-  let v4 =
-    (match v4 with
-    | Some x ->
-        (match x with
-        | `Else x -> map_else_ env x
-        | `Elsif x -> map_elsif env x
-        )
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_else_ (env : env) ((v1, v2, v3) : CST.else_) =
-  let v1 = token env v1 (* "else" *) in
-  let v2 =
-    (match v2 with
-    | Some x -> map_terminator env x
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | Some x -> map_statements env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3)
-
-
-and map_then_ (env : env) (x : CST.then_) =
-  (match x with
-  | `Then_term_stmts (v1, v2) ->
-      let v1 = map_terminator env v1 in
-      let v2 = map_statements env v2 in
-      todo env (v1, v2)
-  | `Then_opt_term_then_opt_stmts (v1, v2, v3) ->
-      let v1 =
-        (match v1 with
-        | Some x -> map_terminator env x
-        | None -> todo env ())
-      in
-      let v2 = token env v2 (* "then" *) in
-      let v3 =
-        (match v3 with
-        | Some x -> map_statements env x
-        | None -> todo env ())
-      in
-      todo env (v1, v2, v3)
-  )
-
-
-and map_ensure (env : env) ((v1, v2) : CST.ensure) =
-  let v1 = token env v1 (* "ensure" *) in
-  let v2 =
-    (match v2 with
-    | Some x -> map_statements env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2)
-
-
 and map_rescue (env : env) ((v1, v2, v3, v4) : CST.rescue) =
   let v1 = token env v1 (* "rescue" *) in
   let v2 =
@@ -551,163 +412,21 @@ and map_rescue (env : env) ((v1, v2, v3, v4) : CST.rescue) =
     | Some x -> map_exception_variable env x
     | None -> todo env ())
   in
-  let v4 =
-    (match v4 with
-    | `Term x -> map_terminator env x
-    | `Then x -> map_then_ env x
-    )
-  in
+  let v4 = map_anon_choice_term env v4 in
   todo env (v1, v2, v3, v4)
 
-
-and map_exceptions (env : env) ((v1, v2) : CST.exceptions) =
-  let v1 =
-    (match v1 with
-    | `Arg x -> map_arg env x
-    | `Splat_arg x -> map_splat_argument env x
-    )
-  in
-  let v2 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 =
-        (match v2 with
-        | `Arg x -> map_arg env x
-        | `Splat_arg x -> map_splat_argument env x
-        )
-      in
-      todo env (v1, v2)
-    ) v2
-  in
-  todo env (v1, v2)
-
-
-and map_exception_variable (env : env) ((v1, v2) : CST.exception_variable) =
-  let v1 = token env v1 (* "=>" *) in
-  let v2 = map_lhs env v2 in
-  todo env (v1, v2)
-
-
-and map_body_statement (env : env) ((v1, v2, v3) : CST.body_statement) =
-  let v1 =
-    (match v1 with
-    | Some x -> map_statements env x
-    | None -> todo env ())
-  in
-  let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Resc x -> map_rescue env x
-      | `Else x -> map_else_ env x
-      | `Ensu x -> map_ensure env x
-      )
-    ) v2
-  in
-  let v3 = token env v3 (* "end" *) in
-  todo env (v1, v2, v3)
-
-
-and map_expression (env : env) (x : CST.expression) =
+and map_anon_choice_var (env : env) (x : CST.anon_choice_var) =
   (match x with
-  | `Exp_cmd_bin (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
-      let v2 =
-        (match v2 with
-        | `Or tok -> token env tok (* "or" *)
-        | `And tok -> token env tok (* "and" *)
-        )
-      in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  | `Exp_cmd_assign x -> map_command_assignment env x
-  | `Exp_cmd_op_assign (v1, v2, v3) ->
-      let v1 = map_lhs env v1 in
-      let v2 =
-        (match v2 with
-        | `PLUSEQ tok -> token env tok (* "+=" *)
-        | `DASHEQ tok -> token env tok (* "-=" *)
-        | `STAREQ tok -> token env tok (* "*=" *)
-        | `STARSTAREQ tok -> token env tok (* "**=" *)
-        | `SLASHEQ tok -> token env tok (* "/=" *)
-        | `BARBAREQ tok -> token env tok (* "||=" *)
-        | `BAREQ tok -> token env tok (* "|=" *)
-        | `AMPAMPEQ tok -> token env tok (* "&&=" *)
-        | `AMPEQ tok -> token env tok (* "&=" *)
-        | `PERCEQ tok -> token env tok (* "%=" *)
-        | `GTGTEQ tok -> token env tok (* ">>=" *)
-        | `LTLTEQ tok -> token env tok (* "<<=" *)
-        | `HATEQ tok -> token env tok (* "^=" *)
-        )
-      in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  | `Exp_cmd_call x -> map_command_call env x
-  | `Exp_ret_cmd (v1, v2) ->
-      let v1 = token env v1 (* "return" *) in
-      let v2 = map_command_argument_list env v2 in
-      todo env (v1, v2)
-  | `Exp_yield_cmd (v1, v2) ->
-      let v1 = token env v1 (* "yield" *) in
-      let v2 = map_command_argument_list env v2 in
-      todo env (v1, v2)
-  | `Exp_brk_cmd (v1, v2) ->
-      let v1 = token env v1 (* "break" *) in
-      let v2 = map_command_argument_list env v2 in
-      todo env (v1, v2)
-  | `Exp_next_cmd (v1, v2) ->
-      let v1 = token env v1 (* "next" *) in
-      let v2 = map_command_argument_list env v2 in
-      todo env (v1, v2)
-  | `Exp_arg x -> map_arg env x
+  | `Var x -> map_variable env x
+  | `Scope_resol x -> map_scope_resolution env x
+  | `Call x -> map_call env x
   )
 
-
-and map_arg (env : env) (x : CST.arg) =
+and map_anon_choice_pair (env : env) (x : CST.anon_choice_pair) =
   (match x with
-  | `Arg_prim x -> map_primary env x
-  | `Arg_assign x -> map_assignment env x
-  | `Arg_op_assign (v1, v2, v3) ->
-      let v1 = map_lhs env v1 in
-      let v2 =
-        (match v2 with
-        | `PLUSEQ tok -> token env tok (* "+=" *)
-        | `DASHEQ tok -> token env tok (* "-=" *)
-        | `STAREQ tok -> token env tok (* "*=" *)
-        | `STARSTAREQ tok -> token env tok (* "**=" *)
-        | `SLASHEQ tok -> token env tok (* "/=" *)
-        | `BARBAREQ tok -> token env tok (* "||=" *)
-        | `BAREQ tok -> token env tok (* "|=" *)
-        | `AMPAMPEQ tok -> token env tok (* "&&=" *)
-        | `AMPEQ tok -> token env tok (* "&=" *)
-        | `PERCEQ tok -> token env tok (* "%=" *)
-        | `GTGTEQ tok -> token env tok (* ">>=" *)
-        | `LTLTEQ tok -> token env tok (* "<<=" *)
-        | `HATEQ tok -> token env tok (* "^=" *)
-        )
-      in
-      let v3 = map_arg env v3 in
-      todo env (v1, v2, v3)
-  | `Arg_cond (v1, v2, v3, v4, v5) ->
-      let v1 = map_arg env v1 in
-      let v2 = token env v2 (* "?" *) in
-      let v3 = map_arg env v3 in
-      let v4 = token env v4 (* ":" *) in
-      let v5 = map_arg env v5 in
-      todo env (v1, v2, v3, v4, v5)
-  | `Arg_range (v1, v2, v3) ->
-      let v1 = map_arg env v1 in
-      let v2 =
-        (match v2 with
-        | `DOTDOT tok -> token env tok (* ".." *)
-        | `DOTDOTDOT tok -> token env tok (* "..." *)
-        )
-      in
-      let v3 = map_arg env v3 in
-      todo env (v1, v2, v3)
-  | `Arg_bin x -> map_binary env x
-  | `Arg_un x -> map_unary env x
+  | `Pair x -> map_pair env x
+  | `Hash_splat_arg x -> map_hash_splat_argument env x
   )
-
 
 and map_primary (env : env) (x : CST.primary) =
   (match x with
@@ -731,16 +450,7 @@ and map_primary (env : env) (x : CST.primary) =
       in
       let v3 =
         (match v3 with
-        | Some (v1, v2) ->
-            let v1 = map_literal_contents env v1 in
-            let v2 =
-              List.map (fun (v1, v2) ->
-                let v1 = blank env v1 in
-                let v2 = map_literal_contents env v2 in
-                todo env (v1, v2)
-              ) v2
-            in
-            todo env (v1, v2)
+        | Some x -> map_anon_lit_content_rep_blank_lit_content env x
         | None -> todo env ())
       in
       let v4 =
@@ -759,16 +469,7 @@ and map_primary (env : env) (x : CST.primary) =
       in
       let v3 =
         (match v3 with
-        | Some (v1, v2) ->
-            let v1 = map_literal_contents env v1 in
-            let v2 =
-              List.map (fun (v1, v2) ->
-                let v1 = blank env v1 in
-                let v2 = map_literal_contents env v2 in
-                todo env (v1, v2)
-              ) v2
-            in
-            todo env (v1, v2)
+        | Some x -> map_anon_lit_content_rep_blank_lit_content env x
         | None -> todo env ())
       in
       let v4 =
@@ -783,21 +484,11 @@ and map_primary (env : env) (x : CST.primary) =
       let v2 =
         (match v2 with
         | Some (v1, v2, v3) ->
-            let v1 =
-              (match v1 with
-              | `Pair x -> map_pair env x
-              | `Hash_splat_arg x -> map_hash_splat_argument env x
-              )
-            in
+            let v1 = map_anon_choice_pair env v1 in
             let v2 =
               List.map (fun (v1, v2) ->
                 let v1 = token env v1 (* "," *) in
-                let v2 =
-                  (match v2 with
-                  | `Pair x -> map_pair env x
-                  | `Hash_splat_arg x -> map_hash_splat_argument env x
-                  )
-                in
+                let v2 = map_anon_choice_pair env v2 in
                 todo env (v1, v2)
               ) v2
             in
@@ -894,12 +585,7 @@ and map_primary (env : env) (x : CST.primary) =
       todo env (v1, v2, v3, v4)
   | `Prim_class (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* "class" *) in
-      let v2 =
-        (match v2 with
-        | `Cst tok -> token env tok (* constant *)
-        | `Scope_resol x -> map_scope_resolution env x
-        )
-      in
+      let v2 = map_anon_choice_cst env v2 in
       let v3 =
         (match v3 with
         | Some x -> map_superclass env x
@@ -919,12 +605,7 @@ and map_primary (env : env) (x : CST.primary) =
       todo env (v1, v2, v3, v4, v5)
   | `Prim_modu (v1, v2, v3) ->
       let v1 = token env v1 (* "module" *) in
-      let v2 =
-        (match v2 with
-        | `Cst tok -> token env tok (* constant *)
-        | `Scope_resol x -> map_scope_resolution env x
-        )
-      in
+      let v2 = map_anon_choice_cst env v2 in
       let v3 =
         (match v3 with
         | `Term_body_stmt (v1, v2) ->
@@ -969,19 +650,10 @@ and map_primary (env : env) (x : CST.primary) =
   | `Prim_if (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* "if" *) in
       let v2 = map_statement env v2 in
-      let v3 =
-        (match v3 with
-        | `Term x -> map_terminator env x
-        | `Then x -> map_then_ env x
-        )
-      in
+      let v3 = map_anon_choice_term env v3 in
       let v4 =
         (match v4 with
-        | Some x ->
-            (match x with
-            | `Else x -> map_else_ env x
-            | `Elsif x -> map_elsif env x
-            )
+        | Some x -> map_anon_choice_else env x
         | None -> todo env ())
       in
       let v5 = token env v5 (* "end" *) in
@@ -989,26 +661,17 @@ and map_primary (env : env) (x : CST.primary) =
   | `Prim_unle (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* "unless" *) in
       let v2 = map_statement env v2 in
-      let v3 =
-        (match v3 with
-        | `Term x -> map_terminator env x
-        | `Then x -> map_then_ env x
-        )
-      in
+      let v3 = map_anon_choice_term env v3 in
       let v4 =
         (match v4 with
-        | Some x ->
-            (match x with
-            | `Else x -> map_else_ env x
-            | `Elsif x -> map_elsif env x
-            )
+        | Some x -> map_anon_choice_else env x
         | None -> todo env ())
       in
       let v5 = token env v5 (* "end" *) in
       todo env (v1, v2, v3, v4, v5)
   | `Prim_for (v1, v2, v3, v4, v5, v6) ->
       let v1 = token env v1 (* "for" *) in
-      let v2 = map_mlhs env v2 in
+      let v2 = map_left_assignment_list env v2 in
       let v3 = map_in_ env v3 in
       let v4 = map_do_ env v4 in
       let v5 =
@@ -1093,12 +756,7 @@ and map_primary (env : env) (x : CST.primary) =
       let v2 = map_parenthesized_statements env v2 in
       todo env (v1, v2)
   | `Prim_un_lit (v1, v2) ->
-      let v1 =
-        (match v1 with
-        | `Un_minus tok -> token env tok (* unary_minus *)
-        | `PLUS tok -> token env tok (* "+" *)
-        )
-      in
+      let v1 = map_anon_choice_un_minus env v1 in
       let v2 =
         (match v2 with
         | `Int tok ->
@@ -1113,194 +771,6 @@ and map_primary (env : env) (x : CST.primary) =
       token env tok (* heredoc_beginning *)
   )
 
-
-and map_parenthesized_statements (env : env) ((v1, v2, v3) : CST.parenthesized_statements) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 =
-    (match v2 with
-    | Some x -> map_statements env x
-    | None -> todo env ())
-  in
-  let v3 = token env v3 (* ")" *) in
-  todo env (v1, v2, v3)
-
-
-and map_scope_resolution (env : env) ((v1, v2) : CST.scope_resolution) =
-  let v1 =
-    (match v1 with
-    | `COLONCOLON tok -> token env tok (* "::" *)
-    | `Prim_COLONCOLON (v1, v2) ->
-        let v1 = map_primary env v1 in
-        let v2 = token env v2 (* "::" *) in
-        todo env (v1, v2)
-    )
-  in
-  let v2 =
-    (match v2 with
-    | `Id tok -> token env tok (* identifier *)
-    | `Cst tok -> token env tok (* constant *)
-    )
-  in
-  todo env (v1, v2)
-
-
-and map_call (env : env) ((v1, v2, v3) : CST.call) =
-  let v1 = map_primary env v1 in
-  let v2 =
-    (match v2 with
-    | `DOT tok -> token env tok (* "." *)
-    | `AMPDOT tok -> token env tok (* "&." *)
-    )
-  in
-  let v3 =
-    (match v3 with
-    | `Id tok -> token env tok (* identifier *)
-    | `Op x -> map_operator env x
-    | `Cst tok -> token env tok (* constant *)
-    | `Arg_list x -> map_argument_list env x
-    )
-  in
-  todo env (v1, v2, v3)
-
-
-and map_command_call (env : env) (x : CST.command_call) =
-  (match x with
-  | `Cmd_call_choice_var_cmd_arg_list (v1, v2) ->
-      let v1 =
-        (match v1 with
-        | `Var x -> map_variable env x
-        | `Scope_resol x -> map_scope_resolution env x
-        | `Call x -> map_call env x
-        )
-      in
-      let v2 = map_command_argument_list env v2 in
-      todo env (v1, v2)
-  | `Cmd_call_choice_var_cmd_arg_list_blk (v1, v2, v3) ->
-      let v1 =
-        (match v1 with
-        | `Var x -> map_variable env x
-        | `Scope_resol x -> map_scope_resolution env x
-        | `Call x -> map_call env x
-        )
-      in
-      let v2 = map_command_argument_list env v2 in
-      let v3 = map_block env v3 in
-      todo env (v1, v2, v3)
-  | `Cmd_call_choice_var_cmd_arg_list_do_blk (v1, v2, v3) ->
-      let v1 =
-        (match v1 with
-        | `Var x -> map_variable env x
-        | `Scope_resol x -> map_scope_resolution env x
-        | `Call x -> map_call env x
-        )
-      in
-      let v2 = map_command_argument_list env v2 in
-      let v3 = map_do_block env v3 in
-      todo env (v1, v2, v3)
-  )
-
-
-and map_method_call (env : env) (x : CST.method_call) =
-  (match x with
-  | `Meth_call_choice_var_arg_list (v1, v2) ->
-      let v1 =
-        (match v1 with
-        | `Var x -> map_variable env x
-        | `Scope_resol x -> map_scope_resolution env x
-        | `Call x -> map_call env x
-        )
-      in
-      let v2 = map_argument_list env v2 in
-      todo env (v1, v2)
-  | `Meth_call_choice_var_arg_list_blk (v1, v2, v3) ->
-      let v1 =
-        (match v1 with
-        | `Var x -> map_variable env x
-        | `Scope_resol x -> map_scope_resolution env x
-        | `Call x -> map_call env x
-        )
-      in
-      let v2 = map_argument_list env v2 in
-      let v3 = map_block env v3 in
-      todo env (v1, v2, v3)
-  | `Meth_call_choice_var_arg_list_do_blk (v1, v2, v3) ->
-      let v1 =
-        (match v1 with
-        | `Var x -> map_variable env x
-        | `Scope_resol x -> map_scope_resolution env x
-        | `Call x -> map_call env x
-        )
-      in
-      let v2 = map_argument_list env v2 in
-      let v3 = map_do_block env v3 in
-      todo env (v1, v2, v3)
-  | `Meth_call_choice_var_blk (v1, v2) ->
-      let v1 =
-        (match v1 with
-        | `Var x -> map_variable env x
-        | `Scope_resol x -> map_scope_resolution env x
-        | `Call x -> map_call env x
-        )
-      in
-      let v2 = map_block env v2 in
-      todo env (v1, v2)
-  | `Meth_call_choice_var_do_blk (v1, v2) ->
-      let v1 =
-        (match v1 with
-        | `Var x -> map_variable env x
-        | `Scope_resol x -> map_scope_resolution env x
-        | `Call x -> map_call env x
-        )
-      in
-      let v2 = map_do_block env v2 in
-      todo env (v1, v2)
-  )
-
-
-and map_command_argument_list (env : env) (x : CST.command_argument_list) =
-  (match x with
-  | `Cmd_arg_list_arg_rep_COMMA_arg (v1, v2) ->
-      let v1 = map_argument env v1 in
-      let v2 =
-        List.map (fun (v1, v2) ->
-          let v1 = token env v1 (* "," *) in
-          let v2 = map_argument env v2 in
-          todo env (v1, v2)
-        ) v2
-      in
-      todo env (v1, v2)
-  | `Cmd_arg_list_cmd_call x -> map_command_call env x
-  )
-
-
-and map_argument_list (env : env) ((v1, v2, v3) : CST.argument_list) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 =
-    (match v2 with
-    | Some x -> map_argument_list_with_trailing_comma env x
-    | None -> todo env ())
-  in
-  let v3 = token env v3 (* ")" *) in
-  todo env (v1, v2, v3)
-
-
-and map_argument_list_with_trailing_comma (env : env) ((v1, v2, v3) : CST.argument_list_with_trailing_comma) =
-  let v1 = map_argument env v1 in
-  let v2 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 = map_argument env v2 in
-      todo env (v1, v2)
-    ) v2
-  in
-  let v3 =
-    (match v3 with
-    | Some tok -> token env tok (* "," *)
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3)
-
-
 and map_argument (env : env) (x : CST.argument) =
   (match x with
   | `Arg_arg x -> map_arg env x
@@ -1313,93 +783,43 @@ and map_argument (env : env) (x : CST.argument) =
   | `Arg_pair x -> map_pair env x
   )
 
-
-and map_splat_argument (env : env) ((v1, v2) : CST.splat_argument) =
-  let v1 = token env v1 (* splat_star *) in
-  let v2 = map_arg env v2 in
-  todo env (v1, v2)
-
-
-and map_hash_splat_argument (env : env) ((v1, v2) : CST.hash_splat_argument) =
-  let v1 = token env v1 (* "**" *) in
-  let v2 = map_arg env v2 in
-  todo env (v1, v2)
-
-
-and map_do_block (env : env) ((v1, v2, v3, v4) : CST.do_block) =
-  let v1 = token env v1 (* "do" *) in
+and map_parenthesized_statements (env : env) ((v1, v2, v3) : CST.parenthesized_statements) =
+  let v1 = token env v1 (* "(" *) in
   let v2 =
     (match v2 with
-    | Some x -> map_terminator env x
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | Some (v1, v2) ->
-        let v1 = map_block_parameters env v1 in
-        let v2 =
-          (match v2 with
-          | Some x -> map_terminator env x
-          | None -> todo env ())
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v4 = map_body_statement env v4 in
-  todo env (v1, v2, v3, v4)
-
-
-and map_block (env : env) ((v1, v2, v3, v4) : CST.block) =
-  let v1 = token env v1 (* "{" *) in
-  let v2 =
-    (match v2 with
-    | Some x -> map_block_parameters env x
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
     | Some x -> map_statements env x
     | None -> todo env ())
   in
-  let v4 = token env v4 (* "}" *) in
-  todo env (v1, v2, v3, v4)
+  let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
 
+and map_string_ (env : env) ((v1, v2, v3) : CST.string_) =
+  let v1 = token env v1 (* string_start *) in
+  let v2 =
+    (match v2 with
+    | Some x -> map_literal_contents env x
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* string_end *) in
+  todo env (v1, v2, v3)
 
-and map_assignment (env : env) (x : CST.assignment) =
-  (match x with
-  | `Choice_lhs_EQ_choice_arg (v1, v2, v3) ->
-      let v1 =
-        (match v1 with
-        | `Lhs x -> map_lhs env x
-        | `Left_assign_list x -> map_left_assignment_list env x
-        )
-      in
-      let v2 = token env v2 (* "=" *) in
-      let v3 =
-        (match v3 with
-        | `Arg x -> map_arg env x
-        | `Splat_arg x -> map_splat_argument env x
-        | `Right_assign_list x -> map_right_assignment_list env x
-        )
-      in
-      todo env (v1, v2, v3)
-  )
-
-
-and map_command_assignment (env : env) (x : CST.command_assignment) =
-  (match x with
-  | `Choice_lhs_EQ_exp (v1, v2, v3) ->
-      let v1 =
-        (match v1 with
-        | `Lhs x -> map_lhs env x
-        | `Left_assign_list x -> map_left_assignment_list env x
-        )
-      in
-      let v2 = token env v2 (* "=" *) in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  )
-
+and map_body_statement (env : env) ((v1, v2, v3) : CST.body_statement) =
+  let v1 =
+    (match v1 with
+    | Some x -> map_statements env x
+    | None -> todo env ())
+  in
+  let v2 =
+    List.map (fun x ->
+      (match x with
+      | `Resc x -> map_rescue env x
+      | `Else x -> map_else_ env x
+      | `Ensu x -> map_ensure env x
+      )
+    ) v2
+  in
+  let v3 = token env v3 (* "end" *) in
+  todo env (v1, v2, v3)
 
 and map_binary (env : env) (x : CST.binary) =
   (match x with
@@ -1502,111 +922,26 @@ and map_binary (env : env) (x : CST.binary) =
       todo env (v1, v2, v3)
   )
 
-
-and map_unary (env : env) (x : CST.unary) =
+and map_then_ (env : env) (x : CST.then_) =
   (match x with
-  | `Un_defi_arg (v1, v2) ->
-      let v1 = token env v1 (* "defined?" *) in
-      let v2 = map_arg env v2 in
+  | `Then_term_stmts (v1, v2) ->
+      let v1 = map_terminator env v1 in
+      let v2 = map_statements env v2 in
       todo env (v1, v2)
-  | `Un_not_arg (v1, v2) ->
-      let v1 = token env v1 (* "not" *) in
-      let v2 = map_arg env v2 in
-      todo env (v1, v2)
-  | `Un_choice_un_minus_arg (v1, v2) ->
+  | `Then_opt_term_then_opt_stmts (v1, v2, v3) ->
       let v1 =
         (match v1 with
-        | `Un_minus tok -> token env tok (* unary_minus *)
-        | `PLUS tok -> token env tok (* "+" *)
-        )
+        | Some x -> map_terminator env x
+        | None -> todo env ())
       in
-      let v2 = map_arg env v2 in
-      todo env (v1, v2)
-  | `Un_choice_BANG_arg (v1, v2) ->
-      let v1 =
-        (match v1 with
-        | `BANG tok -> token env tok (* "!" *)
-        | `TILDE tok -> token env tok (* "~" *)
-        )
+      let v2 = token env v2 (* "then" *) in
+      let v3 =
+        (match v3 with
+        | Some x -> map_statements env x
+        | None -> todo env ())
       in
-      let v2 = map_arg env v2 in
-      todo env (v1, v2)
+      todo env (v1, v2, v3)
   )
-
-
-and map_right_assignment_list (env : env) ((v1, v2) : CST.right_assignment_list) =
-  let v1 =
-    (match v1 with
-    | `Arg x -> map_arg env x
-    | `Splat_arg x -> map_splat_argument env x
-    )
-  in
-  let v2 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 =
-        (match v2 with
-        | `Arg x -> map_arg env x
-        | `Splat_arg x -> map_splat_argument env x
-        )
-      in
-      todo env (v1, v2)
-    ) v2
-  in
-  todo env (v1, v2)
-
-
-and map_left_assignment_list (env : env) (x : CST.left_assignment_list) =
-  map_mlhs env x
-
-
-and map_mlhs (env : env) ((v1, v2, v3) : CST.mlhs) =
-  let v1 =
-    (match v1 with
-    | `Lhs x -> map_lhs env x
-    | `Rest_assign x -> map_rest_assignment env x
-    | `Dest_left_assign x ->
-        map_destructured_left_assignment env x
-    )
-  in
-  let v2 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 =
-        (match v2 with
-        | `Lhs x -> map_lhs env x
-        | `Rest_assign x -> map_rest_assignment env x
-        | `Dest_left_assign x ->
-            map_destructured_left_assignment env x
-        )
-      in
-      todo env (v1, v2)
-    ) v2
-  in
-  let v3 =
-    (match v3 with
-    | Some tok -> token env tok (* "," *)
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3)
-
-
-and map_destructured_left_assignment (env : env) ((v1, v2, v3) : CST.destructured_left_assignment) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 = map_mlhs env v2 in
-  let v3 = token env v3 (* ")" *) in
-  todo env (v1, v2, v3)
-
-
-and map_rest_assignment (env : env) ((v1, v2) : CST.rest_assignment) =
-  let v1 = token env v1 (* "*" *) in
-  let v2 =
-    (match v2 with
-    | Some x -> map_lhs env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2)
-
 
 and map_lhs (env : env) (x : CST.lhs) =
   (match x with
@@ -1629,70 +964,142 @@ and map_lhs (env : env) (x : CST.lhs) =
   | `Meth_call x -> map_method_call env x
   )
 
-
-and map_method_name (env : env) (x : CST.method_name) =
+and map_unary (env : env) (x : CST.unary) =
   (match x with
-  | `Meth_name_id tok -> token env tok (* identifier *)
-  | `Meth_name_cst tok -> token env tok (* constant *)
-  | `Meth_name_sett (v1, v2) ->
-      let v1 = token env v1 (* identifier *) in
-      let v2 = token env v2 (* "=" *) in
+  | `Un_defi_arg (v1, v2) ->
+      let v1 = token env v1 (* "defined?" *) in
+      let v2 = map_arg env v2 in
       todo env (v1, v2)
-  | `Meth_name_symb x -> map_symbol env x
-  | `Meth_name_op x -> map_operator env x
-  | `Meth_name_inst_var tok ->
-      token env tok (* instance_variable *)
-  | `Meth_name_class_var tok ->
-      token env tok (* class_variable *)
-  | `Meth_name_glob_var tok ->
-      token env tok (* pattern "\\$-?(([!@&`'+~=\\/\\\\,;.<>*$?:\"])|([0-9]*\
-  )|([a-zA-Z_][a-zA-Z0-9_]*\
-  ))" *)
+  | `Un_not_arg (v1, v2) ->
+      let v1 = token env v1 (* "not" *) in
+      let v2 = map_arg env v2 in
+      todo env (v1, v2)
+  | `Un_choice_un_minus_arg (v1, v2) ->
+      let v1 = map_anon_choice_un_minus env v1 in
+      let v2 = map_arg env v2 in
+      todo env (v1, v2)
+  | `Un_choice_BANG_arg (v1, v2) ->
+      let v1 =
+        (match v1 with
+        | `BANG tok -> token env tok (* "!" *)
+        | `TILDE tok -> token env tok (* "~" *)
+        )
+      in
+      let v2 = map_arg env v2 in
+      todo env (v1, v2)
   )
 
-
-and map_interpolation (env : env) ((v1, v2, v3) : CST.interpolation) =
-  let v1 = token env v1 (* "#{" *) in
-  let v2 = map_statement env v2 in
-  let v3 = token env v3 (* "}" *) in
-  todo env (v1, v2, v3)
-
-
-and map_string_ (env : env) ((v1, v2, v3) : CST.string_) =
-  let v1 = token env v1 (* string_start *) in
-  let v2 =
-    (match v2 with
-    | Some x -> map_literal_contents env x
-    | None -> todo env ())
-  in
-  let v3 = token env v3 (* string_end *) in
-  todo env (v1, v2, v3)
-
-
-and map_symbol (env : env) (x : CST.symbol) =
+and map_expression (env : env) (x : CST.expression) =
   (match x with
-  | `Symb_simple_symb tok -> token env tok (* simple_symbol *)
-  | `Symb_symb_start_opt_lit_content_str_end (v1, v2, v3) ->
-      let v1 = token env v1 (* symbol_start *) in
+  | `Exp_cmd_bin (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
       let v2 =
         (match v2 with
-        | Some x -> map_literal_contents env x
-        | None -> todo env ())
+        | `Or tok -> token env tok (* "or" *)
+        | `And tok -> token env tok (* "and" *)
+        )
       in
-      let v3 = token env v3 (* string_end *) in
+      let v3 = map_expression env v3 in
       todo env (v1, v2, v3)
+  | `Exp_cmd_assign x -> map_command_assignment env x
+  | `Exp_cmd_op_assign (v1, v2, v3) ->
+      let v1 = map_lhs env v1 in
+      let v2 = map_anon_choice_PLUSEQ env v2 in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_cmd_call x -> map_command_call env x
+  | `Exp_ret_cmd (v1, v2) ->
+      let v1 = token env v1 (* "return" *) in
+      let v2 = map_command_argument_list env v2 in
+      todo env (v1, v2)
+  | `Exp_yield_cmd (v1, v2) ->
+      let v1 = token env v1 (* "yield" *) in
+      let v2 = map_command_argument_list env v2 in
+      todo env (v1, v2)
+  | `Exp_brk_cmd (v1, v2) ->
+      let v1 = token env v1 (* "break" *) in
+      let v2 = map_command_argument_list env v2 in
+      todo env (v1, v2)
+  | `Exp_next_cmd (v1, v2) ->
+      let v1 = token env v1 (* "next" *) in
+      let v2 = map_command_argument_list env v2 in
+      todo env (v1, v2)
+  | `Exp_arg x -> map_arg env x
   )
 
+and map_arg (env : env) (x : CST.arg) =
+  (match x with
+  | `Arg_prim x -> map_primary env x
+  | `Arg_assign x -> map_assignment env x
+  | `Arg_op_assign (v1, v2, v3) ->
+      let v1 = map_lhs env v1 in
+      let v2 = map_anon_choice_PLUSEQ env v2 in
+      let v3 = map_arg env v3 in
+      todo env (v1, v2, v3)
+  | `Arg_cond (v1, v2, v3, v4, v5) ->
+      let v1 = map_arg env v1 in
+      let v2 = token env v2 (* "?" *) in
+      let v3 = map_arg env v3 in
+      let v4 = token env v4 (* ":" *) in
+      let v5 = map_arg env v5 in
+      todo env (v1, v2, v3, v4, v5)
+  | `Arg_range (v1, v2, v3) ->
+      let v1 = map_arg env v1 in
+      let v2 =
+        (match v2 with
+        | `DOTDOT tok -> token env tok (* ".." *)
+        | `DOTDOTDOT tok -> token env tok (* "..." *)
+        )
+      in
+      let v3 = map_arg env v3 in
+      todo env (v1, v2, v3)
+  | `Arg_bin x -> map_binary env x
+  | `Arg_un x -> map_unary env x
+  )
 
-and map_literal_contents (env : env) (xs : CST.literal_contents) =
-  List.map (fun x ->
-    (match x with
-    | `Str_content tok -> token env tok (* string_content *)
-    | `Interp x -> map_interpolation env x
-    | `Esc_seq tok -> token env tok (* escape_sequence *)
-    )
-  ) xs
+and map_right_assignment_list (env : env) ((v1, v2) : CST.right_assignment_list) =
+  let v1 = map_anon_choice_arg env v1 in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_anon_choice_arg env v2 in
+      todo env (v1, v2)
+    ) v2
+  in
+  todo env (v1, v2)
 
+and map_do_block (env : env) ((v1, v2, v3, v4) : CST.do_block) =
+  let v1 = token env v1 (* "do" *) in
+  let v2 =
+    (match v2 with
+    | Some x -> map_terminator env x
+    | None -> todo env ())
+  in
+  let v3 =
+    (match v3 with
+    | Some (v1, v2) ->
+        let v1 = map_block_parameters env v1 in
+        let v2 =
+          (match v2 with
+          | Some x -> map_terminator env x
+          | None -> todo env ())
+        in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v4 = map_body_statement env v4 in
+  todo env (v1, v2, v3, v4)
+
+and map_anon_form_param_rep_COMMA_form_param (env : env) ((v1, v2) : CST.anon_form_param_rep_COMMA_form_param) =
+  let v1 = map_formal_parameter env v1 in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_formal_parameter env v2 in
+      todo env (v1, v2)
+    ) v2
+  in
+  todo env (v1, v2)
 
 and map_pair (env : env) (x : CST.pair) =
   (match x with
@@ -1716,6 +1123,410 @@ and map_pair (env : env) (x : CST.pair) =
       todo env (v1, v2, v3)
   )
 
+and map_assignment (env : env) (x : CST.assignment) =
+  (match x with
+  | `Choice_lhs_EQ_choice_arg (v1, v2, v3) ->
+      let v1 = map_anon_choice_lhs env v1 in
+      let v2 = token env v2 (* "=" *) in
+      let v3 =
+        (match v3 with
+        | `Arg x -> map_arg env x
+        | `Splat_arg x -> map_splat_argument env x
+        | `Right_assign_list x -> map_right_assignment_list env x
+        )
+      in
+      todo env (v1, v2, v3)
+  )
+
+and map_literal_contents (env : env) (xs : CST.literal_contents) =
+  List.map (fun x ->
+    (match x with
+    | `Str_content tok -> token env tok (* string_content *)
+    | `Interp x -> map_interpolation env x
+    | `Esc_seq tok -> token env tok (* escape_sequence *)
+    )
+  ) xs
+
+and map_anon_lit_content_rep_blank_lit_content (env : env) ((v1, v2) : CST.anon_lit_content_rep_blank_lit_content) =
+  let v1 = map_literal_contents env v1 in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = blank env v1 in
+      let v2 = map_literal_contents env v2 in
+      todo env (v1, v2)
+    ) v2
+  in
+  todo env (v1, v2)
+
+and map_when_ (env : env) ((v1, v2, v3, v4) : CST.when_) =
+  let v1 = token env v1 (* "when" *) in
+  let v2 = map_pattern env v2 in
+  let v3 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_pattern env v2 in
+      todo env (v1, v2)
+    ) v3
+  in
+  let v4 = map_anon_choice_term env v4 in
+  todo env (v1, v2, v3, v4)
+
+and map_bare_parameters (env : env) ((v1, v2) : CST.bare_parameters) =
+  let v1 = map_simple_formal_parameter env v1 in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_formal_parameter env v2 in
+      todo env (v1, v2)
+    ) v2
+  in
+  todo env (v1, v2)
+
+and map_statement (env : env) (x : CST.statement) =
+  (match x with
+  | `Stmt_undef (v1, v2, v3) ->
+      let v1 = token env v1 (* "undef" *) in
+      let v2 = map_method_name env v2 in
+      let v3 =
+        List.map (fun (v1, v2) ->
+          let v1 = token env v1 (* "," *) in
+          let v2 = map_method_name env v2 in
+          todo env (v1, v2)
+        ) v3
+      in
+      todo env (v1, v2, v3)
+  | `Stmt_alias (v1, v2, v3) ->
+      let v1 = token env v1 (* "alias" *) in
+      let v2 = map_method_name env v2 in
+      let v3 = map_method_name env v3 in
+      todo env (v1, v2, v3)
+  | `Stmt_if_modi (v1, v2, v3) ->
+      let v1 = map_statement env v1 in
+      let v2 = token env v2 (* "if" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Stmt_unle_modi (v1, v2, v3) ->
+      let v1 = map_statement env v1 in
+      let v2 = token env v2 (* "unless" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Stmt_while_modi (v1, v2, v3) ->
+      let v1 = map_statement env v1 in
+      let v2 = token env v2 (* "while" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Stmt_until_modi (v1, v2, v3) ->
+      let v1 = map_statement env v1 in
+      let v2 = token env v2 (* "until" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Stmt_resc_modi (v1, v2, v3) ->
+      let v1 = map_statement env v1 in
+      let v2 = token env v2 (* "rescue" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Stmt_begin_blk (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "BEGIN" *) in
+      let v2 = token env v2 (* "{" *) in
+      let v3 =
+        (match v3 with
+        | Some x -> map_statements env x
+        | None -> todo env ())
+      in
+      let v4 = token env v4 (* "}" *) in
+      todo env (v1, v2, v3, v4)
+  | `Stmt_end_blk (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "END" *) in
+      let v2 = token env v2 (* "{" *) in
+      let v3 =
+        (match v3 with
+        | Some x -> map_statements env x
+        | None -> todo env ())
+      in
+      let v4 = token env v4 (* "}" *) in
+      todo env (v1, v2, v3, v4)
+  | `Stmt_exp x -> map_expression env x
+  )
+
+and map_anon_choice_cst (env : env) (x : CST.anon_choice_cst) =
+  (match x with
+  | `Cst tok -> token env tok (* constant *)
+  | `Scope_resol x -> map_scope_resolution env x
+  )
+
+and map_command_assignment (env : env) (x : CST.command_assignment) =
+  (match x with
+  | `Choice_lhs_EQ_exp (v1, v2, v3) ->
+      let v1 = map_anon_choice_lhs env v1 in
+      let v2 = token env v2 (* "=" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  )
+
+and map_splat_argument (env : env) ((v1, v2) : CST.splat_argument) =
+  let v1 = token env v1 (* splat_star *) in
+  let v2 = map_arg env v2 in
+  todo env (v1, v2)
+
+and map_exceptions (env : env) ((v1, v2) : CST.exceptions) =
+  let v1 = map_anon_choice_arg env v1 in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_anon_choice_arg env v2 in
+      todo env (v1, v2)
+    ) v2
+  in
+  todo env (v1, v2)
+
+and map_symbol (env : env) (x : CST.symbol) =
+  (match x with
+  | `Symb_simple_symb tok -> token env tok (* simple_symbol *)
+  | `Symb_symb_start_opt_lit_content_str_end (v1, v2, v3) ->
+      let v1 = token env v1 (* symbol_start *) in
+      let v2 =
+        (match v2 with
+        | Some x -> map_literal_contents env x
+        | None -> todo env ())
+      in
+      let v3 = token env v3 (* string_end *) in
+      todo env (v1, v2, v3)
+  )
+
+and map_anon_choice_arg (env : env) (x : CST.anon_choice_arg) =
+  (match x with
+  | `Arg x -> map_arg env x
+  | `Splat_arg x -> map_splat_argument env x
+  )
+
+and map_ensure (env : env) ((v1, v2) : CST.ensure) =
+  let v1 = token env v1 (* "ensure" *) in
+  let v2 =
+    (match v2 with
+    | Some x -> map_statements env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2)
+
+and map_command_call (env : env) (x : CST.command_call) =
+  (match x with
+  | `Cmd_call_choice_var_cmd_arg_list (v1, v2) ->
+      let v1 = map_anon_choice_var env v1 in
+      let v2 = map_command_argument_list env v2 in
+      todo env (v1, v2)
+  | `Cmd_call_choice_var_cmd_arg_list_blk (v1, v2, v3) ->
+      let v1 = map_anon_choice_var env v1 in
+      let v2 = map_command_argument_list env v2 in
+      let v3 = map_block env v3 in
+      todo env (v1, v2, v3)
+  | `Cmd_call_choice_var_cmd_arg_list_do_blk (v1, v2, v3) ->
+      let v1 = map_anon_choice_var env v1 in
+      let v2 = map_command_argument_list env v2 in
+      let v3 = map_do_block env v3 in
+      todo env (v1, v2, v3)
+  )
+
+and map_hash_splat_argument (env : env) ((v1, v2) : CST.hash_splat_argument) =
+  let v1 = token env v1 (* "**" *) in
+  let v2 = map_arg env v2 in
+  todo env (v1, v2)
+
+and map_exception_variable (env : env) ((v1, v2) : CST.exception_variable) =
+  let v1 = token env v1 (* "=>" *) in
+  let v2 = map_lhs env v2 in
+  todo env (v1, v2)
+
+and map_method_name (env : env) (x : CST.method_name) =
+  (match x with
+  | `Meth_name_id tok -> token env tok (* identifier *)
+  | `Meth_name_cst tok -> token env tok (* constant *)
+  | `Meth_name_sett (v1, v2) ->
+      let v1 = token env v1 (* identifier *) in
+      let v2 = token env v2 (* "=" *) in
+      todo env (v1, v2)
+  | `Meth_name_symb x -> map_symbol env x
+  | `Meth_name_op x -> map_operator env x
+  | `Meth_name_inst_var tok ->
+      token env tok (* instance_variable *)
+  | `Meth_name_class_var tok ->
+      token env tok (* class_variable *)
+  | `Meth_name_glob_var tok ->
+      token env tok (* pattern "\\$-?(([!@&`'+~=\\/\\\\,;.<>*$?:\"])|([0-9]*\
+  )|([a-zA-Z_][a-zA-Z0-9_]*\
+  ))" *)
+  )
+
+and map_block_parameters (env : env) ((v1, v2, v3, v4, v5) : CST.block_parameters) =
+  let v1 = token env v1 (* "|" *) in
+  let v2 =
+    (match v2 with
+    | Some x -> map_anon_form_param_rep_COMMA_form_param env x
+    | None -> todo env ())
+  in
+  let v3 =
+    (match v3 with
+    | Some tok -> token env tok (* "," *)
+    | None -> todo env ())
+  in
+  let v4 =
+    (match v4 with
+    | Some (v1, v2, v3) ->
+        let v1 = token env v1 (* ";" *) in
+        let v2 = token env v2 (* identifier *) in
+        let v3 =
+          List.map (fun (v1, v2) ->
+            let v1 = token env v1 (* "," *) in
+            let v2 = token env v2 (* identifier *) in
+            todo env (v1, v2)
+          ) v3
+        in
+        todo env (v1, v2, v3)
+    | None -> todo env ())
+  in
+  let v5 = token env v5 (* "|" *) in
+  todo env (v1, v2, v3, v4, v5)
+
+and map_superclass (env : env) ((v1, v2) : CST.superclass) =
+  let v1 = token env v1 (* "<" *) in
+  let v2 = map_arg env v2 in
+  todo env (v1, v2)
+
+and map_anon_choice_lhs_ (env : env) (x : CST.anon_choice_lhs_) =
+  (match x with
+  | `Lhs x -> map_lhs env x
+  | `Rest_assign (v1, v2) ->
+      let v1 = token env v1 (* "*" *) in
+      let v2 =
+        (match v2 with
+        | Some x -> map_lhs env x
+        | None -> todo env ())
+      in
+      todo env (v1, v2)
+  | `Dest_left_assign (v1, v2, v3) ->
+      let v1 = token env v1 (* "(" *) in
+      let v2 = map_left_assignment_list env v2 in
+      let v3 = token env v3 (* ")" *) in
+      todo env (v1, v2, v3)
+  )
+
+and map_pattern (env : env) (x : CST.pattern) =
+  (match x with
+  | `Pat_arg x -> map_arg env x
+  | `Pat_splat_arg x -> map_splat_argument env x
+  )
+
+and map_command_argument_list (env : env) (x : CST.command_argument_list) =
+  (match x with
+  | `Cmd_arg_list_arg_rep_COMMA_arg (v1, v2) ->
+      let v1 = map_argument env v1 in
+      let v2 =
+        List.map (fun (v1, v2) ->
+          let v1 = token env v1 (* "," *) in
+          let v2 = map_argument env v2 in
+          todo env (v1, v2)
+        ) v2
+      in
+      todo env (v1, v2)
+  | `Cmd_arg_list_cmd_call x -> map_command_call env x
+  )
+
+and map_argument_list (env : env) ((v1, v2, v3) : CST.argument_list) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    (match v2 with
+    | Some x -> map_argument_list_with_trailing_comma env x
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
+
+and map_left_assignment_list (env : env) (x : CST.left_assignment_list) =
+  map_mlhs env x
+
+and map_parameters (env : env) ((v1, v2, v3) : CST.parameters) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    (match v2 with
+    | Some x -> map_anon_form_param_rep_COMMA_form_param env x
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
+
+and map_anon_choice_term (env : env) (x : CST.anon_choice_term) =
+  (match x with
+  | `Term x -> map_terminator env x
+  | `Then x -> map_then_ env x
+  )
+
+and map_simple_formal_parameter (env : env) (x : CST.simple_formal_parameter) =
+  (match x with
+  | `Simple_form_param_id tok ->
+      token env tok (* identifier *)
+  | `Simple_form_param_splat_param (v1, v2) ->
+      let v1 = token env v1 (* "*" *) in
+      let v2 =
+        (match v2 with
+        | Some tok -> token env tok (* identifier *)
+        | None -> todo env ())
+      in
+      todo env (v1, v2)
+  | `Simple_form_param_hash_splat_param (v1, v2) ->
+      let v1 = token env v1 (* "**" *) in
+      let v2 =
+        (match v2 with
+        | Some tok -> token env tok (* identifier *)
+        | None -> todo env ())
+      in
+      todo env (v1, v2)
+  | `Simple_form_param_blk_param (v1, v2) ->
+      let v1 = token env v1 (* "&" *) in
+      let v2 = token env v2 (* identifier *) in
+      todo env (v1, v2)
+  | `Simple_form_param_kw_param (v1, v2, v3) ->
+      let v1 = token env v1 (* identifier *) in
+      let v2 = token env v2 (* ":" *) in
+      let v3 =
+        (match v3 with
+        | Some x -> map_arg env x
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3)
+  | `Simple_form_param_opt_param (v1, v2, v3) ->
+      let v1 = token env v1 (* identifier *) in
+      let v2 = token env v2 (* "=" *) in
+      let v3 = map_arg env v3 in
+      todo env (v1, v2, v3)
+  )
+
+and map_interpolation (env : env) ((v1, v2, v3) : CST.interpolation) =
+  let v1 = token env v1 (* "#{" *) in
+  let v2 = map_statement env v2 in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+and map_formal_parameter (env : env) (x : CST.formal_parameter) =
+  (match x with
+  | `Form_param_simple_form_param x ->
+      map_simple_formal_parameter env x
+  | `Form_param_params x -> map_parameters env x
+  )
+
+and map_anon_choice_else (env : env) (x : CST.anon_choice_else) =
+  (match x with
+  | `Else x -> map_else_ env x
+  | `Elsif (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "elsif" *) in
+      let v2 = map_statement env v2 in
+      let v3 = map_anon_choice_term env v3 in
+      let v4 =
+        (match v4 with
+        | Some x -> map_anon_choice_else env x
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4)
+  )
+
 let map_program (env : env) ((v1, v2) : CST.program) =
   let v1 =
     (match v1 with
@@ -1732,4 +1543,3 @@ let map_program (env : env) ((v1, v2) : CST.program) =
     | None -> todo env ())
   in
   todo env (v1, v2)
-

--- a/ruby/lib/CST.ml
+++ b/ruby/lib/CST.ml
@@ -8,32 +8,7 @@
 open! Sexplib.Conv
 open Tree_sitter_run
 
-type uninterpreted = Token.t (* pattern (.|\s)* *)
-[@@deriving sexp_of]
-
-type binary_star = Token.t
-[@@deriving sexp_of]
-
-type singleton_class_left_angle_left_langle = Token.t
-[@@deriving sexp_of]
-
-type instance_variable = Token.t
-[@@deriving sexp_of]
-
-type binary_minus = Token.t
-[@@deriving sexp_of]
-
-type simple_symbol = Token.t
-[@@deriving sexp_of]
-
-type complex = Token.t (* pattern (\d+)?(\+|-)?(\d+)i *)
-[@@deriving sexp_of]
-
-type character =
-  Token.t (* pattern \?(\\\S({[0-9]*}|[0-9]*|-\S([MC]-\S)?)?|\S) *)
-[@@deriving sexp_of]
-
-type escape_sequence = Token.t
+type heredoc_end = Token.t
 [@@deriving sexp_of]
 
 type false_ = [
@@ -42,53 +17,19 @@ type false_ = [
 ]
 [@@deriving sexp_of]
 
-type subshell_start = Token.t
+type escape_sequence = Token.t
 [@@deriving sexp_of]
 
 type regex_start = Token.t
 [@@deriving sexp_of]
 
-type constant = Token.t
-[@@deriving sexp_of]
-
-type symbol_start = Token.t
-[@@deriving sexp_of]
-
-type unary_minus = Token.t
-[@@deriving sexp_of]
-
 type block_ampersand = Token.t
 [@@deriving sexp_of]
 
-type class_variable = Token.t
+type heredoc_beginning = Token.t
 [@@deriving sexp_of]
 
 type string_array_start = Token.t
-[@@deriving sexp_of]
-
-type splat_star = Token.t
-[@@deriving sexp_of]
-
-type integer =
-  Token.t (* pattern 0[bB][01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0[dD])?\d(_?\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])* *)
-[@@deriving sexp_of]
-
-type heredoc_content = Token.t
-[@@deriving sexp_of]
-
-type string_end = Token.t
-[@@deriving sexp_of]
-
-type line_break = Token.t
-[@@deriving sexp_of]
-
-type identifier = Token.t
-[@@deriving sexp_of]
-
-type string_content = Token.t
-[@@deriving sexp_of]
-
-type heredoc_end = Token.t
 [@@deriving sexp_of]
 
 type nil = [
@@ -97,7 +38,36 @@ type nil = [
 ]
 [@@deriving sexp_of]
 
-type heredoc_beginning = Token.t
+type heredoc_content = Token.t
+[@@deriving sexp_of]
+
+type string_end = Token.t
+[@@deriving sexp_of]
+
+type anon_choice_PLUSEQ = [
+    `PLUSEQ of Token.t (* "+=" *)
+  | `DASHEQ of Token.t (* "-=" *)
+  | `STAREQ of Token.t (* "*=" *)
+  | `STARSTAREQ of Token.t (* "**=" *)
+  | `SLASHEQ of Token.t (* "/=" *)
+  | `BARBAREQ of Token.t (* "||=" *)
+  | `BAREQ of Token.t (* "|=" *)
+  | `AMPAMPEQ of Token.t (* "&&=" *)
+  | `AMPEQ of Token.t (* "&=" *)
+  | `PERCEQ of Token.t (* "%=" *)
+  | `GTGTEQ of Token.t (* ">>=" *)
+  | `LTLTEQ of Token.t (* "<<=" *)
+  | `HATEQ of Token.t (* "^=" *)
+]
+[@@deriving sexp_of]
+
+type instance_variable = Token.t
+[@@deriving sexp_of]
+
+type splat_star = Token.t
+[@@deriving sexp_of]
+
+type identifier_hash_key = Token.t
 [@@deriving sexp_of]
 
 type float_ =
@@ -105,16 +75,47 @@ type float_ =
   )? *)
 [@@deriving sexp_of]
 
-type global_variable =
-  Token.t (* pattern "\\$-?(([!@&`'+~=\\/\\\\,;.<>*$?:\"])|([0-9]*\
-  )|([a-zA-Z_][a-zA-Z0-9_]*\
-  ))" *)
+type heredoc_body_start = Token.t
+[@@deriving sexp_of]
+
+type integer =
+  Token.t (* pattern 0[bB][01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0[dD])?\d(_?\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])* *)
+[@@deriving sexp_of]
+
+type constant = Token.t
+[@@deriving sexp_of]
+
+type unary_minus = Token.t
+[@@deriving sexp_of]
+
+type complex = Token.t (* pattern (\d+)?(\+|-)?(\d+)i *)
+[@@deriving sexp_of]
+
+type string_content = Token.t
+[@@deriving sexp_of]
+
+type singleton_class_left_angle_left_langle = Token.t
+[@@deriving sexp_of]
+
+type string_start = Token.t
+[@@deriving sexp_of]
+
+type binary_minus = Token.t
+[@@deriving sexp_of]
+
+type class_variable = Token.t
+[@@deriving sexp_of]
+
+type binary_star = Token.t
 [@@deriving sexp_of]
 
 type symbol_array_start = Token.t
 [@@deriving sexp_of]
 
-type heredoc_body_start = Token.t
+type global_variable =
+  Token.t (* pattern "\\$-?(([!@&`'+~=\\/\\\\,;.<>*$?:\"])|([0-9]*\
+  )|([a-zA-Z_][a-zA-Z0-9_]*\
+  ))" *)
 [@@deriving sexp_of]
 
 type operator = [
@@ -155,15 +156,31 @@ type true_ = [
 ]
 [@@deriving sexp_of]
 
-type string_start = Token.t
+type symbol_start = Token.t
 [@@deriving sexp_of]
 
-type identifier_hash_key = Token.t
+type subshell_start = Token.t
 [@@deriving sexp_of]
 
-type terminator = [
-    `Term_line_brk of line_break (*tok*)
-  | `Term_SEMI of Token.t (* ";" *)
+type character =
+  Token.t (* pattern \?(\\\S({[0-9]*}|[0-9]*|-\S([MC]-\S)?)?|\S) *)
+[@@deriving sexp_of]
+
+type identifier = Token.t
+[@@deriving sexp_of]
+
+type line_break = Token.t
+[@@deriving sexp_of]
+
+type uninterpreted = Token.t (* pattern (.|\s)* *)
+[@@deriving sexp_of]
+
+type simple_symbol = Token.t
+[@@deriving sexp_of]
+
+type anon_choice_un_minus = [
+    `Un_minus of unary_minus (*tok*)
+  | `PLUS of Token.t (* "+" *)
 ]
 [@@deriving sexp_of]
 
@@ -178,10 +195,47 @@ type variable = [
 ]
 [@@deriving sexp_of]
 
+type terminator = [
+    `Term_line_brk of line_break (*tok*)
+  | `Term_SEMI of Token.t (* ";" *)
+]
+[@@deriving sexp_of]
+
 type do_ = [ `Do_do of Token.t (* "do" *) | `Do_term of terminator ]
 [@@deriving sexp_of]
 
-type statements = [
+type else_ = (Token.t (* "else" *) * terminator option * statements option)
+
+and block = (
+    Token.t (* "{" *)
+  * block_parameters option
+  * statements option
+  * Token.t (* "}" *)
+)
+
+and in_ = (Token.t (* "in" *) * arg)
+
+and scope_resolution = (
+    [
+        `COLONCOLON of Token.t (* "::" *)
+      | `Prim_COLONCOLON of (primary * Token.t (* "::" *))
+    ]
+  * [ `Id of identifier (*tok*) | `Cst of constant (*tok*) ]
+)
+
+and argument_list_with_trailing_comma = (
+    argument
+  * (Token.t (* "," *) * argument) list (* zero or more *)
+  * Token.t (* "," *) option
+)
+
+and mlhs = (
+    anon_choice_lhs_
+  * (Token.t (* "," *) * anon_choice_lhs_) list (* zero or more *)
+  * Token.t (* "," *) option
+)
+
+and statements = [
     `Stmts_rep1_choice_stmt_term_opt_stmt of (
         [
             `Stmt_term of (statement * terminator)
@@ -192,32 +246,35 @@ type statements = [
     )
   | `Stmts_stmt of statement
 ]
-and statement = [
-    `Stmt_undef of (
-        Token.t (* "undef" *)
-      * method_name
-      * (Token.t (* "," *) * method_name) list (* zero or more *)
-    )
-  | `Stmt_alias of (Token.t (* "alias" *) * method_name * method_name)
-  | `Stmt_if_modi of (statement * Token.t (* "if" *) * expression)
-  | `Stmt_unle_modi of (statement * Token.t (* "unless" *) * expression)
-  | `Stmt_while_modi of (statement * Token.t (* "while" *) * expression)
-  | `Stmt_until_modi of (statement * Token.t (* "until" *) * expression)
-  | `Stmt_resc_modi of (statement * Token.t (* "rescue" *) * expression)
-  | `Stmt_begin_blk of (
-        Token.t (* "BEGIN" *)
-      * Token.t (* "{" *)
-      * statements option
-      * Token.t (* "}" *)
-    )
-  | `Stmt_end_blk of (
-        Token.t (* "END" *)
-      * Token.t (* "{" *)
-      * statements option
-      * Token.t (* "}" *)
-    )
-  | `Stmt_exp of expression
+
+and call = (
+    primary
+  * [ `DOT of Token.t (* "." *) | `AMPDOT of Token.t (* "&." *) ]
+  * [
+        `Id of identifier (*tok*)
+      | `Op of operator
+      | `Cst of constant (*tok*)
+      | `Arg_list of argument_list
+    ]
+)
+
+and anon_choice_lhs = [
+    `Lhs of lhs
+  | `Left_assign_list of left_assignment_list
 ]
+
+and method_call = [
+    `Meth_call_choice_var_arg_list of (anon_choice_var * argument_list)
+  | `Meth_call_choice_var_arg_list_blk of (
+        anon_choice_var * argument_list * block
+    )
+  | `Meth_call_choice_var_arg_list_do_blk of (
+        anon_choice_var * argument_list * do_block
+    )
+  | `Meth_call_choice_var_blk of (anon_choice_var * block)
+  | `Meth_call_choice_var_do_blk of (anon_choice_var * do_block)
+]
+
 and method_rest = (
     method_name
   * [
@@ -226,166 +283,25 @@ and method_rest = (
     ]
   * body_statement
 )
-and parameters = (
-    Token.t (* "(" *)
-  * (
-        formal_parameter
-      * (Token.t (* "," *) * formal_parameter) list (* zero or more *)
-    )
-      option
-  * Token.t (* ")" *)
-)
-and bare_parameters = (
-    simple_formal_parameter
-  * (Token.t (* "," *) * formal_parameter) list (* zero or more *)
-)
-and block_parameters = (
-    Token.t (* "|" *)
-  * (
-        formal_parameter
-      * (Token.t (* "," *) * formal_parameter) list (* zero or more *)
-    )
-      option
-  * Token.t (* "," *) option
-  * (
-        Token.t (* ";" *)
-      * identifier (*tok*)
-      * (Token.t (* "," *) * identifier (*tok*)) list (* zero or more *)
-    )
-      option
-  * Token.t (* "|" *)
-)
-and formal_parameter = [
-    `Form_param_simple_form_param of simple_formal_parameter
-  | `Form_param_params of parameters
-]
-and simple_formal_parameter = [
-    `Simple_form_param_id of identifier (*tok*)
-  | `Simple_form_param_splat_param of (
-        Token.t (* "*" *)
-      * identifier (*tok*) option
-    )
-  | `Simple_form_param_hash_splat_param of (
-        Token.t (* "**" *)
-      * identifier (*tok*) option
-    )
-  | `Simple_form_param_blk_param of (Token.t (* "&" *) * identifier (*tok*))
-  | `Simple_form_param_kw_param of (
-        identifier (*tok*)
-      * Token.t (* ":" *)
-      * arg option
-    )
-  | `Simple_form_param_opt_param of (
-        identifier (*tok*) * Token.t (* "=" *) * arg
-    )
-]
-and superclass = (Token.t (* "<" *) * arg)
-and in_ = (Token.t (* "in" *) * arg)
-and when_ = (
-    Token.t (* "when" *)
-  * pattern
-  * (Token.t (* "," *) * pattern) list (* zero or more *)
-  * [ `Term of terminator | `Then of then_ ]
-)
-and pattern = [ `Pat_arg of arg | `Pat_splat_arg of splat_argument ]
-and elsif = (
-    Token.t (* "elsif" *)
-  * statement
-  * [ `Term of terminator | `Then of then_ ]
-  * [ `Else of else_ | `Elsif of elsif ] option
-)
-and else_ = (Token.t (* "else" *) * terminator option * statements option)
-and then_ = [
-    `Then_term_stmts of (terminator * statements)
-  | `Then_opt_term_then_opt_stmts of (
-        terminator option
-      * Token.t (* "then" *)
-      * statements option
-    )
-]
-and ensure = (Token.t (* "ensure" *) * statements option)
+
 and rescue = (
     Token.t (* "rescue" *)
   * exceptions option
   * exception_variable option
-  * [ `Term of terminator | `Then of then_ ]
+  * anon_choice_term
 )
-and exceptions = (
-    [ `Arg of arg | `Splat_arg of splat_argument ]
-  * (Token.t (* "," *) * [ `Arg of arg | `Splat_arg of splat_argument ])
-      list (* zero or more *)
-)
-and exception_variable = (Token.t (* "=>" *) * lhs)
-and body_statement = (
-    statements option
-  * [ `Resc of rescue | `Else of else_ | `Ensu of ensure ]
-      list (* zero or more *)
-  * Token.t (* "end" *)
-)
-and expression = [
-    `Exp_cmd_bin of (
-        expression
-      * [ `Or of Token.t (* "or" *) | `And of Token.t (* "and" *) ]
-      * expression
-    )
-  | `Exp_cmd_assign of command_assignment
-  | `Exp_cmd_op_assign of (
-        lhs
-      * [
-            `PLUSEQ of Token.t (* "+=" *)
-          | `DASHEQ of Token.t (* "-=" *)
-          | `STAREQ of Token.t (* "*=" *)
-          | `STARSTAREQ of Token.t (* "**=" *)
-          | `SLASHEQ of Token.t (* "/=" *)
-          | `BARBAREQ of Token.t (* "||=" *)
-          | `BAREQ of Token.t (* "|=" *)
-          | `AMPAMPEQ of Token.t (* "&&=" *)
-          | `AMPEQ of Token.t (* "&=" *)
-          | `PERCEQ of Token.t (* "%=" *)
-          | `GTGTEQ of Token.t (* ">>=" *)
-          | `LTLTEQ of Token.t (* "<<=" *)
-          | `HATEQ of Token.t (* "^=" *)
-        ]
-      * expression
-    )
-  | `Exp_cmd_call of command_call
-  | `Exp_ret_cmd of (Token.t (* "return" *) * command_argument_list)
-  | `Exp_yield_cmd of (Token.t (* "yield" *) * command_argument_list)
-  | `Exp_brk_cmd of (Token.t (* "break" *) * command_argument_list)
-  | `Exp_next_cmd of (Token.t (* "next" *) * command_argument_list)
-  | `Exp_arg of arg
+
+and anon_choice_var = [
+    `Var of variable
+  | `Scope_resol of scope_resolution
+  | `Call of call
 ]
-and arg = [
-    `Arg_prim of primary
-  | `Arg_assign of assignment
-  | `Arg_op_assign of (
-        lhs
-      * [
-            `PLUSEQ of Token.t (* "+=" *)
-          | `DASHEQ of Token.t (* "-=" *)
-          | `STAREQ of Token.t (* "*=" *)
-          | `STARSTAREQ of Token.t (* "**=" *)
-          | `SLASHEQ of Token.t (* "/=" *)
-          | `BARBAREQ of Token.t (* "||=" *)
-          | `BAREQ of Token.t (* "|=" *)
-          | `AMPAMPEQ of Token.t (* "&&=" *)
-          | `AMPEQ of Token.t (* "&=" *)
-          | `PERCEQ of Token.t (* "%=" *)
-          | `GTGTEQ of Token.t (* ">>=" *)
-          | `LTLTEQ of Token.t (* "<<=" *)
-          | `HATEQ of Token.t (* "^=" *)
-        ]
-      * arg
-    )
-  | `Arg_cond of (arg * Token.t (* "?" *) * arg * Token.t (* ":" *) * arg)
-  | `Arg_range of (
-        arg
-      * [ `DOTDOT of Token.t (* ".." *) | `DOTDOTDOT of Token.t (* "..." *) ]
-      * arg
-    )
-  | `Arg_bin of binary
-  | `Arg_un of unary
+
+and anon_choice_pair = [
+    `Pair of pair
+  | `Hash_splat_arg of hash_splat_argument
 ]
+
 and primary = [
     `Prim_paren_stmts of parenthesized_statements
   | `Prim_lhs of lhs
@@ -397,34 +313,22 @@ and primary = [
   | `Prim_str_array of (
         string_array_start (*tok*)
       * unit (* blank *) option
-      * (
-            literal_contents
-          * (unit (* blank *) * literal_contents) list (* zero or more *)
-        )
-          option
+      * anon_lit_content_rep_blank_lit_content option
       * unit (* blank *) option
       * string_end (*tok*)
     )
   | `Prim_symb_array of (
         symbol_array_start (*tok*)
       * unit (* blank *) option
-      * (
-            literal_contents
-          * (unit (* blank *) * literal_contents) list (* zero or more *)
-        )
-          option
+      * anon_lit_content_rep_blank_lit_content option
       * unit (* blank *) option
       * string_end (*tok*)
     )
   | `Prim_hash of (
         Token.t (* "{" *)
       * (
-            [ `Pair of pair | `Hash_splat_arg of hash_splat_argument ]
-          * (
-                Token.t (* "," *)
-              * [ `Pair of pair | `Hash_splat_arg of hash_splat_argument ]
-            )
-              list (* zero or more *)
+            anon_choice_pair
+          * (Token.t (* "," *) * anon_choice_pair) list (* zero or more *)
           * Token.t (* "," *) option
         )
           option
@@ -465,7 +369,7 @@ and primary = [
     )
   | `Prim_class of (
         Token.t (* "class" *)
-      * [ `Cst of constant (*tok*) | `Scope_resol of scope_resolution ]
+      * anon_choice_cst
       * superclass option
       * terminator
       * body_statement
@@ -477,7 +381,7 @@ and primary = [
     )
   | `Prim_modu of (
         Token.t (* "module" *)
-      * [ `Cst of constant (*tok*) | `Scope_resol of scope_resolution ]
+      * anon_choice_cst
       * [
             `Term_body_stmt of (terminator * body_statement)
           | `End of Token.t (* "end" *)
@@ -505,20 +409,20 @@ and primary = [
   | `Prim_if of (
         Token.t (* "if" *)
       * statement
-      * [ `Term of terminator | `Then of then_ ]
-      * [ `Else of else_ | `Elsif of elsif ] option
+      * anon_choice_term
+      * anon_choice_else option
       * Token.t (* "end" *)
     )
   | `Prim_unle of (
         Token.t (* "unless" *)
       * statement
-      * [ `Term of terminator | `Then of then_ ]
-      * [ `Else of else_ | `Elsif of elsif ] option
+      * anon_choice_term
+      * anon_choice_else option
       * Token.t (* "end" *)
     )
   | `Prim_for of (
         Token.t (* "for" *)
-      * mlhs
+      * left_assignment_list
       * in_
       * do_
       * statements option
@@ -544,122 +448,12 @@ and primary = [
       * parenthesized_statements
     )
   | `Prim_un_lit of (
-        [ `Un_minus of unary_minus (*tok*) | `PLUS of Token.t (* "+" *) ]
+        anon_choice_un_minus
       * [ `Int of integer (*tok*) | `Float of float_ (*tok*) ]
     )
   | `Prim_here_begin of heredoc_beginning (*tok*)
 ]
-and parenthesized_statements = (
-    Token.t (* "(" *)
-  * statements option
-  * Token.t (* ")" *)
-)
-and scope_resolution = (
-    [
-        `COLONCOLON of Token.t (* "::" *)
-      | `Prim_COLONCOLON of (primary * Token.t (* "::" *))
-    ]
-  * [ `Id of identifier (*tok*) | `Cst of constant (*tok*) ]
-)
-and call = (
-    primary
-  * [ `DOT of Token.t (* "." *) | `AMPDOT of Token.t (* "&." *) ]
-  * [
-        `Id of identifier (*tok*)
-      | `Op of operator
-      | `Cst of constant (*tok*)
-      | `Arg_list of argument_list
-    ]
-)
-and command_call = [
-    `Cmd_call_choice_var_cmd_arg_list of (
-        [
-            `Var of variable
-          | `Scope_resol of scope_resolution
-          | `Call of call
-        ]
-      * command_argument_list
-    )
-  | `Cmd_call_choice_var_cmd_arg_list_blk of (
-        [
-            `Var of variable
-          | `Scope_resol of scope_resolution
-          | `Call of call
-        ]
-      * command_argument_list
-      * block
-    )
-  | `Cmd_call_choice_var_cmd_arg_list_do_blk of (
-        [
-            `Var of variable
-          | `Scope_resol of scope_resolution
-          | `Call of call
-        ]
-      * command_argument_list
-      * do_block
-    )
-]
-and method_call = [
-    `Meth_call_choice_var_arg_list of (
-        [
-            `Var of variable
-          | `Scope_resol of scope_resolution
-          | `Call of call
-        ]
-      * argument_list
-    )
-  | `Meth_call_choice_var_arg_list_blk of (
-        [
-            `Var of variable
-          | `Scope_resol of scope_resolution
-          | `Call of call
-        ]
-      * argument_list
-      * block
-    )
-  | `Meth_call_choice_var_arg_list_do_blk of (
-        [
-            `Var of variable
-          | `Scope_resol of scope_resolution
-          | `Call of call
-        ]
-      * argument_list
-      * do_block
-    )
-  | `Meth_call_choice_var_blk of (
-        [
-            `Var of variable
-          | `Scope_resol of scope_resolution
-          | `Call of call
-        ]
-      * block
-    )
-  | `Meth_call_choice_var_do_blk of (
-        [
-            `Var of variable
-          | `Scope_resol of scope_resolution
-          | `Call of call
-        ]
-      * do_block
-    )
-]
-and command_argument_list = [
-    `Cmd_arg_list_arg_rep_COMMA_arg of (
-        argument
-      * (Token.t (* "," *) * argument) list (* zero or more *)
-    )
-  | `Cmd_arg_list_cmd_call of command_call
-]
-and argument_list = (
-    Token.t (* "(" *)
-  * argument_list_with_trailing_comma option
-  * Token.t (* ")" *)
-)
-and argument_list_with_trailing_comma = (
-    argument
-  * (Token.t (* "," *) * argument) list (* zero or more *)
-  * Token.t (* "," *) option
-)
+
 and argument = [
     `Arg_arg of arg
   | `Arg_splat_arg of splat_argument
@@ -667,38 +461,26 @@ and argument = [
   | `Arg_blk_arg of (block_ampersand (*tok*) * arg)
   | `Arg_pair of pair
 ]
-and splat_argument = (splat_star (*tok*) * arg)
-and hash_splat_argument = (Token.t (* "**" *) * arg)
-and do_block = (
-    Token.t (* "do" *)
-  * terminator option
-  * (block_parameters * terminator option) option
-  * body_statement
-)
-and block = (
-    Token.t (* "{" *)
-  * block_parameters option
+
+and parenthesized_statements = (
+    Token.t (* "(" *)
   * statements option
-  * Token.t (* "}" *)
+  * Token.t (* ")" *)
 )
-and assignment = [
-  `Choice_lhs_EQ_choice_arg of (
-      [ `Lhs of lhs | `Left_assign_list of left_assignment_list ]
-    * Token.t (* "=" *)
-    * [
-          `Arg of arg
-        | `Splat_arg of splat_argument
-        | `Right_assign_list of right_assignment_list
-      ]
-  )
-]
-and command_assignment = [
-  `Choice_lhs_EQ_exp of (
-      [ `Lhs of lhs | `Left_assign_list of left_assignment_list ]
-    * Token.t (* "=" *)
-    * expression
-  )
-]
+
+and string_ = (
+    string_start (*tok*)
+  * literal_contents option
+  * string_end (*tok*)
+)
+
+and body_statement = (
+    statements option
+  * [ `Resc of rescue | `Else of else_ | `Ensu of ensure ]
+      list (* zero or more *)
+  * Token.t (* "end" *)
+)
+
 and binary = [
     `Bin_arg_and_arg of (arg * Token.t (* "and" *) * arg)
   | `Bin_arg_or_arg of (arg * Token.t (* "or" *) * arg)
@@ -753,45 +535,16 @@ and binary = [
     )
   | `Bin_arg_STARSTAR_arg of (arg * Token.t (* "**" *) * arg)
 ]
-and unary = [
-    `Un_defi_arg of (Token.t (* "defined?" *) * arg)
-  | `Un_not_arg of (Token.t (* "not" *) * arg)
-  | `Un_choice_un_minus_arg of (
-        [ `Un_minus of unary_minus (*tok*) | `PLUS of Token.t (* "+" *) ]
-      * arg
-    )
-  | `Un_choice_BANG_arg of (
-        [ `BANG of Token.t (* "!" *) | `TILDE of Token.t (* "~" *) ]
-      * arg
+
+and then_ = [
+    `Then_term_stmts of (terminator * statements)
+  | `Then_opt_term_then_opt_stmts of (
+        terminator option
+      * Token.t (* "then" *)
+      * statements option
     )
 ]
-and right_assignment_list = (
-    [ `Arg of arg | `Splat_arg of splat_argument ]
-  * (Token.t (* "," *) * [ `Arg of arg | `Splat_arg of splat_argument ])
-      list (* zero or more *)
-)
-and left_assignment_list = mlhs
-and mlhs = (
-    [
-        `Lhs of lhs
-      | `Rest_assign of rest_assignment
-      | `Dest_left_assign of destructured_left_assignment
-    ]
-  * (
-        Token.t (* "," *)
-      * [
-            `Lhs of lhs
-          | `Rest_assign of rest_assignment
-          | `Dest_left_assign of destructured_left_assignment
-        ]
-    )
-      list (* zero or more *)
-  * Token.t (* "," *) option
-)
-and destructured_left_assignment = (
-    Token.t (* "(" *) * mlhs * Token.t (* ")" *)
-)
-and rest_assignment = (Token.t (* "*" *) * lhs option)
+
 and lhs = [
     `Var of variable
   | `True of true_
@@ -807,37 +560,64 @@ and lhs = [
   | `Call of call
   | `Meth_call of method_call
 ]
-and method_name = [
-    `Meth_name_id of identifier (*tok*)
-  | `Meth_name_cst of constant (*tok*)
-  | `Meth_name_sett of (identifier (*tok*) * Token.t (* "=" *))
-  | `Meth_name_symb of symbol
-  | `Meth_name_op of operator
-  | `Meth_name_inst_var of instance_variable (*tok*)
-  | `Meth_name_class_var of class_variable (*tok*)
-  | `Meth_name_glob_var of global_variable (*tok*)
-]
-and interpolation = (Token.t (* "#{" *) * statement * Token.t (* "}" *))
-and string_ = (
-    string_start (*tok*)
-  * literal_contents option
-  * string_end (*tok*)
-)
-and symbol = [
-    `Symb_simple_symb of simple_symbol (*tok*)
-  | `Symb_symb_start_opt_lit_content_str_end of (
-        symbol_start (*tok*)
-      * literal_contents option
-      * string_end (*tok*)
+
+and unary = [
+    `Un_defi_arg of (Token.t (* "defined?" *) * arg)
+  | `Un_not_arg of (Token.t (* "not" *) * arg)
+  | `Un_choice_un_minus_arg of (anon_choice_un_minus * arg)
+  | `Un_choice_BANG_arg of (
+        [ `BANG of Token.t (* "!" *) | `TILDE of Token.t (* "~" *) ]
+      * arg
     )
 ]
-and literal_contents =
-  [
-      `Str_content of string_content (*tok*)
-    | `Interp of interpolation
-    | `Esc_seq of escape_sequence (*tok*)
-  ]
-    list (* one or more *)
+
+and expression = [
+    `Exp_cmd_bin of (
+        expression
+      * [ `Or of Token.t (* "or" *) | `And of Token.t (* "and" *) ]
+      * expression
+    )
+  | `Exp_cmd_assign of command_assignment
+  | `Exp_cmd_op_assign of (lhs * anon_choice_PLUSEQ * expression)
+  | `Exp_cmd_call of command_call
+  | `Exp_ret_cmd of (Token.t (* "return" *) * command_argument_list)
+  | `Exp_yield_cmd of (Token.t (* "yield" *) * command_argument_list)
+  | `Exp_brk_cmd of (Token.t (* "break" *) * command_argument_list)
+  | `Exp_next_cmd of (Token.t (* "next" *) * command_argument_list)
+  | `Exp_arg of arg
+]
+
+and arg = [
+    `Arg_prim of primary
+  | `Arg_assign of assignment
+  | `Arg_op_assign of (lhs * anon_choice_PLUSEQ * arg)
+  | `Arg_cond of (arg * Token.t (* "?" *) * arg * Token.t (* ":" *) * arg)
+  | `Arg_range of (
+        arg
+      * [ `DOTDOT of Token.t (* ".." *) | `DOTDOTDOT of Token.t (* "..." *) ]
+      * arg
+    )
+  | `Arg_bin of binary
+  | `Arg_un of unary
+]
+
+and right_assignment_list = (
+    anon_choice_arg
+  * (Token.t (* "," *) * anon_choice_arg) list (* zero or more *)
+)
+
+and do_block = (
+    Token.t (* "do" *)
+  * terminator option
+  * (block_parameters * terminator option) option
+  * body_statement
+)
+
+and anon_form_param_rep_COMMA_form_param = (
+    formal_parameter
+  * (Token.t (* "," *) * formal_parameter) list (* zero or more *)
+)
+
 and pair = [
     `Pair_arg_EQGT_arg of (arg * Token.t (* "=>" *) * arg)
   | `Pair_choice_id_hash_key_COLON_arg of (
@@ -851,6 +631,213 @@ and pair = [
       * arg
     )
 ]
+
+and assignment = [
+  `Choice_lhs_EQ_choice_arg of (
+      anon_choice_lhs
+    * Token.t (* "=" *)
+    * [
+          `Arg of arg
+        | `Splat_arg of splat_argument
+        | `Right_assign_list of right_assignment_list
+      ]
+  )
+]
+
+and literal_contents =
+  [
+      `Str_content of string_content (*tok*)
+    | `Interp of interpolation
+    | `Esc_seq of escape_sequence (*tok*)
+  ]
+    list (* one or more *)
+
+and anon_lit_content_rep_blank_lit_content = (
+    literal_contents
+  * (unit (* blank *) * literal_contents) list (* zero or more *)
+)
+
+and when_ = (
+    Token.t (* "when" *)
+  * pattern
+  * (Token.t (* "," *) * pattern) list (* zero or more *)
+  * anon_choice_term
+)
+
+and bare_parameters = (
+    simple_formal_parameter
+  * (Token.t (* "," *) * formal_parameter) list (* zero or more *)
+)
+
+and statement = [
+    `Stmt_undef of (
+        Token.t (* "undef" *)
+      * method_name
+      * (Token.t (* "," *) * method_name) list (* zero or more *)
+    )
+  | `Stmt_alias of (Token.t (* "alias" *) * method_name * method_name)
+  | `Stmt_if_modi of (statement * Token.t (* "if" *) * expression)
+  | `Stmt_unle_modi of (statement * Token.t (* "unless" *) * expression)
+  | `Stmt_while_modi of (statement * Token.t (* "while" *) * expression)
+  | `Stmt_until_modi of (statement * Token.t (* "until" *) * expression)
+  | `Stmt_resc_modi of (statement * Token.t (* "rescue" *) * expression)
+  | `Stmt_begin_blk of (
+        Token.t (* "BEGIN" *)
+      * Token.t (* "{" *)
+      * statements option
+      * Token.t (* "}" *)
+    )
+  | `Stmt_end_blk of (
+        Token.t (* "END" *)
+      * Token.t (* "{" *)
+      * statements option
+      * Token.t (* "}" *)
+    )
+  | `Stmt_exp of expression
+]
+
+and anon_choice_cst = [
+    `Cst of constant (*tok*)
+  | `Scope_resol of scope_resolution
+]
+
+and command_assignment = [
+  `Choice_lhs_EQ_exp of (anon_choice_lhs * Token.t (* "=" *) * expression)
+]
+
+and splat_argument = (splat_star (*tok*) * arg)
+
+and exceptions = (
+    anon_choice_arg
+  * (Token.t (* "," *) * anon_choice_arg) list (* zero or more *)
+)
+
+and symbol = [
+    `Symb_simple_symb of simple_symbol (*tok*)
+  | `Symb_symb_start_opt_lit_content_str_end of (
+        symbol_start (*tok*)
+      * literal_contents option
+      * string_end (*tok*)
+    )
+]
+
+and anon_choice_arg = [ `Arg of arg | `Splat_arg of splat_argument ]
+
+and ensure = (Token.t (* "ensure" *) * statements option)
+
+and command_call = [
+    `Cmd_call_choice_var_cmd_arg_list of (
+        anon_choice_var * command_argument_list
+    )
+  | `Cmd_call_choice_var_cmd_arg_list_blk of (
+        anon_choice_var * command_argument_list * block
+    )
+  | `Cmd_call_choice_var_cmd_arg_list_do_blk of (
+        anon_choice_var * command_argument_list * do_block
+    )
+]
+
+and hash_splat_argument = (Token.t (* "**" *) * arg)
+
+and exception_variable = (Token.t (* "=>" *) * lhs)
+
+and method_name = [
+    `Meth_name_id of identifier (*tok*)
+  | `Meth_name_cst of constant (*tok*)
+  | `Meth_name_sett of (identifier (*tok*) * Token.t (* "=" *))
+  | `Meth_name_symb of symbol
+  | `Meth_name_op of operator
+  | `Meth_name_inst_var of instance_variable (*tok*)
+  | `Meth_name_class_var of class_variable (*tok*)
+  | `Meth_name_glob_var of global_variable (*tok*)
+]
+
+and block_parameters = (
+    Token.t (* "|" *)
+  * anon_form_param_rep_COMMA_form_param option
+  * Token.t (* "," *) option
+  * (
+        Token.t (* ";" *)
+      * identifier (*tok*)
+      * (Token.t (* "," *) * identifier (*tok*)) list (* zero or more *)
+    )
+      option
+  * Token.t (* "|" *)
+)
+
+and superclass = (Token.t (* "<" *) * arg)
+
+and anon_choice_lhs_ = [
+    `Lhs of lhs
+  | `Rest_assign of (Token.t (* "*" *) * lhs option)
+  | `Dest_left_assign of (
+        Token.t (* "(" *) * left_assignment_list * Token.t (* ")" *)
+    )
+]
+
+and pattern = [ `Pat_arg of arg | `Pat_splat_arg of splat_argument ]
+
+and command_argument_list = [
+    `Cmd_arg_list_arg_rep_COMMA_arg of (
+        argument
+      * (Token.t (* "," *) * argument) list (* zero or more *)
+    )
+  | `Cmd_arg_list_cmd_call of command_call
+]
+
+and argument_list = (
+    Token.t (* "(" *)
+  * argument_list_with_trailing_comma option
+  * Token.t (* ")" *)
+)
+
+and left_assignment_list = mlhs
+
+and parameters = (
+    Token.t (* "(" *)
+  * anon_form_param_rep_COMMA_form_param option
+  * Token.t (* ")" *)
+)
+
+and anon_choice_term = [ `Term of terminator | `Then of then_ ]
+
+and simple_formal_parameter = [
+    `Simple_form_param_id of identifier (*tok*)
+  | `Simple_form_param_splat_param of (
+        Token.t (* "*" *)
+      * identifier (*tok*) option
+    )
+  | `Simple_form_param_hash_splat_param of (
+        Token.t (* "**" *)
+      * identifier (*tok*) option
+    )
+  | `Simple_form_param_blk_param of (Token.t (* "&" *) * identifier (*tok*))
+  | `Simple_form_param_kw_param of (
+        identifier (*tok*)
+      * Token.t (* ":" *)
+      * arg option
+    )
+  | `Simple_form_param_opt_param of (
+        identifier (*tok*) * Token.t (* "=" *) * arg
+    )
+]
+
+and interpolation = (Token.t (* "#{" *) * statement * Token.t (* "}" *))
+
+and formal_parameter = [
+    `Form_param_simple_form_param of simple_formal_parameter
+  | `Form_param_params of parameters
+]
+
+and anon_choice_else = [
+    `Else of else_
+  | `Elsif of (
+        Token.t (* "elsif" *)
+      * statement
+      * anon_choice_term
+      * anon_choice_else option
+    )
+]
 [@@deriving sexp_of]
 
 type program = (
@@ -860,25 +847,19 @@ type program = (
 )
 [@@deriving sexp_of]
 
-type self (* inlined *) = Token.t (* "self" *)
+type comment (* inlined *) = Token.t
 [@@deriving sexp_of]
 
 type empty_statement (* inlined *) = Token.t (* ";" *)
 [@@deriving sexp_of]
 
-type comment (* inlined *) = Token.t
+type self (* inlined *) = Token.t (* "self" *)
 [@@deriving sexp_of]
 
 type super (* inlined *) = Token.t (* "super" *)
 [@@deriving sexp_of]
 
 type rational (* inlined *) = (integer (*tok*) * Token.t (* "r" *))
-[@@deriving sexp_of]
-
-type hash_splat_parameter (* inlined *) = (
-    Token.t (* "**" *)
-  * identifier (*tok*) option
-)
 [@@deriving sexp_of]
 
 type splat_parameter (* inlined *) = (
@@ -893,29 +874,21 @@ type setter (* inlined *) = (identifier (*tok*) * Token.t (* "=" *))
 type block_parameter (* inlined *) = (Token.t (* "&" *) * identifier (*tok*))
 [@@deriving sexp_of]
 
+type hash_splat_parameter (* inlined *) = (
+    Token.t (* "**" *)
+  * identifier (*tok*) option
+)
+[@@deriving sexp_of]
+
 type unary_literal (* inlined *) = (
-    [ `Un_minus of unary_minus (*tok*) | `PLUS of Token.t (* "+" *) ]
+    anon_choice_un_minus
   * [ `Int of integer (*tok*) | `Float of float_ (*tok*) ]
 )
 [@@deriving sexp_of]
 
-type begin_block (* inlined *) = (
-    Token.t (* "BEGIN" *)
-  * Token.t (* "{" *)
-  * statements option
-  * Token.t (* "}" *)
+type while_modifier (* inlined *) = (
+    statement * Token.t (* "while" *) * expression
 )
-[@@deriving sexp_of]
-
-type end_block (* inlined *) = (
-    Token.t (* "END" *)
-  * Token.t (* "{" *)
-  * statements option
-  * Token.t (* "}" *)
-)
-[@@deriving sexp_of]
-
-type method_ (* inlined *) = (Token.t (* "def" *) * method_rest)
 [@@deriving sexp_of]
 
 type singleton_method (* inlined *) = (
@@ -929,45 +902,15 @@ type singleton_method (* inlined *) = (
 )
 [@@deriving sexp_of]
 
-type keyword_parameter (* inlined *) = (
-    identifier (*tok*)
-  * Token.t (* ":" *)
-  * arg option
-)
-[@@deriving sexp_of]
-
-type optional_parameter (* inlined *) = (
-    identifier (*tok*) * Token.t (* "=" *) * arg
-)
-[@@deriving sexp_of]
-
-type class_ (* inlined *) = (
-    Token.t (* "class" *)
-  * [ `Cst of constant (*tok*) | `Scope_resol of scope_resolution ]
-  * superclass option
-  * terminator
-  * body_statement
-)
-[@@deriving sexp_of]
-
-type singleton_class (* inlined *) = (
-    Token.t (* "class" *) * singleton_class_left_angle_left_langle (*tok*)
-  * arg * terminator * body_statement
-)
-[@@deriving sexp_of]
-
-type module_ (* inlined *) = (
-    Token.t (* "module" *)
-  * [ `Cst of constant (*tok*) | `Scope_resol of scope_resolution ]
-  * [
-        `Term_body_stmt of (terminator * body_statement)
-      | `End of Token.t (* "end" *)
-    ]
-)
-[@@deriving sexp_of]
-
-type return_command (* inlined *) = (
-    Token.t (* "return" *) * command_argument_list
+type hash (* inlined *) = (
+    Token.t (* "{" *)
+  * (
+        anon_choice_pair
+      * (Token.t (* "," *) * anon_choice_pair) list (* zero or more *)
+      * Token.t (* "," *) option
+    )
+      option
+  * Token.t (* "}" *)
 )
 [@@deriving sexp_of]
 
@@ -976,65 +919,25 @@ type yield_command (* inlined *) = (
 )
 [@@deriving sexp_of]
 
-type break_command (* inlined *) = (
-    Token.t (* "break" *) * command_argument_list
+type yield (* inlined *) = (Token.t (* "yield" *) * argument_list option)
+[@@deriving sexp_of]
+
+type undef (* inlined *) = (
+    Token.t (* "undef" *)
+  * method_name
+  * (Token.t (* "," *) * method_name) list (* zero or more *)
+)
+[@@deriving sexp_of]
+
+type command_binary (* inlined *) = (
+    expression
+  * [ `Or of Token.t (* "or" *) | `And of Token.t (* "and" *) ]
+  * expression
 )
 [@@deriving sexp_of]
 
 type next_command (* inlined *) = (
     Token.t (* "next" *) * command_argument_list
-)
-[@@deriving sexp_of]
-
-type return (* inlined *) = (Token.t (* "return" *) * argument_list option)
-[@@deriving sexp_of]
-
-type yield (* inlined *) = (Token.t (* "yield" *) * argument_list option)
-[@@deriving sexp_of]
-
-type break (* inlined *) = (Token.t (* "break" *) * argument_list option)
-[@@deriving sexp_of]
-
-type next (* inlined *) = (Token.t (* "next" *) * argument_list option)
-[@@deriving sexp_of]
-
-type redo (* inlined *) = (Token.t (* "redo" *) * argument_list option)
-[@@deriving sexp_of]
-
-type retry (* inlined *) = (Token.t (* "retry" *) * argument_list option)
-[@@deriving sexp_of]
-
-type if_modifier (* inlined *) = (
-    statement * Token.t (* "if" *) * expression
-)
-[@@deriving sexp_of]
-
-type unless_modifier (* inlined *) = (
-    statement * Token.t (* "unless" *) * expression
-)
-[@@deriving sexp_of]
-
-type while_modifier (* inlined *) = (
-    statement * Token.t (* "while" *) * expression
-)
-[@@deriving sexp_of]
-
-type until_modifier (* inlined *) = (
-    statement * Token.t (* "until" *) * expression
-)
-[@@deriving sexp_of]
-
-type rescue_modifier (* inlined *) = (
-    statement * Token.t (* "rescue" *) * expression
-)
-[@@deriving sexp_of]
-
-type while_ (* inlined *) = (
-    Token.t (* "while" *)
-  * arg
-  * do_
-  * statements option
-  * Token.t (* "end" *)
 )
 [@@deriving sexp_of]
 
@@ -1047,13 +950,60 @@ type until (* inlined *) = (
 )
 [@@deriving sexp_of]
 
-type for_ (* inlined *) = (
-    Token.t (* "for" *)
-  * mlhs
-  * in_
-  * do_
-  * statements option
+type unless (* inlined *) = (
+    Token.t (* "unless" *)
+  * statement
+  * anon_choice_term
+  * anon_choice_else option
   * Token.t (* "end" *)
+)
+[@@deriving sexp_of]
+
+type break (* inlined *) = (Token.t (* "break" *) * argument_list option)
+[@@deriving sexp_of]
+
+type next (* inlined *) = (Token.t (* "next" *) * argument_list option)
+[@@deriving sexp_of]
+
+type begin_block (* inlined *) = (
+    Token.t (* "BEGIN" *)
+  * Token.t (* "{" *)
+  * statements option
+  * Token.t (* "}" *)
+)
+[@@deriving sexp_of]
+
+type return (* inlined *) = (Token.t (* "return" *) * argument_list option)
+[@@deriving sexp_of]
+
+type parenthesized_unary (* inlined *) = (
+    [ `Defi of Token.t (* "defined?" *) | `Not of Token.t (* "not" *) ]
+  * parenthesized_statements
+)
+[@@deriving sexp_of]
+
+type range (* inlined *) = (
+    arg
+  * [ `DOTDOT of Token.t (* ".." *) | `DOTDOTDOT of Token.t (* "..." *) ]
+  * arg
+)
+[@@deriving sexp_of]
+
+type element_reference (* inlined *) = (
+    primary
+  * Token.t (* "[" *)
+  * argument_list_with_trailing_comma option
+  * Token.t (* "]" *)
+)
+[@@deriving sexp_of]
+
+type module_ (* inlined *) = (
+    Token.t (* "module" *)
+  * anon_choice_cst
+  * [
+        `Term_body_stmt of (terminator * body_statement)
+      | `End of Token.t (* "end" *)
+    ]
 )
 [@@deriving sexp_of]
 
@@ -1068,125 +1018,20 @@ type case (* inlined *) = (
 )
 [@@deriving sexp_of]
 
-type if_ (* inlined *) = (
-    Token.t (* "if" *)
+type elsif (* inlined *) = (
+    Token.t (* "elsif" *)
   * statement
-  * [ `Term of terminator | `Then of then_ ]
-  * [ `Else of else_ | `Elsif of elsif ] option
-  * Token.t (* "end" *)
+  * anon_choice_term
+  * anon_choice_else option
 )
 [@@deriving sexp_of]
 
-type unless (* inlined *) = (
-    Token.t (* "unless" *)
-  * statement
-  * [ `Term of terminator | `Then of then_ ]
-  * [ `Else of else_ | `Elsif of elsif ] option
-  * Token.t (* "end" *)
+type unless_modifier (* inlined *) = (
+    statement * Token.t (* "unless" *) * expression
 )
 [@@deriving sexp_of]
 
-type begin_ (* inlined *) = (
-    Token.t (* "begin" *)
-  * terminator option
-  * body_statement
-)
-[@@deriving sexp_of]
-
-type element_reference (* inlined *) = (
-    primary
-  * Token.t (* "[" *)
-  * argument_list_with_trailing_comma option
-  * Token.t (* "]" *)
-)
-[@@deriving sexp_of]
-
-type block_argument (* inlined *) = (block_ampersand (*tok*) * arg)
-[@@deriving sexp_of]
-
-type operator_assignment (* inlined *) = (
-    lhs
-  * [
-        `PLUSEQ of Token.t (* "+=" *)
-      | `DASHEQ of Token.t (* "-=" *)
-      | `STAREQ of Token.t (* "*=" *)
-      | `STARSTAREQ of Token.t (* "**=" *)
-      | `SLASHEQ of Token.t (* "/=" *)
-      | `BARBAREQ of Token.t (* "||=" *)
-      | `BAREQ of Token.t (* "|=" *)
-      | `AMPAMPEQ of Token.t (* "&&=" *)
-      | `AMPEQ of Token.t (* "&=" *)
-      | `PERCEQ of Token.t (* "%=" *)
-      | `GTGTEQ of Token.t (* ">>=" *)
-      | `LTLTEQ of Token.t (* "<<=" *)
-      | `HATEQ of Token.t (* "^=" *)
-    ]
-  * arg
-)
-[@@deriving sexp_of]
-
-type command_operator_assignment (* inlined *) = (
-    lhs
-  * [
-        `PLUSEQ of Token.t (* "+=" *)
-      | `DASHEQ of Token.t (* "-=" *)
-      | `STAREQ of Token.t (* "*=" *)
-      | `STARSTAREQ of Token.t (* "**=" *)
-      | `SLASHEQ of Token.t (* "/=" *)
-      | `BARBAREQ of Token.t (* "||=" *)
-      | `BAREQ of Token.t (* "|=" *)
-      | `AMPAMPEQ of Token.t (* "&&=" *)
-      | `AMPEQ of Token.t (* "&=" *)
-      | `PERCEQ of Token.t (* "%=" *)
-      | `GTGTEQ of Token.t (* ">>=" *)
-      | `LTLTEQ of Token.t (* "<<=" *)
-      | `HATEQ of Token.t (* "^=" *)
-    ]
-  * expression
-)
-[@@deriving sexp_of]
-
-type conditional (* inlined *) = (
-    arg * Token.t (* "?" *) * arg * Token.t (* ":" *) * arg
-)
-[@@deriving sexp_of]
-
-type range (* inlined *) = (
-    arg
-  * [ `DOTDOT of Token.t (* ".." *) | `DOTDOTDOT of Token.t (* "..." *) ]
-  * arg
-)
-[@@deriving sexp_of]
-
-type command_binary (* inlined *) = (
-    expression
-  * [ `Or of Token.t (* "or" *) | `And of Token.t (* "and" *) ]
-  * expression
-)
-[@@deriving sexp_of]
-
-type parenthesized_unary (* inlined *) = (
-    [ `Defi of Token.t (* "defined?" *) | `Not of Token.t (* "not" *) ]
-  * parenthesized_statements
-)
-[@@deriving sexp_of]
-
-type undef (* inlined *) = (
-    Token.t (* "undef" *)
-  * method_name
-  * (Token.t (* "," *) * method_name) list (* zero or more *)
-)
-[@@deriving sexp_of]
-
-type alias (* inlined *) = (
-    Token.t (* "alias" *) * method_name * method_name
-)
-[@@deriving sexp_of]
-
-type chained_string (* inlined *) = (
-    string_
-  * string_ list (* one or more *)
-)
+type operator_assignment (* inlined *) = (lhs * anon_choice_PLUSEQ * arg)
 [@@deriving sexp_of]
 
 type subshell (* inlined *) = (
@@ -1196,37 +1041,28 @@ type subshell (* inlined *) = (
 )
 [@@deriving sexp_of]
 
-type string_array (* inlined *) = (
-    string_array_start (*tok*)
-  * unit (* blank *) option
-  * (
-        literal_contents
-      * (unit (* blank *) * literal_contents) list (* zero or more *)
-    )
-      option
-  * unit (* blank *) option
-  * string_end (*tok*)
+type lambda (* inlined *) = (
+    Token.t (* "->" *)
+  * [ `Params of parameters | `Bare_params of bare_parameters ] option
+  * [ `Blk of block | `Do_blk of do_block ]
 )
 [@@deriving sexp_of]
 
-type symbol_array (* inlined *) = (
-    symbol_array_start (*tok*)
-  * unit (* blank *) option
-  * (
-        literal_contents
-      * (unit (* blank *) * literal_contents) list (* zero or more *)
-    )
-      option
-  * unit (* blank *) option
-  * string_end (*tok*)
+type chained_string (* inlined *) = (
+    string_
+  * string_ list (* one or more *)
 )
 [@@deriving sexp_of]
 
-type regex (* inlined *) = (
-    regex_start (*tok*)
-  * literal_contents option
-  * string_end (*tok*)
+type method_ (* inlined *) = (Token.t (* "def" *) * method_rest)
+[@@deriving sexp_of]
+
+type conditional (* inlined *) = (
+    arg * Token.t (* "?" *) * arg * Token.t (* ":" *) * arg
 )
+[@@deriving sexp_of]
+
+type retry (* inlined *) = (Token.t (* "retry" *) * argument_list option)
 [@@deriving sexp_of]
 
 type array_ (* inlined *) = (
@@ -1236,26 +1072,147 @@ type array_ (* inlined *) = (
 )
 [@@deriving sexp_of]
 
-type hash (* inlined *) = (
-    Token.t (* "{" *)
-  * (
-        [ `Pair of pair | `Hash_splat_arg of hash_splat_argument ]
-      * (
-            Token.t (* "," *)
-          * [ `Pair of pair | `Hash_splat_arg of hash_splat_argument ]
-        )
-          list (* zero or more *)
-      * Token.t (* "," *) option
-    )
-      option
+type rescue_modifier (* inlined *) = (
+    statement * Token.t (* "rescue" *) * expression
+)
+[@@deriving sexp_of]
+
+type class_ (* inlined *) = (
+    Token.t (* "class" *)
+  * anon_choice_cst
+  * superclass option
+  * terminator
+  * body_statement
+)
+[@@deriving sexp_of]
+
+type until_modifier (* inlined *) = (
+    statement * Token.t (* "until" *) * expression
+)
+[@@deriving sexp_of]
+
+type for_ (* inlined *) = (
+    Token.t (* "for" *)
+  * left_assignment_list
+  * in_
+  * do_
+  * statements option
+  * Token.t (* "end" *)
+)
+[@@deriving sexp_of]
+
+type optional_parameter (* inlined *) = (
+    identifier (*tok*) * Token.t (* "=" *) * arg
+)
+[@@deriving sexp_of]
+
+type singleton_class (* inlined *) = (
+    Token.t (* "class" *) * singleton_class_left_angle_left_langle (*tok*)
+  * arg * terminator * body_statement
+)
+[@@deriving sexp_of]
+
+type rest_assignment (* inlined *) = (Token.t (* "*" *) * lhs option)
+[@@deriving sexp_of]
+
+type alias (* inlined *) = (
+    Token.t (* "alias" *) * method_name * method_name
+)
+[@@deriving sexp_of]
+
+type if_modifier (* inlined *) = (
+    statement * Token.t (* "if" *) * expression
+)
+[@@deriving sexp_of]
+
+type return_command (* inlined *) = (
+    Token.t (* "return" *) * command_argument_list
+)
+[@@deriving sexp_of]
+
+type symbol_array (* inlined *) = (
+    symbol_array_start (*tok*)
+  * unit (* blank *) option
+  * anon_lit_content_rep_blank_lit_content option
+  * unit (* blank *) option
+  * string_end (*tok*)
+)
+[@@deriving sexp_of]
+
+type redo (* inlined *) = (Token.t (* "redo" *) * argument_list option)
+[@@deriving sexp_of]
+
+type break_command (* inlined *) = (
+    Token.t (* "break" *) * command_argument_list
+)
+[@@deriving sexp_of]
+
+type block_argument (* inlined *) = (block_ampersand (*tok*) * arg)
+[@@deriving sexp_of]
+
+type regex (* inlined *) = (
+    regex_start (*tok*)
+  * literal_contents option
+  * string_end (*tok*)
+)
+[@@deriving sexp_of]
+
+type command_operator_assignment (* inlined *) = (
+    lhs * anon_choice_PLUSEQ * expression
+)
+[@@deriving sexp_of]
+
+type end_block (* inlined *) = (
+    Token.t (* "END" *)
+  * Token.t (* "{" *)
+  * statements option
   * Token.t (* "}" *)
 )
 [@@deriving sexp_of]
 
-type lambda (* inlined *) = (
-    Token.t (* "->" *)
-  * [ `Params of parameters | `Bare_params of bare_parameters ] option
-  * [ `Blk of block | `Do_blk of do_block ]
+type string_array (* inlined *) = (
+    string_array_start (*tok*)
+  * unit (* blank *) option
+  * anon_lit_content_rep_blank_lit_content option
+  * unit (* blank *) option
+  * string_end (*tok*)
+)
+[@@deriving sexp_of]
+
+type while_ (* inlined *) = (
+    Token.t (* "while" *)
+  * arg
+  * do_
+  * statements option
+  * Token.t (* "end" *)
+)
+[@@deriving sexp_of]
+
+type if_ (* inlined *) = (
+    Token.t (* "if" *)
+  * statement
+  * anon_choice_term
+  * anon_choice_else option
+  * Token.t (* "end" *)
+)
+[@@deriving sexp_of]
+
+type keyword_parameter (* inlined *) = (
+    identifier (*tok*)
+  * Token.t (* ":" *)
+  * arg option
+)
+[@@deriving sexp_of]
+
+type destructured_left_assignment (* inlined *) = (
+    Token.t (* "(" *) * left_assignment_list * Token.t (* ")" *)
+)
+[@@deriving sexp_of]
+
+type begin_ (* inlined *) = (
+    Token.t (* "begin" *)
+  * terminator option
+  * body_statement
 )
 [@@deriving sexp_of]
 

--- a/typescript/lib/Boilerplate.ml
+++ b/typescript/lib/Boilerplate.ml
@@ -20,14 +20,56 @@ let blank (env : env) () =
 let todo (env : env) _ =
    failwith "not implemented"
 
+let map_hash_bang_line (env : env) (tok : CST.hash_bang_line) =
+  token env tok (* pattern #!.* *)
+
+let map_regex_pattern (env : env) (tok : CST.regex_pattern) =
+  token env tok (* regex_pattern *)
+
+let map_template_chars (env : env) (tok : CST.template_chars) =
+  token env tok (* template_chars *)
+
+let map_automatic_semicolon (env : env) (tok : CST.automatic_semicolon) =
+  token env tok (* automatic_semicolon *)
+
+let map_number (env : env) (tok : CST.number) =
+  token env tok (* number *)
+
+let map_anon_choice_get_ (env : env) (x : CST.anon_choice_get_) =
+  (match x with
+  | `Get tok -> token env tok (* "get" *)
+  | `Set tok -> token env tok (* "set" *)
+  | `Async tok -> token env tok (* "async" *)
+  | `Stat tok -> token env tok (* "static" *)
+  )
+
+let map_escape_sequence (env : env) (tok : CST.escape_sequence) =
+  token env tok (* escape_sequence *)
+
+let map_jsx_identifier (env : env) (tok : CST.jsx_identifier) =
+  token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
+
 let map_jsx_text (env : env) (tok : CST.jsx_text) =
   token env tok (* pattern [^{}<>]+ *)
 
-let map_meta_property (env : env) ((v1, v2, v3) : CST.meta_property) =
-  let v1 = token env v1 (* "new" *) in
-  let v2 = token env v2 (* "." *) in
-  let v3 = token env v3 (* "target" *) in
-  todo env (v1, v2, v3)
+let map_anon_choice_get (env : env) (x : CST.anon_choice_get) =
+  (match x with
+  | `Get tok -> token env tok (* "get" *)
+  | `Set tok -> token env tok (* "set" *)
+  | `STAR tok -> token env tok (* "*" *)
+  )
+
+let map_anon_choice_type (env : env) (x : CST.anon_choice_type) =
+  (match x with
+  | `Type_599dcce tok -> token env tok (* "type" *)
+  | `Type_ac95254 tok -> token env tok (* "typeof" *)
+  )
+
+let map_import (env : env) (tok : CST.import) =
+  token env tok (* import *)
+
+let map_regex_flags (env : env) (tok : CST.regex_flags) =
+  token env tok (* pattern [a-z]+ *)
 
 let map_predefined_type (env : env) (x : CST.predefined_type) =
   (match x with
@@ -39,33 +81,6 @@ let map_predefined_type (env : env) (x : CST.predefined_type) =
   | `Pred_type_void tok -> token env tok (* "void" *)
   )
 
-let map_template_chars (env : env) (tok : CST.template_chars) =
-  token env tok (* template_chars *)
-
-let map_regex_pattern (env : env) (tok : CST.regex_pattern) =
-  token env tok (* regex_pattern *)
-
-let map_escape_sequence (env : env) (tok : CST.escape_sequence) =
-  token env tok (* escape_sequence *)
-
-let map_number (env : env) (tok : CST.number) =
-  token env tok (* number *)
-
-let map_hash_bang_line (env : env) (tok : CST.hash_bang_line) =
-  token env tok (* pattern #!.* *)
-
-let map_automatic_semicolon (env : env) (tok : CST.automatic_semicolon) =
-  token env tok (* automatic_semicolon *)
-
-let map_identifier (env : env) (tok : CST.identifier) =
-  token env tok (* identifier *)
-
-let map_import (env : env) (tok : CST.import) =
-  token env tok (* import *)
-
-let map_regex_flags (env : env) (tok : CST.regex_flags) =
-  token env tok (* pattern [a-z]+ *)
-
 let map_accessibility_modifier (env : env) (x : CST.accessibility_modifier) =
   (match x with
   | `Publ tok -> token env tok (* "public" *)
@@ -73,69 +88,68 @@ let map_accessibility_modifier (env : env) (x : CST.accessibility_modifier) =
   | `Prot tok -> token env tok (* "protected" *)
   )
 
-let map_jsx_identifier (env : env) (tok : CST.jsx_identifier) =
-  token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
+let map_identifier (env : env) (tok : CST.identifier) =
+  token env tok (* identifier *)
 
-let map_string_ (env : env) (x : CST.string_) =
+let map_anon_choice_PLUSPLUS (env : env) (x : CST.anon_choice_PLUSPLUS) =
   (match x with
-  | `Str_DQUOT_rep_choice_blank_DQUOT (v1, v2, v3) ->
-      let v1 = token env v1 (* "\"" *) in
-      let v2 =
-        List.map (fun x ->
-          (match x with
-          | `Blank () -> todo env ()
-          | `Esc_seq tok -> token env tok (* escape_sequence *)
-          )
-        ) v2
-      in
-      let v3 = token env v3 (* "\"" *) in
-      todo env (v1, v2, v3)
-  | `Str_SQUOT_rep_choice_blank_SQUOT (v1, v2, v3) ->
-      let v1 = token env v1 (* "'" *) in
-      let v2 =
-        List.map (fun x ->
-          (match x with
-          | `Blank () -> todo env ()
-          | `Esc_seq tok -> token env tok (* escape_sequence *)
-          )
-        ) v2
-      in
-      let v3 = token env v3 (* "'" *) in
-      todo env (v1, v2, v3)
+  | `PLUSPLUS tok -> token env tok (* "++" *)
+  | `DASHDASH tok -> token env tok (* "--" *)
   )
 
-let map_debugger_statement (env : env) ((v1, v2) : CST.debugger_statement) =
-  let v1 = token env v1 (* "debugger" *) in
-  let v2 =
-    (match v2 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2)
+let map_anon_choice_auto_semi (env : env) (x : CST.anon_choice_auto_semi) =
+  (match x with
+  | `Auto_semi tok -> token env tok (* automatic_semicolon *)
+  | `SEMI tok -> token env tok (* ";" *)
+  )
 
-let map_continue_statement (env : env) ((v1, v2, v3) : CST.continue_statement) =
-  let v1 = token env v1 (* "continue" *) in
-  let v2 =
-    (match v2 with
-    | Some tok -> token env tok (* identifier *)
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
+let map_anon_choice_blank (env : env) (x : CST.anon_choice_blank) =
+  (match x with
+  | `Blank () -> todo env ()
+  | `Esc_seq tok -> token env tok (* escape_sequence *)
+  )
+
+let map_anon_choice_decl (env : env) (x : CST.anon_choice_decl) =
+  (match x with
+  | `Decl tok -> token env tok (* "declare" *)
+  | `Name tok -> token env tok (* "namespace" *)
+  | `Type tok -> token env tok (* "type" *)
+  | `Publ tok -> token env tok (* "public" *)
+  | `Priv tok -> token env tok (* "private" *)
+  | `Prot tok -> token env tok (* "protected" *)
+  | `Read tok -> token env tok (* "readonly" *)
+  | `Modu tok -> token env tok (* "module" *)
+  | `Any tok -> token env tok (* "any" *)
+  | `Num tok -> token env tok (* "number" *)
+  | `Bool tok -> token env tok (* "boolean" *)
+  | `Str tok -> token env tok (* "string" *)
+  | `Symb tok -> token env tok (* "symbol" *)
+  | `Void tok -> token env tok (* "void" *)
+  | `Expo tok -> token env tok (* "export" *)
+  | `Choice_get x -> map_anon_choice_get_ env x
+  )
+
+let map_namespace_import (env : env) ((v1, v2, v3) : CST.namespace_import) =
+  let v1 = token env v1 (* "*" *) in
+  let v2 = token env v2 (* "as" *) in
+  let v3 = token env v3 (* identifier *) in
   todo env (v1, v2, v3)
 
-let rec map_nested_identifier (env : env) ((v1, v2, v3) : CST.nested_identifier) =
-  let v1 =
-    (match v1 with
-    | `Id tok -> token env tok (* identifier *)
-    | `Nest_id x -> map_nested_identifier env x
-    )
-  in
+let map_anon_choice_jsx_id (env : env) (x : CST.anon_choice_jsx_id) =
+  (match x with
+  | `Jsx_id tok ->
+      token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
+  | `Id tok -> token env tok (* identifier *)
+  )
+
+let rec map_anon_choice_id_ (env : env) (x : CST.anon_choice_id_) =
+  (match x with
+  | `Id tok -> token env tok (* identifier *)
+  | `Nest_id x -> map_nested_identifier env x
+  )
+
+and map_nested_identifier (env : env) ((v1, v2, v3) : CST.nested_identifier) =
+  let v1 = map_anon_choice_id_ env v1 in
   let v2 = token env v2 (* "." *) in
   let v3 = token env v3 (* identifier *) in
   todo env (v1, v2, v3)
@@ -143,11 +157,7 @@ let rec map_nested_identifier (env : env) ((v1, v2, v3) : CST.nested_identifier)
 let map_import_export_specifier (env : env) ((v1, v2, v3) : CST.import_export_specifier) =
   let v1 =
     (match v1 with
-    | Some x ->
-        (match x with
-        | `Type_599dcce tok -> token env tok (* "type" *)
-        | `Type_ac95254 tok -> token env tok (* "typeof" *)
-        )
+    | Some x -> map_anon_choice_type env x
     | None -> todo env ())
   in
   let v2 = token env v2 (* identifier *) in
@@ -161,94 +171,60 @@ let map_import_export_specifier (env : env) ((v1, v2, v3) : CST.import_export_sp
   in
   todo env (v1, v2, v3)
 
-let map_namespace_import (env : env) ((v1, v2, v3) : CST.namespace_import) =
-  let v1 = token env v1 (* "*" *) in
-  let v2 = token env v2 (* "as" *) in
-  let v3 = token env v3 (* identifier *) in
+let map_anon_choice_COMMA (env : env) (x : CST.anon_choice_COMMA) =
+  (match x with
+  | `COMMA tok -> token env tok (* "," *)
+  | `Choice_auto_semi x -> map_anon_choice_auto_semi env x
+  )
+
+let map_string_ (env : env) (x : CST.string_) =
+  (match x with
+  | `Str_DQUOT_rep_choice_blank_DQUOT (v1, v2, v3) ->
+      let v1 = token env v1 (* "\"" *) in
+      let v2 = List.map (map_anon_choice_blank env) v2 in
+      let v3 = token env v3 (* "\"" *) in
+      todo env (v1, v2, v3)
+  | `Str_SQUOT_rep_choice_blank_SQUOT (v1, v2, v3) ->
+      let v1 = token env v1 (* "'" *) in
+      let v2 = List.map (map_anon_choice_blank env) v2 in
+      let v3 = token env v3 (* "'" *) in
+      todo env (v1, v2, v3)
+  )
+
+let map_anon_choice_choice_decl (env : env) (x : CST.anon_choice_choice_decl) =
+  (match x with
+  | `Choice_decl x -> map_anon_choice_decl env x
+  | `Id tok -> token env tok (* identifier *)
+  )
+
+let map_anon_choice_id4 (env : env) (x : CST.anon_choice_id4) =
+  (match x with
+  | `Id tok -> token env tok (* identifier *)
+  | `Choice_decl x -> map_anon_choice_decl env x
+  )
+
+let map_jsx_namespace_name (env : env) ((v1, v2, v3) : CST.jsx_namespace_name) =
+  let v1 = map_anon_choice_jsx_id env v1 in
+  let v2 = token env v2 (* ":" *) in
+  let v3 = map_anon_choice_jsx_id env v3 in
   todo env (v1, v2, v3)
 
-let map_break_statement (env : env) ((v1, v2, v3) : CST.break_statement) =
-  let v1 = token env v1 (* "break" *) in
-  let v2 =
-    (match v2 with
-    | Some tok -> token env tok (* identifier *)
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2, v3)
-
-let rec map_decorator_member_expression (env : env) ((v1, v2, v3) : CST.decorator_member_expression) =
-  let v1 =
-    (match v1 with
-    | `Choice_id x ->
-        (match x with
-        | `Id tok -> token env tok (* identifier *)
-        | `Choice_decl x ->
-            (match x with
-            | `Decl tok -> token env tok (* "declare" *)
-            | `Name tok -> token env tok (* "namespace" *)
-            | `Type tok -> token env tok (* "type" *)
-            | `Publ tok -> token env tok (* "public" *)
-            | `Priv tok -> token env tok (* "private" *)
-            | `Prot tok -> token env tok (* "protected" *)
-            | `Read tok -> token env tok (* "readonly" *)
-            | `Modu tok -> token env tok (* "module" *)
-            | `Any tok -> token env tok (* "any" *)
-            | `Num tok -> token env tok (* "number" *)
-            | `Bool tok -> token env tok (* "boolean" *)
-            | `Str tok -> token env tok (* "string" *)
-            | `Symb tok -> token env tok (* "symbol" *)
-            | `Void tok -> token env tok (* "void" *)
-            | `Expo tok -> token env tok (* "export" *)
-            | `Choice_get x ->
-                (match x with
-                | `Get tok -> token env tok (* "get" *)
-                | `Set tok -> token env tok (* "set" *)
-                | `Async tok -> token env tok (* "async" *)
-                | `Stat tok -> token env tok (* "static" *)
-                )
-            )
-        )
-    | `Deco_memb_exp x -> map_decorator_member_expression env x
-    )
-  in
+let map_nested_type_identifier (env : env) ((v1, v2, v3) : CST.nested_type_identifier) =
+  let v1 = map_anon_choice_id_ env v1 in
   let v2 = token env v2 (* "." *) in
   let v3 = token env v3 (* identifier *) in
   todo env (v1, v2, v3)
 
-let map_regex (env : env) ((v1, v2, v3, v4) : CST.regex) =
-  let v1 = token env v1 (* "/" *) in
-  let v2 = token env v2 (* regex_pattern *) in
-  let v3 = token env v3 (* "/" *) in
-  let v4 =
-    (match v4 with
-    | Some tok -> token env tok (* pattern [a-z]+ *)
-    | None -> todo env ())
+let map_anon_impo_expo_spec_rep_COMMA_impo_expo_spec (env : env) ((v1, v2) : CST.anon_impo_expo_spec_rep_COMMA_impo_expo_spec) =
+  let v1 = map_import_export_specifier env v1 in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_import_export_specifier env v2 in
+      todo env (v1, v2)
+    ) v2
   in
-  todo env (v1, v2, v3, v4)
-
-let map_jsx_namespace_name (env : env) ((v1, v2, v3) : CST.jsx_namespace_name) =
-  let v1 =
-    (match v1 with
-    | `Jsx_id tok ->
-        token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
-    | `Id tok -> token env tok (* identifier *)
-    )
-  in
-  let v2 = token env v2 (* ":" *) in
-  let v3 =
-    (match v3 with
-    | `Jsx_id tok ->
-        token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
-    | `Id tok -> token env tok (* identifier *)
-    )
-  in
-  todo env (v1, v2, v3)
+  todo env (v1, v2)
 
 let map_import_require_clause (env : env) ((v1, v2, v3, v4, v5, v6) : CST.import_require_clause) =
   let v1 = token env v1 (* identifier *) in
@@ -258,11 +234,6 @@ let map_import_require_clause (env : env) ((v1, v2, v3, v4, v5, v6) : CST.import
   let v5 = map_string_ env v5 in
   let v6 = token env v6 (* ")" *) in
   todo env (v1, v2, v3, v4, v5, v6)
-
-let map_from_clause (env : env) ((v1, v2) : CST.from_clause) =
-  let v1 = token env v1 (* "from" *) in
-  let v2 = map_string_ env v2 in
-  todo env (v1, v2)
 
 let map_literal_type (env : env) (x : CST.literal_type) =
   (match x with
@@ -281,31 +252,48 @@ let map_literal_type (env : env) (x : CST.literal_type) =
   | `Lit_type_false tok -> token env tok (* "false" *)
   )
 
-let map_nested_type_identifier (env : env) ((v1, v2, v3) : CST.nested_type_identifier) =
-  let v1 =
-    (match v1 with
-    | `Id tok -> token env tok (* identifier *)
-    | `Nest_id x -> map_nested_identifier env x
-    )
-  in
+let map_from_clause (env : env) ((v1, v2) : CST.from_clause) =
+  let v1 = token env v1 (* "from" *) in
+  let v2 = map_string_ env v2 in
+  todo env (v1, v2)
+
+let rec map_decorator_member_expression (env : env) ((v1, v2, v3) : CST.decorator_member_expression) =
+  let v1 = map_anon_choice_choice_id_ env v1 in
   let v2 = token env v2 (* "." *) in
   let v3 = token env v3 (* identifier *) in
   todo env (v1, v2, v3)
 
-let map_export_clause (env : env) ((v1, v2, v3, v4) : CST.export_clause) =
+and map_anon_choice_choice_id_ (env : env) (x : CST.anon_choice_choice_id_) =
+  (match x with
+  | `Choice_id x -> map_anon_choice_id4 env x
+  | `Deco_memb_exp x -> map_decorator_member_expression env x
+  )
+
+let map_anon_choice_choice_jsx_id (env : env) (x : CST.anon_choice_choice_jsx_id) =
+  (match x with
+  | `Choice_jsx_id x -> map_anon_choice_jsx_id env x
+  | `Jsx_name_name x -> map_jsx_namespace_name env x
+  )
+
+let map_anon_choice_choice_jsx_id_ (env : env) (x : CST.anon_choice_choice_jsx_id_) =
+  (match x with
+  | `Choice_jsx_id x -> map_anon_choice_jsx_id env x
+  | `Nest_id x -> map_nested_identifier env x
+  | `Jsx_name_name x -> map_jsx_namespace_name env x
+  )
+
+let map_anon_choice_id (env : env) (x : CST.anon_choice_id) =
+  (match x with
+  | `Id tok -> token env tok (* identifier *)
+  | `Nest_type_id x -> map_nested_type_identifier env x
+  )
+
+let map_named_imports (env : env) ((v1, v2, v3, v4) : CST.named_imports) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     (match v2 with
-    | Some (v1, v2) ->
-        let v1 = map_import_export_specifier env v1 in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 = map_import_export_specifier env v2 in
-            todo env (v1, v2)
-          ) v2
-        in
-        todo env (v1, v2)
+    | Some x ->
+        map_anon_impo_expo_spec_rep_COMMA_impo_expo_spec env x
     | None -> todo env ())
   in
   let v3 =
@@ -316,20 +304,12 @@ let map_export_clause (env : env) ((v1, v2, v3, v4) : CST.export_clause) =
   let v4 = token env v4 (* "}" *) in
   todo env (v1, v2, v3, v4)
 
-let map_named_imports (env : env) ((v1, v2, v3, v4) : CST.named_imports) =
+let map_export_clause (env : env) ((v1, v2, v3, v4) : CST.export_clause) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     (match v2 with
-    | Some (v1, v2) ->
-        let v1 = map_import_export_specifier env v1 in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 = map_import_export_specifier env v2 in
-            todo env (v1, v2)
-          ) v2
-        in
-        todo env (v1, v2)
+    | Some x ->
+        map_anon_impo_expo_spec_rep_COMMA_impo_expo_spec env x
     | None -> todo env ())
   in
   let v3 =
@@ -343,18 +323,7 @@ let map_named_imports (env : env) ((v1, v2, v3, v4) : CST.named_imports) =
 let map_jsx_closing_element (env : env) ((v1, v2, v3, v4) : CST.jsx_closing_element) =
   let v1 = token env v1 (* "<" *) in
   let v2 = token env v2 (* "/" *) in
-  let v3 =
-    (match v3 with
-    | `Choice_jsx_id x ->
-        (match x with
-        | `Jsx_id tok ->
-            token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
-        | `Id tok -> token env tok (* identifier *)
-        )
-    | `Nest_id x -> map_nested_identifier env x
-    | `Jsx_name_name x -> map_jsx_namespace_name env x
-    )
-  in
+  let v3 = map_anon_choice_choice_jsx_id_ env v3 in
   let v4 = token env v4 (* ">" *) in
   todo env (v1, v2, v3, v4)
 
@@ -380,920 +349,7 @@ let map_import_clause (env : env) (x : CST.import_clause) =
       todo env (v1, v2)
   )
 
-let map_import_statement (env : env) ((v1, v2, v3, v4) : CST.import_statement) =
-  let v1 = token env v1 (* "import" *) in
-  let v2 =
-    (match v2 with
-    | Some x ->
-        (match x with
-        | `Type_599dcce tok -> token env tok (* "type" *)
-        | `Type_ac95254 tok -> token env tok (* "typeof" *)
-        )
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | `Impo_clau_from_clau (v1, v2) ->
-        let v1 = map_import_clause env v1 in
-        let v2 = map_from_clause env v2 in
-        todo env (v1, v2)
-    | `Impo_requ_clau x -> map_import_require_clause env x
-    | `Str x -> map_string_ env x
-    )
-  in
-  let v4 =
-    (match v4 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2, v3, v4)
-
-let rec map_export_statement (env : env) (x : CST.export_statement) =
-  (match x with
-  | `Choice_expo_choice_STAR_from_clau_choice_auto_semi x ->
-      (match x with
-      | `Expo_choice_STAR_from_clau_choice_auto_semi (v1, v2) ->
-          let v1 = token env v1 (* "export" *) in
-          let v2 =
-            (match v2 with
-            | `STAR_from_clau_choice_auto_semi (v1, v2, v3) ->
-                let v1 = token env v1 (* "*" *) in
-                let v2 = map_from_clause env v2 in
-                let v3 =
-                  (match v3 with
-                  | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-                  | `SEMI tok -> token env tok (* ";" *)
-                  )
-                in
-                todo env (v1, v2, v3)
-            | `Expo_clau_from_clau_choice_auto_semi (v1, v2, v3) ->
-                let v1 = map_export_clause env v1 in
-                let v2 = map_from_clause env v2 in
-                let v3 =
-                  (match v3 with
-                  | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-                  | `SEMI tok -> token env tok (* ";" *)
-                  )
-                in
-                todo env (v1, v2, v3)
-            | `Expo_clau_choice_auto_semi (v1, v2) ->
-                let v1 = map_export_clause env v1 in
-                let v2 =
-                  (match v2 with
-                  | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-                  | `SEMI tok -> token env tok (* ";" *)
-                  )
-                in
-                todo env (v1, v2)
-            )
-          in
-          todo env (v1, v2)
-      | `Rep_deco_expo_choice_decl (v1, v2, v3) ->
-          let v1 = List.map (map_decorator env) v1 in
-          let v2 = token env v2 (* "export" *) in
-          let v3 =
-            (match v3 with
-            | `Decl x -> map_declaration env x
-            | `Defa_exp_choice_auto_semi (v1, v2, v3) ->
-                let v1 = token env v1 (* "default" *) in
-                let v2 = map_expression env v2 in
-                let v3 =
-                  (match v3 with
-                  | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-                  | `SEMI tok -> token env tok (* ";" *)
-                  )
-                in
-                todo env (v1, v2, v3)
-            )
-          in
-          todo env (v1, v2, v3)
-      )
-  | `Expo_EQ_id_choice_auto_semi (v1, v2, v3, v4) ->
-      let v1 = token env v1 (* "export" *) in
-      let v2 = token env v2 (* "=" *) in
-      let v3 = token env v3 (* identifier *) in
-      let v4 =
-        (match v4 with
-        | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-        | `SEMI tok -> token env tok (* ";" *)
-        )
-      in
-      todo env (v1, v2, v3, v4)
-  | `Expo_as_name_id_choice_auto_semi (v1, v2, v3, v4, v5) ->
-      let v1 = token env v1 (* "export" *) in
-      let v2 = token env v2 (* "as" *) in
-      let v3 = token env v3 (* "namespace" *) in
-      let v4 = token env v4 (* identifier *) in
-      let v5 =
-        (match v5 with
-        | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-        | `SEMI tok -> token env tok (* ";" *)
-        )
-      in
-      todo env (v1, v2, v3, v4, v5)
-  )
-
-
-and map_declaration (env : env) (x : CST.declaration) =
-  (match x with
-  | `Decl_choice_func_decl x ->
-      (match x with
-      | `Func_decl x -> map_function_declaration env x
-      | `Gene_func_decl x ->
-          map_generator_function_declaration env x
-      | `Class_decl x -> map_class_declaration env x
-      | `Lexi_decl x -> map_lexical_declaration env x
-      | `Var_decl x -> map_variable_declaration env x
-      )
-  | `Decl_func_sign (v1, v2, v3, v4, v5) ->
-      let v1 =
-        (match v1 with
-        | Some tok -> token env tok (* "async" *)
-        | None -> todo env ())
-      in
-      let v2 = token env v2 (* "function" *) in
-      let v3 = token env v3 (* identifier *) in
-      let v4 = map_call_signature env v4 in
-      let v5 =
-        (match v5 with
-        | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-        | `SEMI tok -> token env tok (* ";" *)
-        )
-      in
-      todo env (v1, v2, v3, v4, v5)
-  | `Decl_abst_class_decl (v1, v2, v3, v4, v5, v6) ->
-      let v1 = token env v1 (* "abstract" *) in
-      let v2 = token env v2 (* "class" *) in
-      let v3 = token env v3 (* identifier *) in
-      let v4 =
-        (match v4 with
-        | Some x -> map_type_parameters env x
-        | None -> todo env ())
-      in
-      let v5 =
-        (match v5 with
-        | Some x -> map_class_heritage env x
-        | None -> todo env ())
-      in
-      let v6 = map_class_body env v6 in
-      todo env (v1, v2, v3, v4, v5, v6)
-  | `Decl_modu (v1, v2) ->
-      let v1 = token env v1 (* "module" *) in
-      let v2 = map_module__ env v2 in
-      todo env (v1, v2)
-  | `Decl_inte_modu x -> map_internal_module env x
-  | `Decl_type_alias_decl (v1, v2, v3, v4, v5, v6) ->
-      let v1 = token env v1 (* "type" *) in
-      let v2 = token env v2 (* identifier *) in
-      let v3 =
-        (match v3 with
-        | Some x -> map_type_parameters env x
-        | None -> todo env ())
-      in
-      let v4 = token env v4 (* "=" *) in
-      let v5 = map_type_ env v5 in
-      let v6 =
-        (match v6 with
-        | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-        | `SEMI tok -> token env tok (* ";" *)
-        )
-      in
-      todo env (v1, v2, v3, v4, v5, v6)
-  | `Decl_enum_decl (v1, v2, v3, v4) ->
-      let v1 =
-        (match v1 with
-        | Some tok -> token env tok (* "const" *)
-        | None -> todo env ())
-      in
-      let v2 = token env v2 (* "enum" *) in
-      let v3 = token env v3 (* identifier *) in
-      let v4 = map_enum_body env v4 in
-      todo env (v1, v2, v3, v4)
-  | `Decl_inte_decl (v1, v2, v3, v4, v5) ->
-      let v1 = token env v1 (* "interface" *) in
-      let v2 = token env v2 (* identifier *) in
-      let v3 =
-        (match v3 with
-        | Some x -> map_type_parameters env x
-        | None -> todo env ())
-      in
-      let v4 =
-        (match v4 with
-        | Some x -> map_extends_clause env x
-        | None -> todo env ())
-      in
-      let v5 = map_object_type env v5 in
-      todo env (v1, v2, v3, v4, v5)
-  | `Decl_impo_alias (v1, v2, v3, v4, v5) ->
-      let v1 = token env v1 (* "import" *) in
-      let v2 = token env v2 (* identifier *) in
-      let v3 = token env v3 (* "=" *) in
-      let v4 =
-        (match v4 with
-        | `Id tok -> token env tok (* identifier *)
-        | `Nest_id x -> map_nested_identifier env x
-        )
-      in
-      let v5 =
-        (match v5 with
-        | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-        | `SEMI tok -> token env tok (* ";" *)
-        )
-      in
-      todo env (v1, v2, v3, v4, v5)
-  | `Decl_ambi_decl (v1, v2) ->
-      let v1 = token env v1 (* "declare" *) in
-      let v2 =
-        (match v2 with
-        | `Decl x -> map_declaration env x
-        | `Glob_stmt_blk (v1, v2) ->
-            let v1 = token env v1 (* "global" *) in
-            let v2 = map_statement_block env v2 in
-            todo env (v1, v2)
-        | `Modu_DOT_id_COLON_type (v1, v2, v3, v4, v5) ->
-            let v1 = token env v1 (* "module" *) in
-            let v2 = token env v2 (* "." *) in
-            let v3 = token env v3 (* identifier *) in
-            let v4 = token env v4 (* ":" *) in
-            let v5 = map_type_ env v5 in
-            todo env (v1, v2, v3, v4, v5)
-        )
-      in
-      todo env (v1, v2)
-  )
-
-
-and map_expression_statement (env : env) ((v1, v2) : CST.expression_statement) =
-  let v1 =
-    (match v1 with
-    | `Exp x -> map_expression env x
-    | `Seq_exp x -> map_sequence_expression env x
-    )
-  in
-  let v2 =
-    (match v2 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2)
-
-
-and map_variable_declaration (env : env) ((v1, v2, v3, v4) : CST.variable_declaration) =
-  let v1 = token env v1 (* "var" *) in
-  let v2 = map_variable_declarator env v2 in
-  let v3 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 = map_variable_declarator env v2 in
-      todo env (v1, v2)
-    ) v3
-  in
-  let v4 =
-    (match v4 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_lexical_declaration (env : env) ((v1, v2, v3, v4) : CST.lexical_declaration) =
-  let v1 =
-    (match v1 with
-    | `Let tok -> token env tok (* "let" *)
-    | `Const tok -> token env tok (* "const" *)
-    )
-  in
-  let v2 = map_variable_declarator env v2 in
-  let v3 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 = map_variable_declarator env v2 in
-      todo env (v1, v2)
-    ) v3
-  in
-  let v4 =
-    (match v4 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_variable_declarator (env : env) ((v1, v2, v3) : CST.variable_declarator) =
-  let v1 =
-    (match v1 with
-    | `Id tok -> token env tok (* identifier *)
-    | `Choice_obj x ->
-        (match x with
-        | `Obj x -> map_object_ env x
-        | `Array x -> map_array_ env x
-        )
-    )
-  in
-  let v2 =
-    (match v2 with
-    | Some x -> map_type_annotation env x
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | Some x -> map_initializer_ env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3)
-
-
-and map_statement_block (env : env) ((v1, v2, v3, v4) : CST.statement_block) =
-  let v1 = token env v1 (* "{" *) in
-  let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Expo_stmt x -> map_export_statement env x
-      | `Impo_stmt x -> map_import_statement env x
-      | `Debu_stmt x -> map_debugger_statement env x
-      | `Exp_stmt x -> map_expression_statement env x
-      | `Decl x -> map_declaration env x
-      | `Stmt_blk x -> map_statement_block env x
-      | `If_stmt x -> map_if_statement env x
-      | `Swit_stmt x -> map_switch_statement env x
-      | `For_stmt x -> map_for_statement env x
-      | `For_in_stmt x -> map_for_in_statement env x
-      | `While_stmt x -> map_while_statement env x
-      | `Do_stmt x -> map_do_statement env x
-      | `Try_stmt x -> map_try_statement env x
-      | `With_stmt x -> map_with_statement env x
-      | `Brk_stmt x -> map_break_statement env x
-      | `Cont_stmt x -> map_continue_statement env x
-      | `Ret_stmt x -> map_return_statement env x
-      | `Throw_stmt x -> map_throw_statement env x
-      | `Empty_stmt tok -> token env tok (* ";" *)
-      | `Labe_stmt x -> map_labeled_statement env x
-      )
-    ) v2
-  in
-  let v3 = token env v3 (* "}" *) in
-  let v4 =
-    (match v4 with
-    | Some tok -> token env tok (* automatic_semicolon *)
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_if_statement (env : env) ((v1, v2, v3, v4) : CST.if_statement) =
-  let v1 = token env v1 (* "if" *) in
-  let v2 = map_parenthesized_expression env v2 in
-  let v3 =
-    (match v3 with
-    | `Expo_stmt x -> map_export_statement env x
-    | `Impo_stmt x -> map_import_statement env x
-    | `Debu_stmt x -> map_debugger_statement env x
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Decl x -> map_declaration env x
-    | `Stmt_blk x -> map_statement_block env x
-    | `If_stmt x -> map_if_statement env x
-    | `Swit_stmt x -> map_switch_statement env x
-    | `For_stmt x -> map_for_statement env x
-    | `For_in_stmt x -> map_for_in_statement env x
-    | `While_stmt x -> map_while_statement env x
-    | `Do_stmt x -> map_do_statement env x
-    | `Try_stmt x -> map_try_statement env x
-    | `With_stmt x -> map_with_statement env x
-    | `Brk_stmt x -> map_break_statement env x
-    | `Cont_stmt x -> map_continue_statement env x
-    | `Ret_stmt x -> map_return_statement env x
-    | `Throw_stmt x -> map_throw_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    | `Labe_stmt x -> map_labeled_statement env x
-    )
-  in
-  let v4 =
-    (match v4 with
-    | Some (v1, v2) ->
-        let v1 = token env v1 (* "else" *) in
-        let v2 =
-          (match v2 with
-          | `Expo_stmt x -> map_export_statement env x
-          | `Impo_stmt x -> map_import_statement env x
-          | `Debu_stmt x -> map_debugger_statement env x
-          | `Exp_stmt x -> map_expression_statement env x
-          | `Decl x -> map_declaration env x
-          | `Stmt_blk x -> map_statement_block env x
-          | `If_stmt x -> map_if_statement env x
-          | `Swit_stmt x -> map_switch_statement env x
-          | `For_stmt x -> map_for_statement env x
-          | `For_in_stmt x -> map_for_in_statement env x
-          | `While_stmt x -> map_while_statement env x
-          | `Do_stmt x -> map_do_statement env x
-          | `Try_stmt x -> map_try_statement env x
-          | `With_stmt x -> map_with_statement env x
-          | `Brk_stmt x -> map_break_statement env x
-          | `Cont_stmt x -> map_continue_statement env x
-          | `Ret_stmt x -> map_return_statement env x
-          | `Throw_stmt x -> map_throw_statement env x
-          | `Empty_stmt tok -> token env tok (* ";" *)
-          | `Labe_stmt x -> map_labeled_statement env x
-          )
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_switch_statement (env : env) ((v1, v2, v3) : CST.switch_statement) =
-  let v1 = token env v1 (* "switch" *) in
-  let v2 = map_parenthesized_expression env v2 in
-  let v3 = map_switch_body env v3 in
-  todo env (v1, v2, v3)
-
-
-and map_for_statement (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.for_statement) =
-  let v1 = token env v1 (* "for" *) in
-  let v2 = token env v2 (* "(" *) in
-  let v3 =
-    (match v3 with
-    | `Lexi_decl x -> map_lexical_declaration env x
-    | `Var_decl x -> map_variable_declaration env x
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    )
-  in
-  let v4 =
-    (match v4 with
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    )
-  in
-  let v5 =
-    (match v5 with
-    | Some x ->
-        (match x with
-        | `Exp x -> map_expression env x
-        | `Seq_exp x -> map_sequence_expression env x
-        )
-    | None -> todo env ())
-  in
-  let v6 = token env v6 (* ")" *) in
-  let v7 =
-    (match v7 with
-    | `Expo_stmt x -> map_export_statement env x
-    | `Impo_stmt x -> map_import_statement env x
-    | `Debu_stmt x -> map_debugger_statement env x
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Decl x -> map_declaration env x
-    | `Stmt_blk x -> map_statement_block env x
-    | `If_stmt x -> map_if_statement env x
-    | `Swit_stmt x -> map_switch_statement env x
-    | `For_stmt x -> map_for_statement env x
-    | `For_in_stmt x -> map_for_in_statement env x
-    | `While_stmt x -> map_while_statement env x
-    | `Do_stmt x -> map_do_statement env x
-    | `Try_stmt x -> map_try_statement env x
-    | `With_stmt x -> map_with_statement env x
-    | `Brk_stmt x -> map_break_statement env x
-    | `Cont_stmt x -> map_continue_statement env x
-    | `Ret_stmt x -> map_return_statement env x
-    | `Throw_stmt x -> map_throw_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    | `Labe_stmt x -> map_labeled_statement env x
-    )
-  in
-  todo env (v1, v2, v3, v4, v5, v6, v7)
-
-
-and map_for_in_statement (env : env) ((v1, v2, v3, v4) : CST.for_in_statement) =
-  let v1 = token env v1 (* "for" *) in
-  let v2 =
-    (match v2 with
-    | Some tok -> token env tok (* "await" *)
-    | None -> todo env ())
-  in
-  let v3 = map_for_header env v3 in
-  let v4 =
-    (match v4 with
-    | `Expo_stmt x -> map_export_statement env x
-    | `Impo_stmt x -> map_import_statement env x
-    | `Debu_stmt x -> map_debugger_statement env x
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Decl x -> map_declaration env x
-    | `Stmt_blk x -> map_statement_block env x
-    | `If_stmt x -> map_if_statement env x
-    | `Swit_stmt x -> map_switch_statement env x
-    | `For_stmt x -> map_for_statement env x
-    | `For_in_stmt x -> map_for_in_statement env x
-    | `While_stmt x -> map_while_statement env x
-    | `Do_stmt x -> map_do_statement env x
-    | `Try_stmt x -> map_try_statement env x
-    | `With_stmt x -> map_with_statement env x
-    | `Brk_stmt x -> map_break_statement env x
-    | `Cont_stmt x -> map_continue_statement env x
-    | `Ret_stmt x -> map_return_statement env x
-    | `Throw_stmt x -> map_throw_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    | `Labe_stmt x -> map_labeled_statement env x
-    )
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_for_header (env : env) ((v1, v2, v3, v4, v5, v6) : CST.for_header) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 =
-    (match v2 with
-    | Some x ->
-        (match x with
-        | `Var tok -> token env tok (* "var" *)
-        | `Let tok -> token env tok (* "let" *)
-        | `Const tok -> token env tok (* "const" *)
-        )
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | `Paren_exp x -> map_parenthesized_expression env x
-    | `Choice_memb_exp x ->
-        (match x with
-        | `Memb_exp x -> map_member_expression env x
-        | `Subs_exp x -> map_subscript_expression env x
-        | `Id tok -> token env tok (* identifier *)
-        | `Choice_decl x ->
-            (match x with
-            | `Decl tok -> token env tok (* "declare" *)
-            | `Name tok -> token env tok (* "namespace" *)
-            | `Type tok -> token env tok (* "type" *)
-            | `Publ tok -> token env tok (* "public" *)
-            | `Priv tok -> token env tok (* "private" *)
-            | `Prot tok -> token env tok (* "protected" *)
-            | `Read tok -> token env tok (* "readonly" *)
-            | `Modu tok -> token env tok (* "module" *)
-            | `Any tok -> token env tok (* "any" *)
-            | `Num tok -> token env tok (* "number" *)
-            | `Bool tok -> token env tok (* "boolean" *)
-            | `Str tok -> token env tok (* "string" *)
-            | `Symb tok -> token env tok (* "symbol" *)
-            | `Void tok -> token env tok (* "void" *)
-            | `Expo tok -> token env tok (* "export" *)
-            | `Choice_get x ->
-                (match x with
-                | `Get tok -> token env tok (* "get" *)
-                | `Set tok -> token env tok (* "set" *)
-                | `Async tok -> token env tok (* "async" *)
-                | `Stat tok -> token env tok (* "static" *)
-                )
-            )
-        | `Choice_obj x ->
-            (match x with
-            | `Obj x -> map_object_ env x
-            | `Array x -> map_array_ env x
-            )
-        )
-    )
-  in
-  let v4 =
-    (match v4 with
-    | `In tok -> token env tok (* "in" *)
-    | `Of tok -> token env tok (* "of" *)
-    )
-  in
-  let v5 =
-    (match v5 with
-    | `Exp x -> map_expression env x
-    | `Seq_exp x -> map_sequence_expression env x
-    )
-  in
-  let v6 = token env v6 (* ")" *) in
-  todo env (v1, v2, v3, v4, v5, v6)
-
-
-and map_while_statement (env : env) ((v1, v2, v3) : CST.while_statement) =
-  let v1 = token env v1 (* "while" *) in
-  let v2 = map_parenthesized_expression env v2 in
-  let v3 =
-    (match v3 with
-    | `Expo_stmt x -> map_export_statement env x
-    | `Impo_stmt x -> map_import_statement env x
-    | `Debu_stmt x -> map_debugger_statement env x
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Decl x -> map_declaration env x
-    | `Stmt_blk x -> map_statement_block env x
-    | `If_stmt x -> map_if_statement env x
-    | `Swit_stmt x -> map_switch_statement env x
-    | `For_stmt x -> map_for_statement env x
-    | `For_in_stmt x -> map_for_in_statement env x
-    | `While_stmt x -> map_while_statement env x
-    | `Do_stmt x -> map_do_statement env x
-    | `Try_stmt x -> map_try_statement env x
-    | `With_stmt x -> map_with_statement env x
-    | `Brk_stmt x -> map_break_statement env x
-    | `Cont_stmt x -> map_continue_statement env x
-    | `Ret_stmt x -> map_return_statement env x
-    | `Throw_stmt x -> map_throw_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    | `Labe_stmt x -> map_labeled_statement env x
-    )
-  in
-  todo env (v1, v2, v3)
-
-
-and map_do_statement (env : env) ((v1, v2, v3, v4, v5) : CST.do_statement) =
-  let v1 = token env v1 (* "do" *) in
-  let v2 =
-    (match v2 with
-    | `Expo_stmt x -> map_export_statement env x
-    | `Impo_stmt x -> map_import_statement env x
-    | `Debu_stmt x -> map_debugger_statement env x
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Decl x -> map_declaration env x
-    | `Stmt_blk x -> map_statement_block env x
-    | `If_stmt x -> map_if_statement env x
-    | `Swit_stmt x -> map_switch_statement env x
-    | `For_stmt x -> map_for_statement env x
-    | `For_in_stmt x -> map_for_in_statement env x
-    | `While_stmt x -> map_while_statement env x
-    | `Do_stmt x -> map_do_statement env x
-    | `Try_stmt x -> map_try_statement env x
-    | `With_stmt x -> map_with_statement env x
-    | `Brk_stmt x -> map_break_statement env x
-    | `Cont_stmt x -> map_continue_statement env x
-    | `Ret_stmt x -> map_return_statement env x
-    | `Throw_stmt x -> map_throw_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    | `Labe_stmt x -> map_labeled_statement env x
-    )
-  in
-  let v3 = token env v3 (* "while" *) in
-  let v4 = map_parenthesized_expression env v4 in
-  let v5 =
-    (match v5 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2, v3, v4, v5)
-
-
-and map_try_statement (env : env) ((v1, v2, v3, v4) : CST.try_statement) =
-  let v1 = token env v1 (* "try" *) in
-  let v2 = map_statement_block env v2 in
-  let v3 =
-    (match v3 with
-    | Some x -> map_catch_clause env x
-    | None -> todo env ())
-  in
-  let v4 =
-    (match v4 with
-    | Some x -> map_finally_clause env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_with_statement (env : env) ((v1, v2, v3) : CST.with_statement) =
-  let v1 = token env v1 (* "with" *) in
-  let v2 = map_parenthesized_expression env v2 in
-  let v3 =
-    (match v3 with
-    | `Expo_stmt x -> map_export_statement env x
-    | `Impo_stmt x -> map_import_statement env x
-    | `Debu_stmt x -> map_debugger_statement env x
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Decl x -> map_declaration env x
-    | `Stmt_blk x -> map_statement_block env x
-    | `If_stmt x -> map_if_statement env x
-    | `Swit_stmt x -> map_switch_statement env x
-    | `For_stmt x -> map_for_statement env x
-    | `For_in_stmt x -> map_for_in_statement env x
-    | `While_stmt x -> map_while_statement env x
-    | `Do_stmt x -> map_do_statement env x
-    | `Try_stmt x -> map_try_statement env x
-    | `With_stmt x -> map_with_statement env x
-    | `Brk_stmt x -> map_break_statement env x
-    | `Cont_stmt x -> map_continue_statement env x
-    | `Ret_stmt x -> map_return_statement env x
-    | `Throw_stmt x -> map_throw_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    | `Labe_stmt x -> map_labeled_statement env x
-    )
-  in
-  todo env (v1, v2, v3)
-
-
-and map_return_statement (env : env) ((v1, v2, v3) : CST.return_statement) =
-  let v1 = token env v1 (* "return" *) in
-  let v2 =
-    (match v2 with
-    | Some x ->
-        (match x with
-        | `Exp x -> map_expression env x
-        | `Seq_exp x -> map_sequence_expression env x
-        )
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2, v3)
-
-
-and map_throw_statement (env : env) ((v1, v2, v3) : CST.throw_statement) =
-  let v1 = token env v1 (* "throw" *) in
-  let v2 =
-    (match v2 with
-    | `Exp x -> map_expression env x
-    | `Seq_exp x -> map_sequence_expression env x
-    )
-  in
-  let v3 =
-    (match v3 with
-    | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-    | `SEMI tok -> token env tok (* ";" *)
-    )
-  in
-  todo env (v1, v2, v3)
-
-
-and map_labeled_statement (env : env) ((v1, v2, v3) : CST.labeled_statement) =
-  let v1 =
-    (match v1 with
-    | `Id tok -> token env tok (* identifier *)
-    | `Choice_decl x ->
-        (match x with
-        | `Decl tok -> token env tok (* "declare" *)
-        | `Name tok -> token env tok (* "namespace" *)
-        | `Type tok -> token env tok (* "type" *)
-        | `Publ tok -> token env tok (* "public" *)
-        | `Priv tok -> token env tok (* "private" *)
-        | `Prot tok -> token env tok (* "protected" *)
-        | `Read tok -> token env tok (* "readonly" *)
-        | `Modu tok -> token env tok (* "module" *)
-        | `Any tok -> token env tok (* "any" *)
-        | `Num tok -> token env tok (* "number" *)
-        | `Bool tok -> token env tok (* "boolean" *)
-        | `Str tok -> token env tok (* "string" *)
-        | `Symb tok -> token env tok (* "symbol" *)
-        | `Void tok -> token env tok (* "void" *)
-        | `Expo tok -> token env tok (* "export" *)
-        | `Choice_get x ->
-            (match x with
-            | `Get tok -> token env tok (* "get" *)
-            | `Set tok -> token env tok (* "set" *)
-            | `Async tok -> token env tok (* "async" *)
-            | `Stat tok -> token env tok (* "static" *)
-            )
-        )
-    )
-  in
-  let v2 = token env v2 (* ":" *) in
-  let v3 =
-    (match v3 with
-    | `Expo_stmt x -> map_export_statement env x
-    | `Impo_stmt x -> map_import_statement env x
-    | `Debu_stmt x -> map_debugger_statement env x
-    | `Exp_stmt x -> map_expression_statement env x
-    | `Decl x -> map_declaration env x
-    | `Stmt_blk x -> map_statement_block env x
-    | `If_stmt x -> map_if_statement env x
-    | `Swit_stmt x -> map_switch_statement env x
-    | `For_stmt x -> map_for_statement env x
-    | `For_in_stmt x -> map_for_in_statement env x
-    | `While_stmt x -> map_while_statement env x
-    | `Do_stmt x -> map_do_statement env x
-    | `Try_stmt x -> map_try_statement env x
-    | `With_stmt x -> map_with_statement env x
-    | `Brk_stmt x -> map_break_statement env x
-    | `Cont_stmt x -> map_continue_statement env x
-    | `Ret_stmt x -> map_return_statement env x
-    | `Throw_stmt x -> map_throw_statement env x
-    | `Empty_stmt tok -> token env tok (* ";" *)
-    | `Labe_stmt x -> map_labeled_statement env x
-    )
-  in
-  todo env (v1, v2, v3)
-
-
-and map_switch_body (env : env) ((v1, v2, v3) : CST.switch_body) =
-  let v1 = token env v1 (* "{" *) in
-  let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Swit_case x -> map_switch_case env x
-      | `Swit_defa x -> map_switch_default env x
-      )
-    ) v2
-  in
-  let v3 = token env v3 (* "}" *) in
-  todo env (v1, v2, v3)
-
-
-and map_switch_case (env : env) ((v1, v2, v3, v4) : CST.switch_case) =
-  let v1 = token env v1 (* "case" *) in
-  let v2 =
-    (match v2 with
-    | `Exp x -> map_expression env x
-    | `Seq_exp x -> map_sequence_expression env x
-    )
-  in
-  let v3 = token env v3 (* ":" *) in
-  let v4 =
-    List.map (fun x ->
-      (match x with
-      | `Expo_stmt x -> map_export_statement env x
-      | `Impo_stmt x -> map_import_statement env x
-      | `Debu_stmt x -> map_debugger_statement env x
-      | `Exp_stmt x -> map_expression_statement env x
-      | `Decl x -> map_declaration env x
-      | `Stmt_blk x -> map_statement_block env x
-      | `If_stmt x -> map_if_statement env x
-      | `Swit_stmt x -> map_switch_statement env x
-      | `For_stmt x -> map_for_statement env x
-      | `For_in_stmt x -> map_for_in_statement env x
-      | `While_stmt x -> map_while_statement env x
-      | `Do_stmt x -> map_do_statement env x
-      | `Try_stmt x -> map_try_statement env x
-      | `With_stmt x -> map_with_statement env x
-      | `Brk_stmt x -> map_break_statement env x
-      | `Cont_stmt x -> map_continue_statement env x
-      | `Ret_stmt x -> map_return_statement env x
-      | `Throw_stmt x -> map_throw_statement env x
-      | `Empty_stmt tok -> token env tok (* ";" *)
-      | `Labe_stmt x -> map_labeled_statement env x
-      )
-    ) v4
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_switch_default (env : env) ((v1, v2, v3) : CST.switch_default) =
-  let v1 = token env v1 (* "default" *) in
-  let v2 = token env v2 (* ":" *) in
-  let v3 =
-    List.map (fun x ->
-      (match x with
-      | `Expo_stmt x -> map_export_statement env x
-      | `Impo_stmt x -> map_import_statement env x
-      | `Debu_stmt x -> map_debugger_statement env x
-      | `Exp_stmt x -> map_expression_statement env x
-      | `Decl x -> map_declaration env x
-      | `Stmt_blk x -> map_statement_block env x
-      | `If_stmt x -> map_if_statement env x
-      | `Swit_stmt x -> map_switch_statement env x
-      | `For_stmt x -> map_for_statement env x
-      | `For_in_stmt x -> map_for_in_statement env x
-      | `While_stmt x -> map_while_statement env x
-      | `Do_stmt x -> map_do_statement env x
-      | `Try_stmt x -> map_try_statement env x
-      | `With_stmt x -> map_with_statement env x
-      | `Brk_stmt x -> map_break_statement env x
-      | `Cont_stmt x -> map_continue_statement env x
-      | `Ret_stmt x -> map_return_statement env x
-      | `Throw_stmt x -> map_throw_statement env x
-      | `Empty_stmt tok -> token env tok (* ";" *)
-      | `Labe_stmt x -> map_labeled_statement env x
-      )
-    ) v3
-  in
-  todo env (v1, v2, v3)
-
-
-and map_catch_clause (env : env) ((v1, v2, v3) : CST.catch_clause) =
-  let v1 = token env v1 (* "catch" *) in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2, v3) ->
-        let v1 = token env v1 (* "(" *) in
-        let v2 =
-          (match v2 with
-          | `Id tok -> token env tok (* identifier *)
-          | `Choice_obj x ->
-              (match x with
-              | `Obj x -> map_object_ env x
-              | `Array x -> map_array_ env x
-              )
-          )
-        in
-        let v3 = token env v3 (* ")" *) in
-        todo env (v1, v2, v3)
-    | None -> todo env ())
-  in
-  let v3 = map_statement_block env v3 in
-  todo env (v1, v2, v3)
-
-
-and map_finally_clause (env : env) ((v1, v2) : CST.finally_clause) =
-  let v1 = token env v1 (* "finally" *) in
-  let v2 = map_statement_block env v2 in
-  todo env (v1, v2)
-
-
-and map_parenthesized_expression (env : env) ((v1, v2, v3) : CST.parenthesized_expression) =
+let rec map_parenthesized_expression (env : env) ((v1, v2, v3) : CST.parenthesized_expression) =
   let v1 = token env v1 (* "(" *) in
   let v2 =
     (match v2 with
@@ -1311,464 +367,21 @@ and map_parenthesized_expression (env : env) ((v1, v2, v3) : CST.parenthesized_e
   let v3 = token env v3 (* ")" *) in
   todo env (v1, v2, v3)
 
+and map_call_signature_ (env : env) (x : CST.call_signature_) =
+  map_call_signature env x
 
-and map_expression (env : env) (x : CST.expression) =
-  (match x with
-  | `Exp_as_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
-      let v2 = token env v2 (* "as" *) in
-      let v3 =
-        (match v3 with
-        | `Type x -> map_type_ env x
-        | `Temp_str x -> map_template_string env x
-        )
-      in
-      todo env (v1, v2, v3)
-  | `Exp_non_null_exp (v1, v2) ->
-      let v1 = map_expression env v1 in
-      let v2 = token env v2 (* "!" *) in
-      todo env (v1, v2)
-  | `Exp_inte_modu x -> map_internal_module env x
-  | `Exp_super tok -> token env tok (* "super" *)
-  | `Exp_type_asse (v1, v2) ->
-      let v1 = map_type_arguments env v1 in
-      let v2 = map_expression env v2 in
-      todo env (v1, v2)
-  | `Exp_choice_this x ->
-      (match x with
-      | `This tok -> token env tok (* "this" *)
-      | `Id tok -> token env tok (* identifier *)
-      | `Choice_decl x ->
-          (match x with
-          | `Decl tok -> token env tok (* "declare" *)
-          | `Name tok -> token env tok (* "namespace" *)
-          | `Type tok -> token env tok (* "type" *)
-          | `Publ tok -> token env tok (* "public" *)
-          | `Priv tok -> token env tok (* "private" *)
-          | `Prot tok -> token env tok (* "protected" *)
-          | `Read tok -> token env tok (* "readonly" *)
-          | `Modu tok -> token env tok (* "module" *)
-          | `Any tok -> token env tok (* "any" *)
-          | `Num tok -> token env tok (* "number" *)
-          | `Bool tok -> token env tok (* "boolean" *)
-          | `Str tok -> token env tok (* "string" *)
-          | `Symb tok -> token env tok (* "symbol" *)
-          | `Void tok -> token env tok (* "void" *)
-          | `Expo tok -> token env tok (* "export" *)
-          | `Choice_get x ->
-              (match x with
-              | `Get tok -> token env tok (* "get" *)
-              | `Set tok -> token env tok (* "set" *)
-              | `Async tok -> token env tok (* "async" *)
-              | `Stat tok -> token env tok (* "static" *)
-              )
-          )
-      | `Num tok -> token env tok (* number *)
-      | `Str x -> map_string_ env x
-      | `Temp_str x -> map_template_string env x
-      | `Regex x -> map_regex env x
-      | `True tok -> token env tok (* "true" *)
-      | `False tok -> token env tok (* "false" *)
-      | `Null tok -> token env tok (* "null" *)
-      | `Unde tok -> token env tok (* "undefined" *)
-      | `Impo tok -> token env tok (* import *)
-      | `Obj x -> map_object_ env x
-      | `Array x -> map_array_ env x
-      | `Func x -> map_function_ env x
-      | `Arrow_func x -> map_arrow_function env x
-      | `Gene_func x -> map_generator_function env x
-      | `Class x -> map_class_ env x
-      | `Paren_exp x -> map_parenthesized_expression env x
-      | `Subs_exp x -> map_subscript_expression env x
-      | `Memb_exp x -> map_member_expression env x
-      | `Meta_prop x -> map_meta_property env x
-      | `New_exp x -> map_new_expression env x
-      )
-  | `Exp_assign_exp (v1, v2, v3) ->
-      let v1 =
-        (match v1 with
-        | `Paren_exp x -> map_parenthesized_expression env x
-        | `Choice_memb_exp x ->
-            (match x with
-            | `Memb_exp x -> map_member_expression env x
-            | `Subs_exp x -> map_subscript_expression env x
-            | `Id tok -> token env tok (* identifier *)
-            | `Choice_decl x ->
-                (match x with
-                | `Decl tok -> token env tok (* "declare" *)
-                | `Name tok -> token env tok (* "namespace" *)
-                | `Type tok -> token env tok (* "type" *)
-                | `Publ tok -> token env tok (* "public" *)
-                | `Priv tok -> token env tok (* "private" *)
-                | `Prot tok -> token env tok (* "protected" *)
-                | `Read tok -> token env tok (* "readonly" *)
-                | `Modu tok -> token env tok (* "module" *)
-                | `Any tok -> token env tok (* "any" *)
-                | `Num tok -> token env tok (* "number" *)
-                | `Bool tok -> token env tok (* "boolean" *)
-                | `Str tok -> token env tok (* "string" *)
-                | `Symb tok -> token env tok (* "symbol" *)
-                | `Void tok -> token env tok (* "void" *)
-                | `Expo tok -> token env tok (* "export" *)
-                | `Choice_get x ->
-                    (match x with
-                    | `Get tok -> token env tok (* "get" *)
-                    | `Set tok -> token env tok (* "set" *)
-                    | `Async tok -> token env tok (* "async" *)
-                    | `Stat tok -> token env tok (* "static" *)
-                    )
-                )
-            | `Choice_obj x ->
-                (match x with
-                | `Obj x -> map_object_ env x
-                | `Array x -> map_array_ env x
-                )
-            )
-        )
-      in
-      let v2 = token env v2 (* "=" *) in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  | `Exp_augm_assign_exp (v1, v2, v3) ->
-      let v1 =
-        (match v1 with
-        | `Memb_exp x -> map_member_expression env x
-        | `Subs_exp x -> map_subscript_expression env x
-        | `Choice_decl x ->
-            (match x with
-            | `Decl tok -> token env tok (* "declare" *)
-            | `Name tok -> token env tok (* "namespace" *)
-            | `Type tok -> token env tok (* "type" *)
-            | `Publ tok -> token env tok (* "public" *)
-            | `Priv tok -> token env tok (* "private" *)
-            | `Prot tok -> token env tok (* "protected" *)
-            | `Read tok -> token env tok (* "readonly" *)
-            | `Modu tok -> token env tok (* "module" *)
-            | `Any tok -> token env tok (* "any" *)
-            | `Num tok -> token env tok (* "number" *)
-            | `Bool tok -> token env tok (* "boolean" *)
-            | `Str tok -> token env tok (* "string" *)
-            | `Symb tok -> token env tok (* "symbol" *)
-            | `Void tok -> token env tok (* "void" *)
-            | `Expo tok -> token env tok (* "export" *)
-            | `Choice_get x ->
-                (match x with
-                | `Get tok -> token env tok (* "get" *)
-                | `Set tok -> token env tok (* "set" *)
-                | `Async tok -> token env tok (* "async" *)
-                | `Stat tok -> token env tok (* "static" *)
-                )
-            )
-        | `Id tok -> token env tok (* identifier *)
-        | `Paren_exp x -> map_parenthesized_expression env x
-        )
-      in
-      let v2 =
-        (match v2 with
-        | `PLUSEQ tok -> token env tok (* "+=" *)
-        | `DASHEQ tok -> token env tok (* "-=" *)
-        | `STAREQ tok -> token env tok (* "*=" *)
-        | `SLASHEQ tok -> token env tok (* "/=" *)
-        | `PERCEQ tok -> token env tok (* "%=" *)
-        | `HATEQ tok -> token env tok (* "^=" *)
-        | `AMPEQ tok -> token env tok (* "&=" *)
-        | `BAREQ tok -> token env tok (* "|=" *)
-        | `GTGTEQ tok -> token env tok (* ">>=" *)
-        | `GTGTGTEQ tok -> token env tok (* ">>>=" *)
-        | `LTLTEQ tok -> token env tok (* "<<=" *)
-        | `STARSTAREQ tok -> token env tok (* "**=" *)
-        )
-      in
-      let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  | `Exp_await_exp (v1, v2) ->
-      let v1 = token env v1 (* "await" *) in
-      let v2 = map_expression env v2 in
-      todo env (v1, v2)
-  | `Exp_un_exp x -> map_unary_expression env x
-  | `Exp_bin_exp x -> map_binary_expression env x
-  | `Exp_tern_exp (v1, v2, v3, v4, v5) ->
-      let v1 = map_expression env v1 in
-      let v2 = token env v2 (* "?" *) in
-      let v3 = map_expression env v3 in
-      let v4 = token env v4 (* ":" *) in
-      let v5 = map_expression env v5 in
-      todo env (v1, v2, v3, v4, v5)
-  | `Exp_upda_exp x -> map_update_expression env x
-  | `Exp_call_exp (v1, v2, v3) ->
-      let v1 =
-        (match v1 with
-        | `Exp x -> map_expression env x
-        | `Super tok -> token env tok (* "super" *)
-        | `Func x -> map_function_ env x
-        )
-      in
-      let v2 =
-        (match v2 with
-        | Some x -> map_type_arguments env x
-        | None -> todo env ())
-      in
-      let v3 =
-        (match v3 with
-        | `Args x -> map_arguments env x
-        | `Temp_str x -> map_template_string env x
-        )
-      in
-      todo env (v1, v2, v3)
-  | `Exp_yield_exp (v1, v2) ->
-      let v1 = token env v1 (* "yield" *) in
-      let v2 =
-        (match v2 with
-        | `STAR_exp (v1, v2) ->
-            let v1 = token env v1 (* "*" *) in
-            let v2 = map_expression env v2 in
-            todo env (v1, v2)
-        | `Opt_exp opt ->
-            (match opt with
-            | Some x -> map_expression env x
-            | None -> todo env ())
-        )
-      in
-      todo env (v1, v2)
-  )
-
-
-and map_object_ (env : env) ((v1, v2, v3) : CST.object_) =
-  let v1 = token env v1 (* "{" *) in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) ->
-        let v1 =
-          (match v1 with
-          | Some x ->
-              (match x with
-              | `Pair x -> map_pair env x
-              | `Spre_elem x -> map_spread_element env x
-              | `Meth_defi x -> map_method_definition env x
-              | `Assign_pat x -> map_assignment_pattern env x
-              | `Choice_id x ->
-                  (match x with
-                  | `Id tok -> token env tok (* identifier *)
-                  | `Choice_decl x ->
-                      (match x with
-                      | `Decl tok -> token env tok (* "declare" *)
-                      | `Name tok -> token env tok (* "namespace" *)
-                      | `Type tok -> token env tok (* "type" *)
-                      | `Publ tok -> token env tok (* "public" *)
-                      | `Priv tok -> token env tok (* "private" *)
-                      | `Prot tok -> token env tok (* "protected" *)
-                      | `Read tok -> token env tok (* "readonly" *)
-                      | `Modu tok -> token env tok (* "module" *)
-                      | `Any tok -> token env tok (* "any" *)
-                      | `Num tok -> token env tok (* "number" *)
-                      | `Bool tok -> token env tok (* "boolean" *)
-                      | `Str tok -> token env tok (* "string" *)
-                      | `Symb tok -> token env tok (* "symbol" *)
-                      | `Void tok -> token env tok (* "void" *)
-                      | `Expo tok -> token env tok (* "export" *)
-                      | `Choice_get x ->
-                          (match x with
-                          | `Get tok -> token env tok (* "get" *)
-                          | `Set tok -> token env tok (* "set" *)
-                          | `Async tok -> token env tok (* "async" *)
-                          | `Stat tok -> token env tok (* "static" *)
-                          )
-                      )
-                  )
-              )
-          | None -> todo env ())
-        in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 =
-              (match v2 with
-              | Some x ->
-                  (match x with
-                  | `Pair x -> map_pair env x
-                  | `Spre_elem x -> map_spread_element env x
-                  | `Meth_defi x -> map_method_definition env x
-                  | `Assign_pat x -> map_assignment_pattern env x
-                  | `Choice_id x ->
-                      (match x with
-                      | `Id tok -> token env tok (* identifier *)
-                      | `Choice_decl x ->
-                          (match x with
-                          | `Decl tok -> token env tok (* "declare" *)
-                          | `Name tok -> token env tok (* "namespace" *)
-                          | `Type tok -> token env tok (* "type" *)
-                          | `Publ tok -> token env tok (* "public" *)
-                          | `Priv tok -> token env tok (* "private" *)
-                          | `Prot tok -> token env tok (* "protected" *)
-                          | `Read tok -> token env tok (* "readonly" *)
-                          | `Modu tok -> token env tok (* "module" *)
-                          | `Any tok -> token env tok (* "any" *)
-                          | `Num tok -> token env tok (* "number" *)
-                          | `Bool tok -> token env tok (* "boolean" *)
-                          | `Str tok -> token env tok (* "string" *)
-                          | `Symb tok -> token env tok (* "symbol" *)
-                          | `Void tok -> token env tok (* "void" *)
-                          | `Expo tok -> token env tok (* "export" *)
-                          | `Choice_get x ->
-                              (match x with
-                              | `Get tok -> token env tok (* "get" *)
-                              | `Set tok -> token env tok (* "set" *)
-                              | `Async tok -> token env tok (* "async" *)
-                              | `Stat tok -> token env tok (* "static" *)
-                              )
-                          )
-                      )
-                  )
-              | None -> todo env ())
-            in
-            todo env (v1, v2)
-          ) v2
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v3 = token env v3 (* "}" *) in
-  todo env (v1, v2, v3)
-
-
-and map_assignment_pattern (env : env) ((v1, v2, v3) : CST.assignment_pattern) =
-  let v1 =
-    (match v1 with
-    | `Choice_choice_decl x ->
-        (match x with
-        | `Choice_decl x ->
-            (match x with
-            | `Decl tok -> token env tok (* "declare" *)
-            | `Name tok -> token env tok (* "namespace" *)
-            | `Type tok -> token env tok (* "type" *)
-            | `Publ tok -> token env tok (* "public" *)
-            | `Priv tok -> token env tok (* "private" *)
-            | `Prot tok -> token env tok (* "protected" *)
-            | `Read tok -> token env tok (* "readonly" *)
-            | `Modu tok -> token env tok (* "module" *)
-            | `Any tok -> token env tok (* "any" *)
-            | `Num tok -> token env tok (* "number" *)
-            | `Bool tok -> token env tok (* "boolean" *)
-            | `Str tok -> token env tok (* "string" *)
-            | `Symb tok -> token env tok (* "symbol" *)
-            | `Void tok -> token env tok (* "void" *)
-            | `Expo tok -> token env tok (* "export" *)
-            | `Choice_get x ->
-                (match x with
-                | `Get tok -> token env tok (* "get" *)
-                | `Set tok -> token env tok (* "set" *)
-                | `Async tok -> token env tok (* "async" *)
-                | `Stat tok -> token env tok (* "static" *)
-                )
-            )
-        | `Id tok -> token env tok (* identifier *)
-        )
-    | `Choice_obj x ->
-        (match x with
-        | `Obj x -> map_object_ env x
-        | `Array x -> map_array_ env x
-        )
-    )
-  in
-  let v2 = token env v2 (* "=" *) in
-  let v3 = map_expression env v3 in
-  todo env (v1, v2, v3)
-
-
-and map_array_ (env : env) ((v1, v2, v3) : CST.array_) =
-  let v1 = token env v1 (* "[" *) in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) ->
-        let v1 =
-          (match v1 with
-          | Some x ->
-              (match x with
-              | `Exp x -> map_expression env x
-              | `Spre_elem x -> map_spread_element env x
-              )
-          | None -> todo env ())
-        in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 =
-              (match v2 with
-              | Some x ->
-                  (match x with
-                  | `Exp x -> map_expression env x
-                  | `Spre_elem x -> map_spread_element env x
-                  )
-              | None -> todo env ())
-            in
-            todo env (v1, v2)
-          ) v2
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  let v3 = token env v3 (* "]" *) in
-  todo env (v1, v2, v3)
-
-
-and map_class_ (env : env) ((v1, v2, v3, v4, v5, v6) : CST.class_) =
-  let v1 = List.map (map_decorator env) v1 in
-  let v2 = token env v2 (* "class" *) in
+and map_variable_declaration (env : env) ((v1, v2, v3, v4) : CST.variable_declaration) =
+  let v1 = token env v1 (* "var" *) in
+  let v2 = map_variable_declarator env v2 in
   let v3 =
-    (match v3 with
-    | Some tok -> token env tok (* identifier *)
-    | None -> todo env ())
-  in
-  let v4 =
-    (match v4 with
-    | Some x -> map_type_parameters env x
-    | None -> todo env ())
-  in
-  let v5 =
-    (match v5 with
-    | Some x -> map_class_heritage env x
-    | None -> todo env ())
-  in
-  let v6 = map_class_body env v6 in
-  todo env (v1, v2, v3, v4, v5, v6)
-
-
-and map_class_declaration (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.class_declaration) =
-  let v1 = List.map (map_decorator env) v1 in
-  let v2 = token env v2 (* "class" *) in
-  let v3 = token env v3 (* identifier *) in
-  let v4 =
-    (match v4 with
-    | Some x -> map_type_parameters env x
-    | None -> todo env ())
-  in
-  let v5 =
-    (match v5 with
-    | Some x -> map_class_heritage env x
-    | None -> todo env ())
-  in
-  let v6 = map_class_body env v6 in
-  let v7 =
-    (match v7 with
-    | Some tok -> token env tok (* automatic_semicolon *)
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3, v4, v5, v6, v7)
-
-
-and map_class_heritage (env : env) (x : CST.class_heritage) =
-  (match x with
-  | `Class_heri_extens_clau_opt_imples_clau (v1, v2) ->
-      let v1 = map_extends_clause env v1 in
-      let v2 =
-        (match v2 with
-        | Some x -> map_implements_clause env x
-        | None -> todo env ())
-      in
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_variable_declarator env v2 in
       todo env (v1, v2)
-  | `Class_heri_imples_clau x -> map_implements_clause env x
-  )
-
+    ) v3
+  in
+  let v4 = map_anon_choice_auto_semi env v4 in
+  todo env (v1, v2, v3, v4)
 
 and map_function_ (env : env) ((v1, v2, v3, v4, v5) : CST.function_) =
   let v1 =
@@ -1782,259 +395,88 @@ and map_function_ (env : env) ((v1, v2, v3, v4, v5) : CST.function_) =
     | Some tok -> token env tok (* identifier *)
     | None -> todo env ())
   in
-  let v4 = map_call_signature env v4 in
+  let v4 = map_call_signature_ env v4 in
   let v5 = map_statement_block env v5 in
   todo env (v1, v2, v3, v4, v5)
 
-
-and map_function_declaration (env : env) ((v1, v2, v3, v4, v5, v6) : CST.function_declaration) =
-  let v1 =
-    (match v1 with
-    | Some tok -> token env tok (* "async" *)
-    | None -> todo env ())
-  in
-  let v2 = token env v2 (* "function" *) in
-  let v3 = token env v3 (* identifier *) in
-  let v4 = map_call_signature env v4 in
-  let v5 = map_statement_block env v5 in
-  let v6 =
-    (match v6 with
-    | Some tok -> token env tok (* automatic_semicolon *)
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3, v4, v5, v6)
-
-
-and map_generator_function (env : env) ((v1, v2, v3, v4, v5, v6) : CST.generator_function) =
-  let v1 =
-    (match v1 with
-    | Some tok -> token env tok (* "async" *)
-    | None -> todo env ())
-  in
-  let v2 = token env v2 (* "function" *) in
-  let v3 = token env v3 (* "*" *) in
-  let v4 =
-    (match v4 with
-    | Some tok -> token env tok (* identifier *)
-    | None -> todo env ())
-  in
-  let v5 = map_call_signature env v5 in
-  let v6 = map_statement_block env v6 in
-  todo env (v1, v2, v3, v4, v5, v6)
-
-
-and map_generator_function_declaration (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.generator_function_declaration) =
-  let v1 =
-    (match v1 with
-    | Some tok -> token env tok (* "async" *)
-    | None -> todo env ())
-  in
-  let v2 = token env v2 (* "function" *) in
-  let v3 = token env v3 (* "*" *) in
-  let v4 = token env v4 (* identifier *) in
-  let v5 = map_call_signature env v5 in
-  let v6 = map_statement_block env v6 in
-  let v7 =
-    (match v7 with
-    | Some tok -> token env tok (* automatic_semicolon *)
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3, v4, v5, v6, v7)
-
-
-and map_arrow_function (env : env) ((v1, v2, v3, v4) : CST.arrow_function) =
-  let v1 =
-    (match v1 with
-    | Some tok -> token env tok (* "async" *)
-    | None -> todo env ())
-  in
-  let v2 =
-    (match v2 with
-    | `Choice_choice_decl x ->
-        (match x with
-        | `Choice_decl x ->
-            (match x with
-            | `Decl tok -> token env tok (* "declare" *)
-            | `Name tok -> token env tok (* "namespace" *)
-            | `Type tok -> token env tok (* "type" *)
-            | `Publ tok -> token env tok (* "public" *)
-            | `Priv tok -> token env tok (* "private" *)
-            | `Prot tok -> token env tok (* "protected" *)
-            | `Read tok -> token env tok (* "readonly" *)
-            | `Modu tok -> token env tok (* "module" *)
-            | `Any tok -> token env tok (* "any" *)
-            | `Num tok -> token env tok (* "number" *)
-            | `Bool tok -> token env tok (* "boolean" *)
-            | `Str tok -> token env tok (* "string" *)
-            | `Symb tok -> token env tok (* "symbol" *)
-            | `Void tok -> token env tok (* "void" *)
-            | `Expo tok -> token env tok (* "export" *)
-            | `Choice_get x ->
-                (match x with
-                | `Get tok -> token env tok (* "get" *)
-                | `Set tok -> token env tok (* "set" *)
-                | `Async tok -> token env tok (* "async" *)
-                | `Stat tok -> token env tok (* "static" *)
-                )
-            )
-        | `Id tok -> token env tok (* identifier *)
-        )
-    | `Call_sign x -> map_call_signature env x
-    )
-  in
-  let v3 = token env v3 (* "=>" *) in
-  let v4 =
-    (match v4 with
-    | `Exp x -> map_expression env x
-    | `Stmt_blk x -> map_statement_block env x
-    )
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_call_signature (env : env) ((v1, v2, v3) : CST.call_signature) =
-  let v1 =
-    (match v1 with
-    | Some x -> map_type_parameters env x
-    | None -> todo env ())
-  in
-  let v2 = map_formal_parameters env v2 in
-  let v3 =
-    (match v3 with
-    | Some x -> map_type_annotation env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3)
-
-
-and map_new_expression (env : env) ((v1, v2, v3) : CST.new_expression) =
-  let v1 = token env v1 (* "new" *) in
-  let v2 =
-    (match v2 with
-    | `This tok -> token env tok (* "this" *)
-    | `Id tok -> token env tok (* identifier *)
-    | `Choice_decl x ->
-        (match x with
-        | `Decl tok -> token env tok (* "declare" *)
-        | `Name tok -> token env tok (* "namespace" *)
-        | `Type tok -> token env tok (* "type" *)
-        | `Publ tok -> token env tok (* "public" *)
-        | `Priv tok -> token env tok (* "private" *)
-        | `Prot tok -> token env tok (* "protected" *)
-        | `Read tok -> token env tok (* "readonly" *)
-        | `Modu tok -> token env tok (* "module" *)
-        | `Any tok -> token env tok (* "any" *)
-        | `Num tok -> token env tok (* "number" *)
-        | `Bool tok -> token env tok (* "boolean" *)
-        | `Str tok -> token env tok (* "string" *)
-        | `Symb tok -> token env tok (* "symbol" *)
-        | `Void tok -> token env tok (* "void" *)
-        | `Expo tok -> token env tok (* "export" *)
-        | `Choice_get x ->
-            (match x with
-            | `Get tok -> token env tok (* "get" *)
-            | `Set tok -> token env tok (* "set" *)
-            | `Async tok -> token env tok (* "async" *)
-            | `Stat tok -> token env tok (* "static" *)
-            )
-        )
-    | `Num tok -> token env tok (* number *)
-    | `Str x -> map_string_ env x
-    | `Temp_str x -> map_template_string env x
-    | `Regex x -> map_regex env x
-    | `True tok -> token env tok (* "true" *)
-    | `False tok -> token env tok (* "false" *)
-    | `Null tok -> token env tok (* "null" *)
-    | `Unde tok -> token env tok (* "undefined" *)
-    | `Impo tok -> token env tok (* import *)
-    | `Obj x -> map_object_ env x
-    | `Array x -> map_array_ env x
-    | `Func x -> map_function_ env x
-    | `Arrow_func x -> map_arrow_function env x
-    | `Gene_func x -> map_generator_function env x
-    | `Class x -> map_class_ env x
-    | `Paren_exp x -> map_parenthesized_expression env x
-    | `Subs_exp x -> map_subscript_expression env x
-    | `Memb_exp x -> map_member_expression env x
-    | `Meta_prop x -> map_meta_property env x
-    | `New_exp x -> map_new_expression env x
-    )
-  in
-  let v3 =
-    (match v3 with
-    | Some x -> map_arguments env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3)
-
-
-and map_member_expression (env : env) ((v1, v2, v3) : CST.member_expression) =
-  let v1 =
-    (match v1 with
-    | `Exp x -> map_expression env x
-    | `Id tok -> token env tok (* identifier *)
-    | `Super tok -> token env tok (* "super" *)
-    | `Choice_decl x ->
-        (match x with
-        | `Decl tok -> token env tok (* "declare" *)
-        | `Name tok -> token env tok (* "namespace" *)
-        | `Type tok -> token env tok (* "type" *)
-        | `Publ tok -> token env tok (* "public" *)
-        | `Priv tok -> token env tok (* "private" *)
-        | `Prot tok -> token env tok (* "protected" *)
-        | `Read tok -> token env tok (* "readonly" *)
-        | `Modu tok -> token env tok (* "module" *)
-        | `Any tok -> token env tok (* "any" *)
-        | `Num tok -> token env tok (* "number" *)
-        | `Bool tok -> token env tok (* "boolean" *)
-        | `Str tok -> token env tok (* "string" *)
-        | `Symb tok -> token env tok (* "symbol" *)
-        | `Void tok -> token env tok (* "void" *)
-        | `Expo tok -> token env tok (* "export" *)
-        | `Choice_get x ->
-            (match x with
-            | `Get tok -> token env tok (* "get" *)
-            | `Set tok -> token env tok (* "set" *)
-            | `Async tok -> token env tok (* "async" *)
-            | `Stat tok -> token env tok (* "static" *)
-            )
-        )
-    )
-  in
-  let v2 = token env v2 (* "." *) in
-  let v3 = token env v3 (* identifier *) in
-  todo env (v1, v2, v3)
-
-
-and map_subscript_expression (env : env) ((v1, v2, v3, v4) : CST.subscript_expression) =
-  let v1 =
-    (match v1 with
-    | `Exp x -> map_expression env x
-    | `Super tok -> token env tok (* "super" *)
-    )
-  in
-  let v2 = token env v2 (* "[" *) in
-  let v3 =
-    (match v3 with
-    | `Exp x -> map_expression env x
-    | `Seq_exp x -> map_sequence_expression env x
-    )
-  in
-  let v4 = token env v4 (* "]" *) in
-  todo env (v1, v2, v3, v4)
-
-
-and map_initializer_ (env : env) ((v1, v2) : CST.initializer_) =
-  let v1 = token env v1 (* "=" *) in
-  let v2 = map_expression env v2 in
+and map_generic_type (env : env) ((v1, v2) : CST.generic_type) =
+  let v1 = map_anon_choice_id env v1 in
+  let v2 = map_type_arguments env v2 in
   todo env (v1, v2)
 
+and map_anon_choice_expo_stmt (env : env) (x : CST.anon_choice_expo_stmt) =
+  (match x with
+  | `Expo_stmt x -> map_export_statement env x
+  | `Prop_sign (v1, v2, v3, v4, v5, v6) ->
+      let v1 =
+        (match v1 with
+        | Some x -> map_accessibility_modifier env x
+        | None -> todo env ())
+      in
+      let v2 =
+        (match v2 with
+        | Some tok -> token env tok (* "static" *)
+        | None -> todo env ())
+      in
+      let v3 =
+        (match v3 with
+        | Some tok -> token env tok (* "readonly" *)
+        | None -> todo env ())
+      in
+      let v4 = map_property_name env v4 in
+      let v5 =
+        (match v5 with
+        | Some tok -> token env tok (* "?" *)
+        | None -> todo env ())
+      in
+      let v6 =
+        (match v6 with
+        | Some x -> map_type_annotation env x
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4, v5, v6)
+  | `Call_sign_ x -> map_call_signature_ env x
+  | `Cons_sign (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "new" *) in
+      let v2 =
+        (match v2 with
+        | Some x -> map_type_parameters env x
+        | None -> todo env ())
+      in
+      let v3 = map_formal_parameters env v3 in
+      let v4 =
+        (match v4 with
+        | Some x -> map_type_annotation env x
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4)
+  | `Index_sign x -> map_index_signature env x
+  | `Meth_sign x -> map_method_signature env x
+  )
 
-and map_spread_element (env : env) ((v1, v2) : CST.spread_element) =
-  let v1 = token env v1 (* "..." *) in
-  let v2 = map_expression env v2 in
-  todo env (v1, v2)
+and map_implements_clause (env : env) ((v1, v2, v3) : CST.implements_clause) =
+  let v1 = token env v1 (* "implements" *) in
+  let v2 = map_type_ env v2 in
+  let v3 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_type_ env v2 in
+      todo env (v1, v2)
+    ) v3
+  in
+  todo env (v1, v2, v3)
 
+and map_anon_choice_exp (env : env) (x : CST.anon_choice_exp) =
+  (match x with
+  | `Exp x -> map_expression env x
+  | `Seq_exp x -> map_sequence_expression env x
+  )
+
+and map_switch_default (env : env) ((v1, v2, v3) : CST.switch_default) =
+  let v1 = token env v1 (* "default" *) in
+  let v2 = token env v2 (* ":" *) in
+  let v3 = List.map (map_anon_choice_expo_stmt_ env) v3 in
+  todo env (v1, v2, v3)
 
 and map_binary_expression (env : env) (x : CST.binary_expression) =
   (match x with
@@ -2165,6 +607,783 @@ and map_binary_expression (env : env) (x : CST.binary_expression) =
       todo env (v1, v2, v3)
   )
 
+and map_arguments (env : env) ((v1, v2, v3) : CST.arguments) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    map_anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp env v2
+  in
+  let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
+
+and map_generator_function_declaration (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.generator_function_declaration) =
+  let v1 =
+    (match v1 with
+    | Some tok -> token env tok (* "async" *)
+    | None -> todo env ())
+  in
+  let v2 = token env v2 (* "function" *) in
+  let v3 = token env v3 (* "*" *) in
+  let v4 = token env v4 (* identifier *) in
+  let v5 = map_call_signature_ env v5 in
+  let v6 = map_statement_block env v6 in
+  let v7 =
+    (match v7 with
+    | Some tok -> token env tok (* automatic_semicolon *)
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3, v4, v5, v6, v7)
+
+and map_variable_declarator (env : env) ((v1, v2, v3) : CST.variable_declarator) =
+  let v1 = map_anon_choice_id3 env v1 in
+  let v2 =
+    (match v2 with
+    | Some x -> map_type_annotation env x
+    | None -> todo env ())
+  in
+  let v3 =
+    (match v3 with
+    | Some x -> map_initializer_ env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3)
+
+and map_sequence_expression (env : env) ((v1, v2, v3) : CST.sequence_expression) =
+  let v1 = map_expression env v1 in
+  let v2 = token env v2 (* "," *) in
+  let v3 =
+    (match v3 with
+    | `Seq_exp x -> map_sequence_expression env x
+    | `Exp x -> map_expression env x
+    )
+  in
+  todo env (v1, v2, v3)
+
+and map_type_arguments (env : env) ((v1, v2, v3, v4, v5) : CST.type_arguments) =
+  let v1 = token env v1 (* "<" *) in
+  let v2 = map_type_ env v2 in
+  let v3 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_type_ env v2 in
+      todo env (v1, v2)
+    ) v3
+  in
+  let v4 =
+    (match v4 with
+    | Some tok -> token env tok (* "," *)
+    | None -> todo env ())
+  in
+  let v5 = token env v5 (* ">" *) in
+  todo env (v1, v2, v3, v4, v5)
+
+and map_class_body (env : env) ((v1, v2, v3) : CST.class_body) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    List.map (fun x ->
+      (match x with
+      | `Deco x -> map_decorator env x
+      | `Meth_defi_opt_choice_auto_semi (v1, v2) ->
+          let v1 = map_method_definition env v1 in
+          let v2 =
+            (match v2 with
+            | Some x -> map_anon_choice_auto_semi env x
+            | None -> todo env ())
+          in
+          todo env (v1, v2)
+      | `Choice_abst_meth_sign_choice_choice_auto_semi (v1, v2) ->
+          let v1 =
+            (match v1 with
+            | `Abst_meth_sign x -> map_abstract_method_signature env x
+            | `Index_sign x -> map_index_signature env x
+            | `Meth_sign x -> map_method_signature env x
+            | `Publ_field_defi x -> map_public_field_definition env x
+            )
+          in
+          let v2 =
+            (match v2 with
+            | `Choice_auto_semi x -> map_anon_choice_auto_semi env x
+            | `COMMA tok -> token env tok (* "," *)
+            )
+          in
+          todo env (v1, v2)
+      )
+    ) v2
+  in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+and map_type_parameter (env : env) ((v1, v2, v3) : CST.type_parameter) =
+  let v1 = token env v1 (* identifier *) in
+  let v2 =
+    (match v2 with
+    | Some x -> map_constraint_ env x
+    | None -> todo env ())
+  in
+  let v3 =
+    (match v3 with
+    | Some x -> map_default_type env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3)
+
+and map_anon_choice_obj (env : env) (x : CST.anon_choice_obj) =
+  (match x with
+  | `Obj x -> map_object_ env x
+  | `Array x -> map_array_ env x
+  )
+
+and map_anon_choice_this (env : env) (x : CST.anon_choice_this) =
+  (match x with
+  | `This tok -> token env tok (* "this" *)
+  | `Id tok -> token env tok (* identifier *)
+  | `Choice_decl x -> map_anon_choice_decl env x
+  | `Num tok -> token env tok (* number *)
+  | `Str x -> map_string_ env x
+  | `Temp_str x -> map_template_string env x
+  | `Regex (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "/" *) in
+      let v2 = token env v2 (* regex_pattern *) in
+      let v3 = token env v3 (* "/" *) in
+      let v4 =
+        (match v4 with
+        | Some tok -> token env tok (* pattern [a-z]+ *)
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4)
+  | `True tok -> token env tok (* "true" *)
+  | `False tok -> token env tok (* "false" *)
+  | `Null tok -> token env tok (* "null" *)
+  | `Unde tok -> token env tok (* "undefined" *)
+  | `Impo tok -> token env tok (* import *)
+  | `Obj x -> map_object_ env x
+  | `Array x -> map_array_ env x
+  | `Func x -> map_function_ env x
+  | `Arrow_func (v1, v2, v3, v4) ->
+      let v1 =
+        (match v1 with
+        | Some tok -> token env tok (* "async" *)
+        | None -> todo env ())
+      in
+      let v2 =
+        (match v2 with
+        | `Choice_choice_decl x -> map_anon_choice_choice_decl env x
+        | `Call_sign x -> map_call_signature_ env x
+        )
+      in
+      let v3 = token env v3 (* "=>" *) in
+      let v4 =
+        (match v4 with
+        | `Exp x -> map_expression env x
+        | `Stmt_blk x -> map_statement_block env x
+        )
+      in
+      todo env (v1, v2, v3, v4)
+  | `Gene_func (v1, v2, v3, v4, v5, v6) ->
+      let v1 =
+        (match v1 with
+        | Some tok -> token env tok (* "async" *)
+        | None -> todo env ())
+      in
+      let v2 = token env v2 (* "function" *) in
+      let v3 = token env v3 (* "*" *) in
+      let v4 =
+        (match v4 with
+        | Some tok -> token env tok (* identifier *)
+        | None -> todo env ())
+      in
+      let v5 = map_call_signature_ env v5 in
+      let v6 = map_statement_block env v6 in
+      todo env (v1, v2, v3, v4, v5, v6)
+  | `Class (v1, v2, v3, v4, v5, v6) ->
+      let v1 = List.map (map_decorator env) v1 in
+      let v2 = token env v2 (* "class" *) in
+      let v3 =
+        (match v3 with
+        | Some tok -> token env tok (* identifier *)
+        | None -> todo env ())
+      in
+      let v4 =
+        (match v4 with
+        | Some x -> map_type_parameters env x
+        | None -> todo env ())
+      in
+      let v5 =
+        (match v5 with
+        | Some x -> map_class_heritage env x
+        | None -> todo env ())
+      in
+      let v6 = map_class_body env v6 in
+      todo env (v1, v2, v3, v4, v5, v6)
+  | `Paren_exp x -> map_parenthesized_expression env x
+  | `Subs_exp x -> map_subscript_expression env x
+  | `Memb_exp x -> map_member_expression env x
+  | `Meta_prop (v1, v2, v3) ->
+      let v1 = token env v1 (* "new" *) in
+      let v2 = token env v2 (* "." *) in
+      let v3 = token env v3 (* "target" *) in
+      todo env (v1, v2, v3)
+  | `New_exp (v1, v2, v3) ->
+      let v1 = token env v1 (* "new" *) in
+      let v2 = map_anon_choice_this env v2 in
+      let v3 =
+        (match v3 with
+        | Some x -> map_arguments env x
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3)
+  )
+
+and map_anon_choice_memb_exp (env : env) (x : CST.anon_choice_memb_exp) =
+  (match x with
+  | `Memb_exp x -> map_member_expression env x
+  | `Subs_exp x -> map_subscript_expression env x
+  | `Id tok -> token env tok (* identifier *)
+  | `Choice_decl x -> map_anon_choice_decl env x
+  | `Choice_obj x -> map_anon_choice_obj env x
+  )
+
+and map_member_expression (env : env) ((v1, v2, v3) : CST.member_expression) =
+  let v1 =
+    (match v1 with
+    | `Exp x -> map_expression env x
+    | `Id tok -> token env tok (* identifier *)
+    | `Super tok -> token env tok (* "super" *)
+    | `Choice_decl x -> map_anon_choice_decl env x
+    )
+  in
+  let v2 = token env v2 (* "." *) in
+  let v3 = token env v3 (* identifier *) in
+  todo env (v1, v2, v3)
+
+and map_anon_choice_pair (env : env) (x : CST.anon_choice_pair) =
+  (match x with
+  | `Pair (v1, v2, v3) ->
+      let v1 = map_property_name env v1 in
+      let v2 = token env v2 (* ":" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Spre_elem x -> map_spread_element env x
+  | `Meth_defi x -> map_method_definition env x
+  | `Assign_pat (v1, v2, v3) ->
+      let v1 =
+        (match v1 with
+        | `Choice_choice_decl x -> map_anon_choice_choice_decl env x
+        | `Choice_obj x -> map_anon_choice_obj env x
+        )
+      in
+      let v2 = token env v2 (* "=" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Choice_id x -> map_anon_choice_id4 env x
+  )
+
+and map_subscript_expression (env : env) ((v1, v2, v3, v4) : CST.subscript_expression) =
+  let v1 =
+    (match v1 with
+    | `Exp x -> map_expression env x
+    | `Super tok -> token env tok (* "super" *)
+    )
+  in
+  let v2 = token env v2 (* "[" *) in
+  let v3 = map_anon_choice_exp env v3 in
+  let v4 = token env v4 (* "]" *) in
+  todo env (v1, v2, v3, v4)
+
+and map_anon_choice_expo_stmt_ (env : env) (x : CST.anon_choice_expo_stmt_) =
+  (match x with
+  | `Expo_stmt x -> map_export_statement env x
+  | `Impo_stmt (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "import" *) in
+      let v2 =
+        (match v2 with
+        | Some x -> map_anon_choice_type env x
+        | None -> todo env ())
+      in
+      let v3 =
+        (match v3 with
+        | `Impo_clau_from_clau (v1, v2) ->
+            let v1 = map_import_clause env v1 in
+            let v2 = map_from_clause env v2 in
+            todo env (v1, v2)
+        | `Impo_requ_clau x -> map_import_require_clause env x
+        | `Str x -> map_string_ env x
+        )
+      in
+      let v4 = map_anon_choice_auto_semi env v4 in
+      todo env (v1, v2, v3, v4)
+  | `Debu_stmt (v1, v2) ->
+      let v1 = token env v1 (* "debugger" *) in
+      let v2 = map_anon_choice_auto_semi env v2 in
+      todo env (v1, v2)
+  | `Exp_stmt x -> map_expression_statement env x
+  | `Decl x -> map_declaration env x
+  | `Stmt_blk x -> map_statement_block env x
+  | `If_stmt (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "if" *) in
+      let v2 = map_parenthesized_expression env v2 in
+      let v3 = map_anon_choice_expo_stmt_ env v3 in
+      let v4 =
+        (match v4 with
+        | Some (v1, v2) ->
+            let v1 = token env v1 (* "else" *) in
+            let v2 = map_anon_choice_expo_stmt_ env v2 in
+            todo env (v1, v2)
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4)
+  | `Swit_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "switch" *) in
+      let v2 = map_parenthesized_expression env v2 in
+      let v3 = map_switch_body env v3 in
+      todo env (v1, v2, v3)
+  | `For_stmt (v1, v2, v3, v4, v5, v6, v7) ->
+      let v1 = token env v1 (* "for" *) in
+      let v2 = token env v2 (* "(" *) in
+      let v3 =
+        (match v3 with
+        | `Lexi_decl x -> map_lexical_declaration env x
+        | `Var_decl x -> map_variable_declaration env x
+        | `Exp_stmt x -> map_expression_statement env x
+        | `Empty_stmt tok -> token env tok (* ";" *)
+        )
+      in
+      let v4 =
+        (match v4 with
+        | `Exp_stmt x -> map_expression_statement env x
+        | `Empty_stmt tok -> token env tok (* ";" *)
+        )
+      in
+      let v5 =
+        (match v5 with
+        | Some x -> map_anon_choice_exp env x
+        | None -> todo env ())
+      in
+      let v6 = token env v6 (* ")" *) in
+      let v7 = map_anon_choice_expo_stmt_ env v7 in
+      todo env (v1, v2, v3, v4, v5, v6, v7)
+  | `For_in_stmt (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "for" *) in
+      let v2 =
+        (match v2 with
+        | Some tok -> token env tok (* "await" *)
+        | None -> todo env ())
+      in
+      let v3 = map_for_header env v3 in
+      let v4 = map_anon_choice_expo_stmt_ env v4 in
+      todo env (v1, v2, v3, v4)
+  | `While_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "while" *) in
+      let v2 = map_parenthesized_expression env v2 in
+      let v3 = map_anon_choice_expo_stmt_ env v3 in
+      todo env (v1, v2, v3)
+  | `Do_stmt (v1, v2, v3, v4, v5) ->
+      let v1 = token env v1 (* "do" *) in
+      let v2 = map_anon_choice_expo_stmt_ env v2 in
+      let v3 = token env v3 (* "while" *) in
+      let v4 = map_parenthesized_expression env v4 in
+      let v5 = map_anon_choice_auto_semi env v5 in
+      todo env (v1, v2, v3, v4, v5)
+  | `Try_stmt (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "try" *) in
+      let v2 = map_statement_block env v2 in
+      let v3 =
+        (match v3 with
+        | Some x -> map_catch_clause env x
+        | None -> todo env ())
+      in
+      let v4 =
+        (match v4 with
+        | Some x -> map_finally_clause env x
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4)
+  | `With_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "with" *) in
+      let v2 = map_parenthesized_expression env v2 in
+      let v3 = map_anon_choice_expo_stmt_ env v3 in
+      todo env (v1, v2, v3)
+  | `Brk_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "break" *) in
+      let v2 =
+        (match v2 with
+        | Some tok -> token env tok (* identifier *)
+        | None -> todo env ())
+      in
+      let v3 = map_anon_choice_auto_semi env v3 in
+      todo env (v1, v2, v3)
+  | `Cont_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "continue" *) in
+      let v2 =
+        (match v2 with
+        | Some tok -> token env tok (* identifier *)
+        | None -> todo env ())
+      in
+      let v3 = map_anon_choice_auto_semi env v3 in
+      todo env (v1, v2, v3)
+  | `Ret_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "return" *) in
+      let v2 =
+        (match v2 with
+        | Some x -> map_anon_choice_exp env x
+        | None -> todo env ())
+      in
+      let v3 = map_anon_choice_auto_semi env v3 in
+      todo env (v1, v2, v3)
+  | `Throw_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "throw" *) in
+      let v2 = map_anon_choice_exp env v2 in
+      let v3 = map_anon_choice_auto_semi env v3 in
+      todo env (v1, v2, v3)
+  | `Empty_stmt tok -> token env tok (* ";" *)
+  | `Labe_stmt (v1, v2, v3) ->
+      let v1 = map_anon_choice_id4 env v1 in
+      let v2 = token env v2 (* ":" *) in
+      let v3 = map_anon_choice_expo_stmt_ env v3 in
+      todo env (v1, v2, v3)
+  )
+
+and map_initializer_ (env : env) ((v1, v2) : CST.initializer_) =
+  let v1 = token env v1 (* "=" *) in
+  let v2 = map_expression env v2 in
+  todo env (v1, v2)
+
+and map_anon_choice_prop_name (env : env) (x : CST.anon_choice_prop_name) =
+  (match x with
+  | `Prop_name x -> map_property_name env x
+  | `Enum_assign (v1, v2) ->
+      let v1 = map_property_name env v1 in
+      let v2 = map_initializer_ env v2 in
+      todo env (v1, v2)
+  )
+
+and map_module__ (env : env) ((v1, v2) : CST.module__) =
+  let v1 =
+    (match v1 with
+    | `Str x -> map_string_ env x
+    | `Id tok -> token env tok (* identifier *)
+    | `Nest_id x -> map_nested_identifier env x
+    )
+  in
+  let v2 =
+    (match v2 with
+    | Some x -> map_statement_block env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2)
+
+and map_expression_statement (env : env) ((v1, v2) : CST.expression_statement) =
+  let v1 = map_anon_choice_exp env v1 in
+  let v2 = map_anon_choice_auto_semi env v2 in
+  todo env (v1, v2)
+
+and map_catch_clause (env : env) ((v1, v2, v3) : CST.catch_clause) =
+  let v1 = token env v1 (* "catch" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2, v3) ->
+        let v1 = token env v1 (* "(" *) in
+        let v2 = map_anon_choice_id3 env v2 in
+        let v3 = token env v3 (* ")" *) in
+        todo env (v1, v2, v3)
+    | None -> todo env ())
+  in
+  let v3 = map_statement_block env v3 in
+  todo env (v1, v2, v3)
+
+and map_object_type (env : env) ((v1, v2, v3) : CST.object_type) =
+  let v1 =
+    (match v1 with
+    | `LCURL tok -> token env tok (* "{" *)
+    | `LCURLBAR tok -> token env tok (* "{|" *)
+    )
+  in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2, v3, v4) ->
+        let v1 =
+          (match v1 with
+          | Some x ->
+              (match x with
+              | `COMMA tok -> token env tok (* "," *)
+              | `SEMI tok -> token env tok (* ";" *)
+              )
+          | None -> todo env ())
+        in
+        let v2 = map_anon_choice_expo_stmt env v2 in
+        let v3 =
+          List.map (fun (v1, v2) ->
+            let v1 = map_anon_choice_COMMA env v1 in
+            let v2 = map_anon_choice_expo_stmt env v2 in
+            todo env (v1, v2)
+          ) v3
+        in
+        let v4 =
+          (match v4 with
+          | Some x -> map_anon_choice_COMMA env x
+          | None -> todo env ())
+        in
+        todo env (v1, v2, v3, v4)
+    | None -> todo env ())
+  in
+  let v3 =
+    (match v3 with
+    | `RCURL tok -> token env tok (* "}" *)
+    | `BARRCURL tok -> token env tok (* "|}" *)
+    )
+  in
+  todo env (v1, v2, v3)
+
+and map_template_string (env : env) ((v1, v2, v3) : CST.template_string) =
+  let v1 = token env v1 (* "`" *) in
+  let v2 =
+    List.map (fun x ->
+      (match x with
+      | `Temp_chars tok -> token env tok (* template_chars *)
+      | `Esc_seq tok -> token env tok (* escape_sequence *)
+      | `Temp_subs x -> map_template_substitution env x
+      )
+    ) v2
+  in
+  let v3 = token env v3 (* "`" *) in
+  todo env (v1, v2, v3)
+
+and map_decorator (env : env) ((v1, v2) : CST.decorator) =
+  let v1 = token env v1 (* "@" *) in
+  let v2 =
+    (match v2 with
+    | `Choice_id x -> map_anon_choice_id4 env x
+    | `Deco_memb_exp x -> map_decorator_member_expression env x
+    | `Deco_call_exp x -> map_decorator_call_expression env x
+    )
+  in
+  todo env (v1, v2)
+
+and map_internal_module (env : env) ((v1, v2) : CST.internal_module) =
+  let v1 = token env v1 (* "namespace" *) in
+  let v2 = map_module__ env v2 in
+  todo env (v1, v2)
+
+and map_anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp (env : env) (opt : CST.anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp) =
+  (match opt with
+  | Some (v1, v2) ->
+      let v1 =
+        (match v1 with
+        | Some x -> map_anon_choice_exp_ env x
+        | None -> todo env ())
+      in
+      let v2 = map_anon_rep_COMMA_opt_choice_exp env v2 in
+      todo env (v1, v2)
+  | None -> todo env ())
+
+and map_for_header (env : env) ((v1, v2, v3, v4, v5, v6) : CST.for_header) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    (match v2 with
+    | Some x ->
+        (match x with
+        | `Var tok -> token env tok (* "var" *)
+        | `Let tok -> token env tok (* "let" *)
+        | `Const tok -> token env tok (* "const" *)
+        )
+    | None -> todo env ())
+  in
+  let v3 = map_anon_choice_paren_exp env v3 in
+  let v4 =
+    (match v4 with
+    | `In tok -> token env tok (* "in" *)
+    | `Of tok -> token env tok (* "of" *)
+    )
+  in
+  let v5 = map_anon_choice_exp env v5 in
+  let v6 = token env v6 (* ")" *) in
+  todo env (v1, v2, v3, v4, v5, v6)
+
+and map_expression (env : env) (x : CST.expression) =
+  (match x with
+  | `Exp_as_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "as" *) in
+      let v3 =
+        (match v3 with
+        | `Type x -> map_type_ env x
+        | `Temp_str x -> map_template_string env x
+        )
+      in
+      todo env (v1, v2, v3)
+  | `Exp_non_null_exp (v1, v2) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "!" *) in
+      todo env (v1, v2)
+  | `Exp_inte_modu x -> map_internal_module env x
+  | `Exp_super tok -> token env tok (* "super" *)
+  | `Exp_type_asse (v1, v2) ->
+      let v1 = map_type_arguments env v1 in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `Exp_choice_this x -> map_anon_choice_this env x
+  | `Exp_assign_exp (v1, v2, v3) ->
+      let v1 = map_anon_choice_paren_exp env v1 in
+      let v2 = token env v2 (* "=" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_augm_assign_exp (v1, v2, v3) ->
+      let v1 =
+        (match v1 with
+        | `Memb_exp x -> map_member_expression env x
+        | `Subs_exp x -> map_subscript_expression env x
+        | `Choice_decl x -> map_anon_choice_decl env x
+        | `Id tok -> token env tok (* identifier *)
+        | `Paren_exp x -> map_parenthesized_expression env x
+        )
+      in
+      let v2 =
+        (match v2 with
+        | `PLUSEQ tok -> token env tok (* "+=" *)
+        | `DASHEQ tok -> token env tok (* "-=" *)
+        | `STAREQ tok -> token env tok (* "*=" *)
+        | `SLASHEQ tok -> token env tok (* "/=" *)
+        | `PERCEQ tok -> token env tok (* "%=" *)
+        | `HATEQ tok -> token env tok (* "^=" *)
+        | `AMPEQ tok -> token env tok (* "&=" *)
+        | `BAREQ tok -> token env tok (* "|=" *)
+        | `GTGTEQ tok -> token env tok (* ">>=" *)
+        | `GTGTGTEQ tok -> token env tok (* ">>>=" *)
+        | `LTLTEQ tok -> token env tok (* "<<=" *)
+        | `STARSTAREQ tok -> token env tok (* "**=" *)
+        )
+      in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_await_exp (v1, v2) ->
+      let v1 = token env v1 (* "await" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `Exp_un_exp x -> map_unary_expression env x
+  | `Exp_bin_exp x -> map_binary_expression env x
+  | `Exp_tern_exp (v1, v2, v3, v4, v5) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "?" *) in
+      let v3 = map_expression env v3 in
+      let v4 = token env v4 (* ":" *) in
+      let v5 = map_expression env v5 in
+      todo env (v1, v2, v3, v4, v5)
+  | `Exp_upda_exp x -> map_update_expression env x
+  | `Exp_call_exp (v1, v2, v3) ->
+      let v1 =
+        (match v1 with
+        | `Exp x -> map_expression env x
+        | `Super tok -> token env tok (* "super" *)
+        | `Func x -> map_function_ env x
+        )
+      in
+      let v2 =
+        (match v2 with
+        | Some x -> map_type_arguments env x
+        | None -> todo env ())
+      in
+      let v3 =
+        (match v3 with
+        | `Args x -> map_arguments env x
+        | `Temp_str x -> map_template_string env x
+        )
+      in
+      todo env (v1, v2, v3)
+  | `Exp_yield_exp (v1, v2) ->
+      let v1 = token env v1 (* "yield" *) in
+      let v2 =
+        (match v2 with
+        | `STAR_exp (v1, v2) ->
+            let v1 = token env v1 (* "*" *) in
+            let v2 = map_expression env v2 in
+            todo env (v1, v2)
+        | `Opt_exp opt ->
+            (match opt with
+            | Some x -> map_expression env x
+            | None -> todo env ())
+        )
+      in
+      todo env (v1, v2)
+  )
+
+and map_anon_choice_paren_exp (env : env) (x : CST.anon_choice_paren_exp) =
+  (match x with
+  | `Paren_exp x -> map_parenthesized_expression env x
+  | `Choice_memb_exp x -> map_anon_choice_memb_exp env x
+  )
+
+and map_primary_type (env : env) (x : CST.primary_type) =
+  (match x with
+  | `Prim_type_paren_type (v1, v2, v3) ->
+      let v1 = token env v1 (* "(" *) in
+      let v2 = map_type_ env v2 in
+      let v3 = token env v3 (* ")" *) in
+      todo env (v1, v2, v3)
+  | `Prim_type_pred_type x -> map_predefined_type env x
+  | `Prim_type_id tok -> token env tok (* identifier *)
+  | `Prim_type_nest_type_id x ->
+      map_nested_type_identifier env x
+  | `Prim_type_gene_type x -> map_generic_type env x
+  | `Prim_type_type_pred (v1, v2, v3) ->
+      let v1 = token env v1 (* identifier *) in
+      let v2 = token env v2 (* "is" *) in
+      let v3 = map_type_ env v3 in
+      todo env (v1, v2, v3)
+  | `Prim_type_obj_type x -> map_object_type env x
+  | `Prim_type_array_type (v1, v2, v3) ->
+      let v1 = map_primary_type env v1 in
+      let v2 = token env v2 (* "[" *) in
+      let v3 = token env v3 (* "]" *) in
+      todo env (v1, v2, v3)
+  | `Prim_type_tuple_type (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "[" *) in
+      let v2 = map_type_ env v2 in
+      let v3 =
+        List.map (fun (v1, v2) ->
+          let v1 = token env v1 (* "," *) in
+          let v2 = map_type_ env v2 in
+          todo env (v1, v2)
+        ) v3
+      in
+      let v4 = token env v4 (* "]" *) in
+      todo env (v1, v2, v3, v4)
+  | `Prim_type_flow_maybe_type (v1, v2) ->
+      let v1 = token env v1 (* "?" *) in
+      let v2 = map_primary_type env v2 in
+      todo env (v1, v2)
+  | `Prim_type_type_query (v1, v2) ->
+      let v1 = token env v1 (* "typeof" *) in
+      let v2 = map_anon_choice_id_ env v2 in
+      todo env (v1, v2)
+  | `Prim_type_index_type_query (v1, v2) ->
+      let v1 = token env v1 (* "keyof" *) in
+      let v2 = map_anon_choice_id env v2 in
+      todo env (v1, v2)
+  | `Prim_type_this tok -> token env tok (* "this" *)
+  | `Prim_type_exis_type tok -> token env tok (* "*" *)
+  | `Prim_type_lit_type x -> map_literal_type env x
+  | `Prim_type_look_type (v1, v2, v3, v4) ->
+      let v1 = map_primary_type env v1 in
+      let v2 = token env v2 (* "[" *) in
+      let v3 = map_type_ env v3 in
+      let v4 = token env v4 (* "]" *) in
+      todo env (v1, v2, v3, v4)
+  )
+
+and map_index_signature (env : env) ((v1, v2, v3, v4) : CST.index_signature) =
+  let v1 = token env v1 (* "[" *) in
+  let v2 =
+    (match v2 with
+    | `Choice_id_COLON_pred_type (v1, v2, v3) ->
+        let v1 = map_anon_choice_id4 env v1 in
+        let v2 = token env v2 (* ":" *) in
+        let v3 = map_predefined_type env v3 in
+        todo env (v1, v2, v3)
+    | `Mapp_type_clau x -> map_mapped_type_clause env x
+    )
+  in
+  let v3 = token env v3 (* "]" *) in
+  let v4 = map_type_annotation env v4 in
+  todo env (v1, v2, v3, v4)
 
 and map_unary_expression (env : env) (x : CST.unary_expression) =
   (match x with
@@ -2198,228 +1417,209 @@ and map_unary_expression (env : env) (x : CST.unary_expression) =
       todo env (v1, v2)
   )
 
-
-and map_update_expression (env : env) (x : CST.update_expression) =
-  (match x with
-  | `Exp_choice_PLUSPLUS (v1, v2) ->
-      let v1 = map_expression env v1 in
-      let v2 =
-        (match v2 with
-        | `PLUSPLUS tok -> token env tok (* "++" *)
-        | `DASHDASH tok -> token env tok (* "--" *)
-        )
-      in
-      todo env (v1, v2)
-  | `Choice_PLUSPLUS_exp (v1, v2) ->
-      let v1 =
-        (match v1 with
-        | `PLUSPLUS tok -> token env tok (* "++" *)
-        | `DASHDASH tok -> token env tok (* "--" *)
-        )
-      in
-      let v2 = map_expression env v2 in
-      todo env (v1, v2)
-  )
-
-
-and map_sequence_expression (env : env) ((v1, v2, v3) : CST.sequence_expression) =
-  let v1 = map_expression env v1 in
-  let v2 = token env v2 (* "," *) in
-  let v3 =
-    (match v3 with
-    | `Seq_exp x -> map_sequence_expression env x
-    | `Exp x -> map_expression env x
-    )
-  in
-  todo env (v1, v2, v3)
-
-
-and map_template_string (env : env) ((v1, v2, v3) : CST.template_string) =
-  let v1 = token env v1 (* "`" *) in
-  let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Temp_chars tok -> token env tok (* template_chars *)
-      | `Esc_seq tok -> token env tok (* escape_sequence *)
-      | `Temp_subs x -> map_template_substitution env x
-      )
-    ) v2
-  in
-  let v3 = token env v3 (* "`" *) in
-  todo env (v1, v2, v3)
-
-
-and map_template_substitution (env : env) ((v1, v2, v3) : CST.template_substitution) =
-  let v1 = token env v1 (* "${" *) in
-  let v2 =
-    (match v2 with
-    | `Exp x -> map_expression env x
-    | `Seq_exp x -> map_sequence_expression env x
-    )
-  in
-  let v3 = token env v3 (* "}" *) in
-  todo env (v1, v2, v3)
-
-
-and map_arguments (env : env) ((v1, v2, v3) : CST.arguments) =
+and map_formal_parameters (env : env) ((v1, v2, v3) : CST.formal_parameters) =
   let v1 = token env v1 (* "(" *) in
   let v2 =
     (match v2 with
-    | Some (v1, v2) ->
-        let v1 =
-          (match v1 with
-          | Some x ->
-              (match x with
-              | `Exp x -> map_expression env x
-              | `Spre_elem x -> map_spread_element env x
-              )
+    | Some (v1, v2, v3, v4) ->
+        let v1 = List.map (map_decorator env) v1 in
+        let v2 = map_anon_choice_requ_param env v2 in
+        let v3 =
+          List.map (fun (v1, v2, v3) ->
+            let v1 = token env v1 (* "," *) in
+            let v2 = List.map (map_decorator env) v2 in
+            let v3 = map_anon_choice_requ_param env v3 in
+            todo env (v1, v2, v3)
+          ) v3
+        in
+        let v4 =
+          (match v4 with
+          | Some tok -> token env tok (* "," *)
           | None -> todo env ())
         in
-        let v2 =
-          List.map (fun (v1, v2) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 =
-              (match v2 with
-              | Some x ->
-                  (match x with
-                  | `Exp x -> map_expression env x
-                  | `Spre_elem x -> map_spread_element env x
-                  )
-              | None -> todo env ())
-            in
-            todo env (v1, v2)
-          ) v2
-        in
-        todo env (v1, v2)
+        todo env (v1, v2, v3, v4)
     | None -> todo env ())
   in
   let v3 = token env v3 (* ")" *) in
   todo env (v1, v2, v3)
 
-
-and map_decorator (env : env) ((v1, v2) : CST.decorator) =
-  let v1 = token env v1 (* "@" *) in
-  let v2 =
-    (match v2 with
-    | `Choice_id x ->
-        (match x with
-        | `Id tok -> token env tok (* identifier *)
-        | `Choice_decl x ->
-            (match x with
-            | `Decl tok -> token env tok (* "declare" *)
-            | `Name tok -> token env tok (* "namespace" *)
-            | `Type tok -> token env tok (* "type" *)
-            | `Publ tok -> token env tok (* "public" *)
-            | `Priv tok -> token env tok (* "private" *)
-            | `Prot tok -> token env tok (* "protected" *)
-            | `Read tok -> token env tok (* "readonly" *)
-            | `Modu tok -> token env tok (* "module" *)
-            | `Any tok -> token env tok (* "any" *)
-            | `Num tok -> token env tok (* "number" *)
-            | `Bool tok -> token env tok (* "boolean" *)
-            | `Str tok -> token env tok (* "string" *)
-            | `Symb tok -> token env tok (* "symbol" *)
-            | `Void tok -> token env tok (* "void" *)
-            | `Expo tok -> token env tok (* "export" *)
-            | `Choice_get x ->
-                (match x with
-                | `Get tok -> token env tok (* "get" *)
-                | `Set tok -> token env tok (* "set" *)
-                | `Async tok -> token env tok (* "async" *)
-                | `Stat tok -> token env tok (* "static" *)
-                )
-            )
-        )
-    | `Deco_memb_exp x -> map_decorator_member_expression env x
-    | `Deco_call_exp x -> map_decorator_call_expression env x
-    )
-  in
+and map_default_type (env : env) ((v1, v2) : CST.default_type) =
+  let v1 = token env v1 (* "=" *) in
+  let v2 = map_type_ env v2 in
   todo env (v1, v2)
 
-
-and map_decorator_call_expression (env : env) ((v1, v2) : CST.decorator_call_expression) =
-  let v1 =
-    (match v1 with
-    | `Choice_id x ->
-        (match x with
-        | `Id tok -> token env tok (* identifier *)
-        | `Choice_decl x ->
-            (match x with
-            | `Decl tok -> token env tok (* "declare" *)
-            | `Name tok -> token env tok (* "namespace" *)
-            | `Type tok -> token env tok (* "type" *)
-            | `Publ tok -> token env tok (* "public" *)
-            | `Priv tok -> token env tok (* "private" *)
-            | `Prot tok -> token env tok (* "protected" *)
-            | `Read tok -> token env tok (* "readonly" *)
-            | `Modu tok -> token env tok (* "module" *)
-            | `Any tok -> token env tok (* "any" *)
-            | `Num tok -> token env tok (* "number" *)
-            | `Bool tok -> token env tok (* "boolean" *)
-            | `Str tok -> token env tok (* "string" *)
-            | `Symb tok -> token env tok (* "symbol" *)
-            | `Void tok -> token env tok (* "void" *)
-            | `Expo tok -> token env tok (* "export" *)
-            | `Choice_get x ->
-                (match x with
-                | `Get tok -> token env tok (* "get" *)
-                | `Set tok -> token env tok (* "set" *)
-                | `Async tok -> token env tok (* "async" *)
-                | `Stat tok -> token env tok (* "static" *)
-                )
-            )
-        )
-    | `Deco_memb_exp x -> map_decorator_member_expression env x
-    )
-  in
-  let v2 = map_arguments env v2 in
-  todo env (v1, v2)
-
-
-and map_class_body (env : env) ((v1, v2, v3) : CST.class_body) =
+and map_switch_body (env : env) ((v1, v2, v3) : CST.switch_body) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     List.map (fun x ->
       (match x with
-      | `Deco x -> map_decorator env x
-      | `Meth_defi_opt_choice_auto_semi (v1, v2) ->
-          let v1 = map_method_definition env v1 in
-          let v2 =
-            (match v2 with
-            | Some x ->
-                (match x with
-                | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-                | `SEMI tok -> token env tok (* ";" *)
-                )
-            | None -> todo env ())
-          in
-          todo env (v1, v2)
-      | `Choice_abst_meth_sign_choice_choice_auto_semi (v1, v2) ->
-          let v1 =
-            (match v1 with
-            | `Abst_meth_sign x -> map_abstract_method_signature env x
-            | `Index_sign x -> map_index_signature env x
-            | `Meth_sign x -> map_method_signature env x
-            | `Publ_field_defi x -> map_public_field_definition env x
-            )
-          in
-          let v2 =
-            (match v2 with
-            | `Choice_auto_semi x ->
-                (match x with
-                | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-                | `SEMI tok -> token env tok (* ";" *)
-                )
-            | `COMMA tok -> token env tok (* "," *)
-            )
-          in
-          todo env (v1, v2)
+      | `Swit_case x -> map_switch_case env x
+      | `Swit_defa x -> map_switch_default env x
       )
     ) v2
   in
   let v3 = token env v3 (* "}" *) in
   todo env (v1, v2, v3)
 
+and map_mapped_type_clause (env : env) ((v1, v2, v3) : CST.mapped_type_clause) =
+  let v1 = token env v1 (* identifier *) in
+  let v2 = token env v2 (* "in" *) in
+  let v3 = map_type_ env v3 in
+  todo env (v1, v2, v3)
+
+and map_method_definition (env : env) ((v1, v2, v3, v4, v5, v6, v7, v8, v9) : CST.method_definition) =
+  let v1 =
+    (match v1 with
+    | Some x -> map_accessibility_modifier env x
+    | None -> todo env ())
+  in
+  let v2 =
+    (match v2 with
+    | Some tok -> token env tok (* "static" *)
+    | None -> todo env ())
+  in
+  let v3 =
+    (match v3 with
+    | Some tok -> token env tok (* "readonly" *)
+    | None -> todo env ())
+  in
+  let v4 =
+    (match v4 with
+    | Some tok -> token env tok (* "async" *)
+    | None -> todo env ())
+  in
+  let v5 =
+    (match v5 with
+    | Some x -> map_anon_choice_get env x
+    | None -> todo env ())
+  in
+  let v6 = map_property_name env v6 in
+  let v7 =
+    (match v7 with
+    | Some tok -> token env tok (* "?" *)
+    | None -> todo env ())
+  in
+  let v8 = map_call_signature_ env v8 in
+  let v9 = map_statement_block env v9 in
+  todo env (v1, v2, v3, v4, v5, v6, v7, v8, v9)
+
+and map_class_declaration (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.class_declaration) =
+  let v1 = List.map (map_decorator env) v1 in
+  let v2 = token env v2 (* "class" *) in
+  let v3 = token env v3 (* identifier *) in
+  let v4 =
+    (match v4 with
+    | Some x -> map_type_parameters env x
+    | None -> todo env ())
+  in
+  let v5 =
+    (match v5 with
+    | Some x -> map_class_heritage env x
+    | None -> todo env ())
+  in
+  let v6 = map_class_body env v6 in
+  let v7 =
+    (match v7 with
+    | Some tok -> token env tok (* automatic_semicolon *)
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3, v4, v5, v6, v7)
+
+and map_array_ (env : env) ((v1, v2, v3) : CST.array_) =
+  let v1 = token env v1 (* "[" *) in
+  let v2 =
+    map_anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp env v2
+  in
+  let v3 = token env v3 (* "]" *) in
+  todo env (v1, v2, v3)
+
+and map_export_statement (env : env) (x : CST.export_statement) =
+  (match x with
+  | `Choice_expo_choice_STAR_from_clau_choice_auto_semi x ->
+      (match x with
+      | `Expo_choice_STAR_from_clau_choice_auto_semi (v1, v2) ->
+          let v1 = token env v1 (* "export" *) in
+          let v2 =
+            (match v2 with
+            | `STAR_from_clau_choice_auto_semi (v1, v2, v3) ->
+                let v1 = token env v1 (* "*" *) in
+                let v2 = map_from_clause env v2 in
+                let v3 = map_anon_choice_auto_semi env v3 in
+                todo env (v1, v2, v3)
+            | `Expo_clau_from_clau_choice_auto_semi (v1, v2, v3) ->
+                let v1 = map_export_clause env v1 in
+                let v2 = map_from_clause env v2 in
+                let v3 = map_anon_choice_auto_semi env v3 in
+                todo env (v1, v2, v3)
+            | `Expo_clau_choice_auto_semi (v1, v2) ->
+                let v1 = map_export_clause env v1 in
+                let v2 = map_anon_choice_auto_semi env v2 in
+                todo env (v1, v2)
+            )
+          in
+          todo env (v1, v2)
+      | `Rep_deco_expo_choice_decl (v1, v2, v3) ->
+          let v1 = List.map (map_decorator env) v1 in
+          let v2 = token env v2 (* "export" *) in
+          let v3 =
+            (match v3 with
+            | `Decl x -> map_declaration env x
+            | `Defa_exp_choice_auto_semi (v1, v2, v3) ->
+                let v1 = token env v1 (* "default" *) in
+                let v2 = map_expression env v2 in
+                let v3 = map_anon_choice_auto_semi env v3 in
+                todo env (v1, v2, v3)
+            )
+          in
+          todo env (v1, v2, v3)
+      )
+  | `Expo_EQ_id_choice_auto_semi (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "export" *) in
+      let v2 = token env v2 (* "=" *) in
+      let v3 = token env v3 (* identifier *) in
+      let v4 = map_anon_choice_auto_semi env v4 in
+      todo env (v1, v2, v3, v4)
+  | `Expo_as_name_id_choice_auto_semi (v1, v2, v3, v4, v5) ->
+      let v1 = token env v1 (* "export" *) in
+      let v2 = token env v2 (* "as" *) in
+      let v3 = token env v3 (* "namespace" *) in
+      let v4 = token env v4 (* identifier *) in
+      let v5 = map_anon_choice_auto_semi env v5 in
+      todo env (v1, v2, v3, v4, v5)
+  )
+
+and map_type_annotation (env : env) ((v1, v2) : CST.type_annotation) =
+  let v1 = token env v1 (* ":" *) in
+  let v2 = map_type_ env v2 in
+  todo env (v1, v2)
+
+and map_anon_rep_COMMA_opt_choice_exp (env : env) (xs : CST.anon_rep_COMMA_opt_choice_exp) =
+  List.map (fun (v1, v2) ->
+    let v1 = token env v1 (* "," *) in
+    let v2 =
+      (match v2 with
+      | Some x -> map_anon_choice_exp_ env x
+      | None -> todo env ())
+    in
+    todo env (v1, v2)
+  ) xs
+
+and map_decorator_call_expression (env : env) ((v1, v2) : CST.decorator_call_expression) =
+  let v1 = map_anon_choice_choice_id_ env v1 in
+  let v2 = map_arguments env v2 in
+  todo env (v1, v2)
+
+and map_update_expression (env : env) (x : CST.update_expression) =
+  (match x with
+  | `Exp_choice_PLUSPLUS (v1, v2) ->
+      let v1 = map_expression env v1 in
+      let v2 = map_anon_choice_PLUSPLUS env v2 in
+      todo env (v1, v2)
+  | `Choice_PLUSPLUS_exp (v1, v2) ->
+      let v1 = map_anon_choice_PLUSPLUS env v1 in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  )
 
 and map_public_field_definition (env : env) ((v1, v2, v3, v4, v5, v6) : CST.public_field_definition) =
   let v1 =
@@ -2489,303 +1689,86 @@ and map_public_field_definition (env : env) ((v1, v2, v3, v4, v5, v6) : CST.publ
   in
   todo env (v1, v2, v3, v4, v5, v6)
 
-
-and map_formal_parameters (env : env) ((v1, v2, v3) : CST.formal_parameters) =
-  let v1 = token env v1 (* "(" *) in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2, v3, v4) ->
-        let v1 = List.map (map_decorator env) v1 in
-        let v2 =
-          (match v2 with
-          | `Requ_param x -> map_required_parameter env x
-          | `Rest_param x -> map_rest_parameter env x
-          | `Opt_param x -> map_optional_parameter env x
-          )
-        in
-        let v3 =
-          List.map (fun (v1, v2, v3) ->
-            let v1 = token env v1 (* "," *) in
-            let v2 = List.map (map_decorator env) v2 in
-            let v3 =
-              (match v3 with
-              | `Requ_param x -> map_required_parameter env x
-              | `Rest_param x -> map_rest_parameter env x
-              | `Opt_param x -> map_optional_parameter env x
-              )
-            in
-            todo env (v1, v2, v3)
-          ) v3
-        in
-        let v4 =
-          (match v4 with
-          | Some tok -> token env tok (* "," *)
-          | None -> todo env ())
-        in
-        todo env (v1, v2, v3, v4)
-    | None -> todo env ())
-  in
-  let v3 = token env v3 (* ")" *) in
-  todo env (v1, v2, v3)
-
-
-and map_rest_parameter (env : env) ((v1, v2, v3) : CST.rest_parameter) =
-  let v1 = token env v1 (* "..." *) in
-  let v2 = token env v2 (* identifier *) in
-  let v3 =
-    (match v3 with
-    | Some x -> map_type_annotation env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3)
-
-
-and map_method_definition (env : env) ((v1, v2, v3, v4, v5, v6, v7, v8, v9) : CST.method_definition) =
+and map_lexical_declaration (env : env) ((v1, v2, v3, v4) : CST.lexical_declaration) =
   let v1 =
     (match v1 with
-    | Some x -> map_accessibility_modifier env x
-    | None -> todo env ())
+    | `Let tok -> token env tok (* "let" *)
+    | `Const tok -> token env tok (* "const" *)
+    )
   in
-  let v2 =
-    (match v2 with
-    | Some tok -> token env tok (* "static" *)
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | Some tok -> token env tok (* "readonly" *)
-    | None -> todo env ())
-  in
-  let v4 =
-    (match v4 with
-    | Some tok -> token env tok (* "async" *)
-    | None -> todo env ())
-  in
-  let v5 =
-    (match v5 with
-    | Some x ->
-        (match x with
-        | `Get tok -> token env tok (* "get" *)
-        | `Set tok -> token env tok (* "set" *)
-        | `STAR tok -> token env tok (* "*" *)
-        )
-    | None -> todo env ())
-  in
-  let v6 = map_property_name env v6 in
-  let v7 =
-    (match v7 with
-    | Some tok -> token env tok (* "?" *)
-    | None -> todo env ())
-  in
-  let v8 = map_call_signature env v8 in
-  let v9 = map_statement_block env v9 in
-  todo env (v1, v2, v3, v4, v5, v6, v7, v8, v9)
-
-
-and map_pair (env : env) ((v1, v2, v3) : CST.pair) =
-  let v1 = map_property_name env v1 in
-  let v2 = token env v2 (* ":" *) in
-  let v3 = map_expression env v3 in
-  todo env (v1, v2, v3)
-
-
-and map_property_name (env : env) (x : CST.property_name) =
-  (match x with
-  | `Prop_name_choice_id x ->
-      (match x with
-      | `Id tok -> token env tok (* identifier *)
-      | `Choice_decl x ->
-          (match x with
-          | `Decl tok -> token env tok (* "declare" *)
-          | `Name tok -> token env tok (* "namespace" *)
-          | `Type tok -> token env tok (* "type" *)
-          | `Publ tok -> token env tok (* "public" *)
-          | `Priv tok -> token env tok (* "private" *)
-          | `Prot tok -> token env tok (* "protected" *)
-          | `Read tok -> token env tok (* "readonly" *)
-          | `Modu tok -> token env tok (* "module" *)
-          | `Any tok -> token env tok (* "any" *)
-          | `Num tok -> token env tok (* "number" *)
-          | `Bool tok -> token env tok (* "boolean" *)
-          | `Str tok -> token env tok (* "string" *)
-          | `Symb tok -> token env tok (* "symbol" *)
-          | `Void tok -> token env tok (* "void" *)
-          | `Expo tok -> token env tok (* "export" *)
-          | `Choice_get x ->
-              (match x with
-              | `Get tok -> token env tok (* "get" *)
-              | `Set tok -> token env tok (* "set" *)
-              | `Async tok -> token env tok (* "async" *)
-              | `Stat tok -> token env tok (* "static" *)
-              )
-          )
-      )
-  | `Prop_name_str x -> map_string_ env x
-  | `Prop_name_num tok -> token env tok (* number *)
-  | `Prop_name_comp_prop_name (v1, v2, v3) ->
-      let v1 = token env v1 (* "[" *) in
-      let v2 = map_expression env v2 in
-      let v3 = token env v3 (* "]" *) in
-      todo env (v1, v2, v3)
-  )
-
-
-and map_method_signature (env : env) ((v1, v2, v3, v4, v5, v6, v7, v8) : CST.method_signature) =
-  let v1 =
-    (match v1 with
-    | Some x -> map_accessibility_modifier env x
-    | None -> todo env ())
-  in
-  let v2 =
-    (match v2 with
-    | Some tok -> token env tok (* "static" *)
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | Some tok -> token env tok (* "readonly" *)
-    | None -> todo env ())
-  in
-  let v4 =
-    (match v4 with
-    | Some tok -> token env tok (* "async" *)
-    | None -> todo env ())
-  in
-  let v5 =
-    (match v5 with
-    | Some x ->
-        (match x with
-        | `Get tok -> token env tok (* "get" *)
-        | `Set tok -> token env tok (* "set" *)
-        | `STAR tok -> token env tok (* "*" *)
-        )
-    | None -> todo env ())
-  in
-  let v6 = map_property_name env v6 in
-  let v7 =
-    (match v7 with
-    | Some tok -> token env tok (* "?" *)
-    | None -> todo env ())
-  in
-  let v8 = map_call_signature env v8 in
-  todo env (v1, v2, v3, v4, v5, v6, v7, v8)
-
-
-and map_abstract_method_signature (env : env) ((v1, v2, v3, v4, v5, v6) : CST.abstract_method_signature) =
-  let v1 =
-    (match v1 with
-    | Some x -> map_accessibility_modifier env x
-    | None -> todo env ())
-  in
-  let v2 = token env v2 (* "abstract" *) in
-  let v3 =
-    (match v3 with
-    | Some x ->
-        (match x with
-        | `Get tok -> token env tok (* "get" *)
-        | `Set tok -> token env tok (* "set" *)
-        | `STAR tok -> token env tok (* "*" *)
-        )
-    | None -> todo env ())
-  in
-  let v4 = map_property_name env v4 in
-  let v5 =
-    (match v5 with
-    | Some tok -> token env tok (* "?" *)
-    | None -> todo env ())
-  in
-  let v6 = map_call_signature env v6 in
-  todo env (v1, v2, v3, v4, v5, v6)
-
-
-and map_implements_clause (env : env) ((v1, v2, v3) : CST.implements_clause) =
-  let v1 = token env v1 (* "implements" *) in
-  let v2 = map_type_ env v2 in
+  let v2 = map_variable_declarator env v2 in
   let v3 =
     List.map (fun (v1, v2) ->
       let v1 = token env v1 (* "," *) in
-      let v2 = map_type_ env v2 in
+      let v2 = map_variable_declarator env v2 in
       todo env (v1, v2)
     ) v3
   in
-  todo env (v1, v2, v3)
-
-
-and map_internal_module (env : env) ((v1, v2) : CST.internal_module) =
-  let v1 = token env v1 (* "namespace" *) in
-  let v2 = map_module__ env v2 in
-  todo env (v1, v2)
-
-
-and map_module__ (env : env) ((v1, v2) : CST.module__) =
-  let v1 =
-    (match v1 with
-    | `Str x -> map_string_ env x
-    | `Id tok -> token env tok (* identifier *)
-    | `Nest_id x -> map_nested_identifier env x
-    )
-  in
-  let v2 =
-    (match v2 with
-    | Some x -> map_statement_block env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2)
-
+  let v4 = map_anon_choice_auto_semi env v4 in
+  todo env (v1, v2, v3, v4)
 
 and map_extends_clause (env : env) ((v1, v2, v3) : CST.extends_clause) =
   let v1 = token env v1 (* "extends" *) in
-  let v2 =
-    (match v2 with
-    | `Choice_id x ->
-        (match x with
-        | `Id tok -> token env tok (* identifier *)
-        | `Nest_type_id x -> map_nested_type_identifier env x
-        | `Gene_type x -> map_generic_type env x
-        )
-    | `Exp x -> map_expression env x
-    )
-  in
+  let v2 = map_anon_choice_choice_id env v2 in
   let v3 =
     List.map (fun (v1, v2) ->
       let v1 = token env v1 (* "," *) in
-      let v2 =
-        (match v2 with
-        | `Choice_id x ->
-            (match x with
-            | `Id tok -> token env tok (* identifier *)
-            | `Nest_type_id x -> map_nested_type_identifier env x
-            | `Gene_type x -> map_generic_type env x
-            )
-        | `Exp x -> map_expression env x
-        )
-      in
+      let v2 = map_anon_choice_choice_id env v2 in
       todo env (v1, v2)
     ) v3
   in
   todo env (v1, v2, v3)
 
+and map_anon_choice_requ_param (env : env) (x : CST.anon_choice_requ_param) =
+  (match x with
+  | `Requ_param (v1, v2, v3) ->
+      let v1 = map_parameter_name env v1 in
+      let v2 =
+        (match v2 with
+        | Some x -> map_type_annotation env x
+        | None -> todo env ())
+      in
+      let v3 =
+        (match v3 with
+        | Some x -> map_initializer_ env x
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3)
+  | `Rest_param (v1, v2, v3) ->
+      let v1 = token env v1 (* "..." *) in
+      let v2 = token env v2 (* identifier *) in
+      let v3 =
+        (match v3 with
+        | Some x -> map_type_annotation env x
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3)
+  | `Opt_param (v1, v2, v3, v4) ->
+      let v1 = map_parameter_name env v1 in
+      let v2 = token env v2 (* "?" *) in
+      let v3 =
+        (match v3 with
+        | Some x -> map_type_annotation env x
+        | None -> todo env ())
+      in
+      let v4 =
+        (match v4 with
+        | Some x -> map_initializer_ env x
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4)
+  )
 
 and map_enum_body (env : env) ((v1, v2, v3) : CST.enum_body) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     (match v2 with
     | Some (v1, v2, v3) ->
-        let v1 =
-          (match v1 with
-          | `Prop_name x -> map_property_name env x
-          | `Enum_assign x -> map_enum_assignment env x
-          )
-        in
+        let v1 = map_anon_choice_prop_name env v1 in
         let v2 =
           List.map (fun (v1, v2) ->
             let v1 = token env v1 (* "," *) in
-            let v2 =
-              (match v2 with
-              | `Prop_name x -> map_property_name env x
-              | `Enum_assign x -> map_enum_assignment env x
-              )
-            in
+            let v2 = map_anon_choice_prop_name env v2 in
             todo env (v1, v2)
           ) v2
         in
@@ -2800,99 +1783,115 @@ and map_enum_body (env : env) ((v1, v2, v3) : CST.enum_body) =
   let v3 = token env v3 (* "}" *) in
   todo env (v1, v2, v3)
 
+and map_class_heritage (env : env) (x : CST.class_heritage) =
+  (match x with
+  | `Class_heri_extens_clau_opt_imples_clau (v1, v2) ->
+      let v1 = map_extends_clause env v1 in
+      let v2 =
+        (match v2 with
+        | Some x -> map_implements_clause env x
+        | None -> todo env ())
+      in
+      todo env (v1, v2)
+  | `Class_heri_imples_clau x -> map_implements_clause env x
+  )
 
-and map_enum_assignment (env : env) ((v1, v2) : CST.enum_assignment) =
-  let v1 = map_property_name env v1 in
-  let v2 = map_initializer_ env v2 in
-  todo env (v1, v2)
+and map_property_name (env : env) (x : CST.property_name) =
+  (match x with
+  | `Prop_name_choice_id x -> map_anon_choice_id4 env x
+  | `Prop_name_str x -> map_string_ env x
+  | `Prop_name_num tok -> token env tok (* number *)
+  | `Prop_name_comp_prop_name (v1, v2, v3) ->
+      let v1 = token env v1 (* "[" *) in
+      let v2 = map_expression env v2 in
+      let v3 = token env v3 (* "]" *) in
+      todo env (v1, v2, v3)
+  )
 
-
-and map_required_parameter (env : env) ((v1, v2, v3) : CST.required_parameter) =
-  let v1 = map_parameter_name env v1 in
-  let v2 =
-    (match v2 with
-    | Some x -> map_type_annotation env x
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | Some x -> map_initializer_ env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3)
-
-
-and map_optional_parameter (env : env) ((v1, v2, v3, v4) : CST.optional_parameter) =
-  let v1 = map_parameter_name env v1 in
-  let v2 = token env v2 (* "?" *) in
-  let v3 =
-    (match v3 with
-    | Some x -> map_type_annotation env x
-    | None -> todo env ())
-  in
-  let v4 =
-    (match v4 with
-    | Some x -> map_initializer_ env x
-    | None -> todo env ())
-  in
+and map_switch_case (env : env) ((v1, v2, v3, v4) : CST.switch_case) =
+  let v1 = token env v1 (* "case" *) in
+  let v2 = map_anon_choice_exp env v2 in
+  let v3 = token env v3 (* ":" *) in
+  let v4 = List.map (map_anon_choice_expo_stmt_ env) v4 in
   todo env (v1, v2, v3, v4)
 
+and map_spread_element (env : env) ((v1, v2) : CST.spread_element) =
+  let v1 = token env v1 (* "..." *) in
+  let v2 = map_expression env v2 in
+  todo env (v1, v2)
 
-and map_parameter_name (env : env) ((v1, v2, v3) : CST.parameter_name) =
+and map_abstract_method_signature (env : env) ((v1, v2, v3, v4, v5, v6) : CST.abstract_method_signature) =
   let v1 =
     (match v1 with
     | Some x -> map_accessibility_modifier env x
     | None -> todo env ())
   in
-  let v2 =
-    (match v2 with
-    | Some tok -> token env tok (* "readonly" *)
-    | None -> todo env ())
-  in
+  let v2 = token env v2 (* "abstract" *) in
   let v3 =
     (match v3 with
-    | `Id tok -> token env tok (* identifier *)
-    | `Choice_decl x ->
-        (match x with
-        | `Decl tok -> token env tok (* "declare" *)
-        | `Name tok -> token env tok (* "namespace" *)
-        | `Type tok -> token env tok (* "type" *)
-        | `Publ tok -> token env tok (* "public" *)
-        | `Priv tok -> token env tok (* "private" *)
-        | `Prot tok -> token env tok (* "protected" *)
-        | `Read tok -> token env tok (* "readonly" *)
-        | `Modu tok -> token env tok (* "module" *)
-        | `Any tok -> token env tok (* "any" *)
-        | `Num tok -> token env tok (* "number" *)
-        | `Bool tok -> token env tok (* "boolean" *)
-        | `Str tok -> token env tok (* "string" *)
-        | `Symb tok -> token env tok (* "symbol" *)
-        | `Void tok -> token env tok (* "void" *)
-        | `Expo tok -> token env tok (* "export" *)
-        | `Choice_get x ->
-            (match x with
-            | `Get tok -> token env tok (* "get" *)
-            | `Set tok -> token env tok (* "set" *)
-            | `Async tok -> token env tok (* "async" *)
-            | `Stat tok -> token env tok (* "static" *)
-            )
-        )
-    | `Choice_obj x ->
-        (match x with
-        | `Obj x -> map_object_ env x
-        | `Array x -> map_array_ env x
-        )
-    | `This tok -> token env tok (* "this" *)
-    )
+    | Some x -> map_anon_choice_get env x
+    | None -> todo env ())
+  in
+  let v4 = map_property_name env v4 in
+  let v5 =
+    (match v5 with
+    | Some tok -> token env tok (* "?" *)
+    | None -> todo env ())
+  in
+  let v6 = map_call_signature_ env v6 in
+  todo env (v1, v2, v3, v4, v5, v6)
+
+and map_finally_clause (env : env) ((v1, v2) : CST.finally_clause) =
+  let v1 = token env v1 (* "finally" *) in
+  let v2 = map_statement_block env v2 in
+  todo env (v1, v2)
+
+and map_call_signature (env : env) ((v1, v2, v3) : CST.call_signature) =
+  let v1 =
+    (match v1 with
+    | Some x -> map_type_parameters env x
+    | None -> todo env ())
+  in
+  let v2 = map_formal_parameters env v2 in
+  let v3 =
+    (match v3 with
+    | Some x -> map_type_annotation env x
+    | None -> todo env ())
   in
   todo env (v1, v2, v3)
 
+and map_object_ (env : env) ((v1, v2, v3) : CST.object_) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2) ->
+        let v1 =
+          (match v1 with
+          | Some x -> map_anon_choice_pair env x
+          | None -> todo env ())
+        in
+        let v2 =
+          List.map (fun (v1, v2) ->
+            let v1 = token env v1 (* "," *) in
+            let v2 =
+              (match v2 with
+              | Some x -> map_anon_choice_pair env x
+              | None -> todo env ())
+            in
+            todo env (v1, v2)
+          ) v2
+        in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
 
-and map_type_annotation (env : env) ((v1, v2) : CST.type_annotation) =
-  let v1 = token env v1 (* ":" *) in
-  let v2 = map_type_ env v2 in
-  todo env (v1, v2)
-
+and map_anon_choice_id3 (env : env) (x : CST.anon_choice_id3) =
+  (match x with
+  | `Id tok -> token env tok (* identifier *)
+  | `Choice_obj x -> map_anon_choice_obj env x
+  )
 
 and map_type_ (env : env) (x : CST.type_) =
   (match x with
@@ -2938,226 +1937,6 @@ and map_type_ (env : env) (x : CST.type_) =
       todo env (v1, v2, v3, v4, v5)
   )
 
-
-and map_primary_type (env : env) (x : CST.primary_type) =
-  (match x with
-  | `Prim_type_paren_type (v1, v2, v3) ->
-      let v1 = token env v1 (* "(" *) in
-      let v2 = map_type_ env v2 in
-      let v3 = token env v3 (* ")" *) in
-      todo env (v1, v2, v3)
-  | `Prim_type_pred_type x -> map_predefined_type env x
-  | `Prim_type_id tok -> token env tok (* identifier *)
-  | `Prim_type_nest_type_id x ->
-      map_nested_type_identifier env x
-  | `Prim_type_gene_type x -> map_generic_type env x
-  | `Prim_type_type_pred (v1, v2, v3) ->
-      let v1 = token env v1 (* identifier *) in
-      let v2 = token env v2 (* "is" *) in
-      let v3 = map_type_ env v3 in
-      todo env (v1, v2, v3)
-  | `Prim_type_obj_type x -> map_object_type env x
-  | `Prim_type_array_type (v1, v2, v3) ->
-      let v1 = map_primary_type env v1 in
-      let v2 = token env v2 (* "[" *) in
-      let v3 = token env v3 (* "]" *) in
-      todo env (v1, v2, v3)
-  | `Prim_type_tuple_type (v1, v2, v3, v4) ->
-      let v1 = token env v1 (* "[" *) in
-      let v2 = map_type_ env v2 in
-      let v3 =
-        List.map (fun (v1, v2) ->
-          let v1 = token env v1 (* "," *) in
-          let v2 = map_type_ env v2 in
-          todo env (v1, v2)
-        ) v3
-      in
-      let v4 = token env v4 (* "]" *) in
-      todo env (v1, v2, v3, v4)
-  | `Prim_type_flow_maybe_type (v1, v2) ->
-      let v1 = token env v1 (* "?" *) in
-      let v2 = map_primary_type env v2 in
-      todo env (v1, v2)
-  | `Prim_type_type_query (v1, v2) ->
-      let v1 = token env v1 (* "typeof" *) in
-      let v2 =
-        (match v2 with
-        | `Id tok -> token env tok (* identifier *)
-        | `Nest_id x -> map_nested_identifier env x
-        )
-      in
-      todo env (v1, v2)
-  | `Prim_type_index_type_query (v1, v2) ->
-      let v1 = token env v1 (* "keyof" *) in
-      let v2 =
-        (match v2 with
-        | `Id tok -> token env tok (* identifier *)
-        | `Nest_type_id x -> map_nested_type_identifier env x
-        )
-      in
-      todo env (v1, v2)
-  | `Prim_type_this tok -> token env tok (* "this" *)
-  | `Prim_type_exis_type tok -> token env tok (* "*" *)
-  | `Prim_type_lit_type x -> map_literal_type env x
-  | `Prim_type_look_type (v1, v2, v3, v4) ->
-      let v1 = map_primary_type env v1 in
-      let v2 = token env v2 (* "[" *) in
-      let v3 = map_type_ env v3 in
-      let v4 = token env v4 (* "]" *) in
-      todo env (v1, v2, v3, v4)
-  )
-
-
-and map_generic_type (env : env) ((v1, v2) : CST.generic_type) =
-  let v1 =
-    (match v1 with
-    | `Id tok -> token env tok (* identifier *)
-    | `Nest_type_id x -> map_nested_type_identifier env x
-    )
-  in
-  let v2 = map_type_arguments env v2 in
-  todo env (v1, v2)
-
-
-and map_mapped_type_clause (env : env) ((v1, v2, v3) : CST.mapped_type_clause) =
-  let v1 = token env v1 (* identifier *) in
-  let v2 = token env v2 (* "in" *) in
-  let v3 = map_type_ env v3 in
-  todo env (v1, v2, v3)
-
-
-and map_type_arguments (env : env) ((v1, v2, v3, v4, v5) : CST.type_arguments) =
-  let v1 = token env v1 (* "<" *) in
-  let v2 = map_type_ env v2 in
-  let v3 =
-    List.map (fun (v1, v2) ->
-      let v1 = token env v1 (* "," *) in
-      let v2 = map_type_ env v2 in
-      todo env (v1, v2)
-    ) v3
-  in
-  let v4 =
-    (match v4 with
-    | Some tok -> token env tok (* "," *)
-    | None -> todo env ())
-  in
-  let v5 = token env v5 (* ">" *) in
-  todo env (v1, v2, v3, v4, v5)
-
-
-and map_object_type (env : env) ((v1, v2, v3) : CST.object_type) =
-  let v1 =
-    (match v1 with
-    | `LCURL tok -> token env tok (* "{" *)
-    | `LCURLBAR tok -> token env tok (* "{|" *)
-    )
-  in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2, v3, v4) ->
-        let v1 =
-          (match v1 with
-          | Some x ->
-              (match x with
-              | `COMMA tok -> token env tok (* "," *)
-              | `SEMI tok -> token env tok (* ";" *)
-              )
-          | None -> todo env ())
-        in
-        let v2 =
-          (match v2 with
-          | `Expo_stmt x -> map_export_statement env x
-          | `Prop_sign x -> map_property_signature env x
-          | `Call_sign_ x -> map_call_signature_ env x
-          | `Cons_sign x -> map_construct_signature env x
-          | `Index_sign x -> map_index_signature env x
-          | `Meth_sign x -> map_method_signature env x
-          )
-        in
-        let v3 =
-          List.map (fun (v1, v2) ->
-            let v1 =
-              (match v1 with
-              | `COMMA tok -> token env tok (* "," *)
-              | `Choice_auto_semi x ->
-                  (match x with
-                  | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-                  | `SEMI tok -> token env tok (* ";" *)
-                  )
-              )
-            in
-            let v2 =
-              (match v2 with
-              | `Expo_stmt x -> map_export_statement env x
-              | `Prop_sign x -> map_property_signature env x
-              | `Call_sign_ x -> map_call_signature_ env x
-              | `Cons_sign x -> map_construct_signature env x
-              | `Index_sign x -> map_index_signature env x
-              | `Meth_sign x -> map_method_signature env x
-              )
-            in
-            todo env (v1, v2)
-          ) v3
-        in
-        let v4 =
-          (match v4 with
-          | Some x ->
-              (match x with
-              | `COMMA tok -> token env tok (* "," *)
-              | `Choice_auto_semi x ->
-                  (match x with
-                  | `Auto_semi tok -> token env tok (* automatic_semicolon *)
-                  | `SEMI tok -> token env tok (* ";" *)
-                  )
-              )
-          | None -> todo env ())
-        in
-        todo env (v1, v2, v3, v4)
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | `RCURL tok -> token env tok (* "}" *)
-    | `BARRCURL tok -> token env tok (* "|}" *)
-    )
-  in
-  todo env (v1, v2, v3)
-
-
-and map_call_signature_ (env : env) (x : CST.call_signature_) =
-  map_call_signature env x
-
-
-and map_property_signature (env : env) ((v1, v2, v3, v4, v5, v6) : CST.property_signature) =
-  let v1 =
-    (match v1 with
-    | Some x -> map_accessibility_modifier env x
-    | None -> todo env ())
-  in
-  let v2 =
-    (match v2 with
-    | Some tok -> token env tok (* "static" *)
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | Some tok -> token env tok (* "readonly" *)
-    | None -> todo env ())
-  in
-  let v4 = map_property_name env v4 in
-  let v5 =
-    (match v5 with
-    | Some tok -> token env tok (* "?" *)
-    | None -> todo env ())
-  in
-  let v6 =
-    (match v6 with
-    | Some x -> map_type_annotation env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3, v4, v5, v6)
-
-
 and map_type_parameters (env : env) ((v1, v2, v3, v4, v5) : CST.type_parameters) =
   let v1 = token env v1 (* "<" *) in
   let v2 = map_type_parameter env v2 in
@@ -3176,28 +1955,6 @@ and map_type_parameters (env : env) ((v1, v2, v3, v4, v5) : CST.type_parameters)
   let v5 = token env v5 (* ">" *) in
   todo env (v1, v2, v3, v4, v5)
 
-
-and map_type_parameter (env : env) ((v1, v2, v3) : CST.type_parameter) =
-  let v1 = token env v1 (* identifier *) in
-  let v2 =
-    (match v2 with
-    | Some x -> map_constraint_ env x
-    | None -> todo env ())
-  in
-  let v3 =
-    (match v3 with
-    | Some x -> map_default_type env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3)
-
-
-and map_default_type (env : env) ((v1, v2) : CST.default_type) =
-  let v1 = token env v1 (* "=" *) in
-  let v2 = map_type_ env v2 in
-  todo env (v1, v2)
-
-
 and map_constraint_ (env : env) ((v1, v2) : CST.constraint_) =
   let v1 =
     (match v1 with
@@ -3208,67 +1965,222 @@ and map_constraint_ (env : env) ((v1, v2) : CST.constraint_) =
   let v2 = map_type_ env v2 in
   todo env (v1, v2)
 
+and map_anon_choice_id2 (env : env) (x : CST.anon_choice_id2) =
+  (match x with
+  | `Id tok -> token env tok (* identifier *)
+  | `Nest_type_id x -> map_nested_type_identifier env x
+  | `Gene_type x -> map_generic_type env x
+  )
 
-and map_construct_signature (env : env) ((v1, v2, v3, v4) : CST.construct_signature) =
-  let v1 = token env v1 (* "new" *) in
-  let v2 =
-    (match v2 with
-    | Some x -> map_type_parameters env x
+and map_parameter_name (env : env) ((v1, v2, v3) : CST.parameter_name) =
+  let v1 =
+    (match v1 with
+    | Some x -> map_accessibility_modifier env x
     | None -> todo env ())
   in
-  let v3 = map_formal_parameters env v3 in
-  let v4 =
-    (match v4 with
-    | Some x -> map_type_annotation env x
-    | None -> todo env ())
-  in
-  todo env (v1, v2, v3, v4)
-
-
-and map_index_signature (env : env) ((v1, v2, v3, v4) : CST.index_signature) =
-  let v1 = token env v1 (* "[" *) in
   let v2 =
     (match v2 with
-    | `Choice_id_COLON_pred_type (v1, v2, v3) ->
-        let v1 =
-          (match v1 with
-          | `Id tok -> token env tok (* identifier *)
-          | `Choice_decl x ->
-              (match x with
-              | `Decl tok -> token env tok (* "declare" *)
-              | `Name tok -> token env tok (* "namespace" *)
-              | `Type tok -> token env tok (* "type" *)
-              | `Publ tok -> token env tok (* "public" *)
-              | `Priv tok -> token env tok (* "private" *)
-              | `Prot tok -> token env tok (* "protected" *)
-              | `Read tok -> token env tok (* "readonly" *)
-              | `Modu tok -> token env tok (* "module" *)
-              | `Any tok -> token env tok (* "any" *)
-              | `Num tok -> token env tok (* "number" *)
-              | `Bool tok -> token env tok (* "boolean" *)
-              | `Str tok -> token env tok (* "string" *)
-              | `Symb tok -> token env tok (* "symbol" *)
-              | `Void tok -> token env tok (* "void" *)
-              | `Expo tok -> token env tok (* "export" *)
-              | `Choice_get x ->
-                  (match x with
-                  | `Get tok -> token env tok (* "get" *)
-                  | `Set tok -> token env tok (* "set" *)
-                  | `Async tok -> token env tok (* "async" *)
-                  | `Stat tok -> token env tok (* "static" *)
-                  )
-              )
-          )
-        in
-        let v2 = token env v2 (* ":" *) in
-        let v3 = map_predefined_type env v3 in
-        todo env (v1, v2, v3)
-    | `Mapp_type_clau x -> map_mapped_type_clause env x
+    | Some tok -> token env tok (* "readonly" *)
+    | None -> todo env ())
+  in
+  let v3 =
+    (match v3 with
+    | `Id tok -> token env tok (* identifier *)
+    | `Choice_decl x -> map_anon_choice_decl env x
+    | `Choice_obj x -> map_anon_choice_obj env x
+    | `This tok -> token env tok (* "this" *)
     )
   in
-  let v3 = token env v3 (* "]" *) in
-  let v4 = map_type_annotation env v4 in
+  todo env (v1, v2, v3)
+
+and map_anon_choice_exp_ (env : env) (x : CST.anon_choice_exp_) =
+  (match x with
+  | `Exp x -> map_expression env x
+  | `Spre_elem x -> map_spread_element env x
+  )
+
+and map_statement_block (env : env) ((v1, v2, v3, v4) : CST.statement_block) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 = List.map (map_anon_choice_expo_stmt_ env) v2 in
+  let v3 = token env v3 (* "}" *) in
+  let v4 =
+    (match v4 with
+    | Some tok -> token env tok (* automatic_semicolon *)
+    | None -> todo env ())
+  in
   todo env (v1, v2, v3, v4)
+
+and map_function_declaration (env : env) ((v1, v2, v3, v4, v5, v6) : CST.function_declaration) =
+  let v1 =
+    (match v1 with
+    | Some tok -> token env tok (* "async" *)
+    | None -> todo env ())
+  in
+  let v2 = token env v2 (* "function" *) in
+  let v3 = token env v3 (* identifier *) in
+  let v4 = map_call_signature_ env v4 in
+  let v5 = map_statement_block env v5 in
+  let v6 =
+    (match v6 with
+    | Some tok -> token env tok (* automatic_semicolon *)
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3, v4, v5, v6)
+
+and map_template_substitution (env : env) ((v1, v2, v3) : CST.template_substitution) =
+  let v1 = token env v1 (* "${" *) in
+  let v2 = map_anon_choice_exp env v2 in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+and map_method_signature (env : env) ((v1, v2, v3, v4, v5, v6, v7, v8) : CST.method_signature) =
+  let v1 =
+    (match v1 with
+    | Some x -> map_accessibility_modifier env x
+    | None -> todo env ())
+  in
+  let v2 =
+    (match v2 with
+    | Some tok -> token env tok (* "static" *)
+    | None -> todo env ())
+  in
+  let v3 =
+    (match v3 with
+    | Some tok -> token env tok (* "readonly" *)
+    | None -> todo env ())
+  in
+  let v4 =
+    (match v4 with
+    | Some tok -> token env tok (* "async" *)
+    | None -> todo env ())
+  in
+  let v5 =
+    (match v5 with
+    | Some x -> map_anon_choice_get env x
+    | None -> todo env ())
+  in
+  let v6 = map_property_name env v6 in
+  let v7 =
+    (match v7 with
+    | Some tok -> token env tok (* "?" *)
+    | None -> todo env ())
+  in
+  let v8 = map_call_signature_ env v8 in
+  todo env (v1, v2, v3, v4, v5, v6, v7, v8)
+
+and map_anon_choice_choice_id (env : env) (x : CST.anon_choice_choice_id) =
+  (match x with
+  | `Choice_id x -> map_anon_choice_id2 env x
+  | `Exp x -> map_expression env x
+  )
+
+and map_declaration (env : env) (x : CST.declaration) =
+  (match x with
+  | `Decl_choice_func_decl x ->
+      (match x with
+      | `Func_decl x -> map_function_declaration env x
+      | `Gene_func_decl x ->
+          map_generator_function_declaration env x
+      | `Class_decl x -> map_class_declaration env x
+      | `Lexi_decl x -> map_lexical_declaration env x
+      | `Var_decl x -> map_variable_declaration env x
+      )
+  | `Decl_func_sign (v1, v2, v3, v4, v5) ->
+      let v1 =
+        (match v1 with
+        | Some tok -> token env tok (* "async" *)
+        | None -> todo env ())
+      in
+      let v2 = token env v2 (* "function" *) in
+      let v3 = token env v3 (* identifier *) in
+      let v4 = map_call_signature_ env v4 in
+      let v5 = map_anon_choice_auto_semi env v5 in
+      todo env (v1, v2, v3, v4, v5)
+  | `Decl_abst_class_decl (v1, v2, v3, v4, v5, v6) ->
+      let v1 = token env v1 (* "abstract" *) in
+      let v2 = token env v2 (* "class" *) in
+      let v3 = token env v3 (* identifier *) in
+      let v4 =
+        (match v4 with
+        | Some x -> map_type_parameters env x
+        | None -> todo env ())
+      in
+      let v5 =
+        (match v5 with
+        | Some x -> map_class_heritage env x
+        | None -> todo env ())
+      in
+      let v6 = map_class_body env v6 in
+      todo env (v1, v2, v3, v4, v5, v6)
+  | `Decl_modu (v1, v2) ->
+      let v1 = token env v1 (* "module" *) in
+      let v2 = map_module__ env v2 in
+      todo env (v1, v2)
+  | `Decl_inte_modu x -> map_internal_module env x
+  | `Decl_type_alias_decl (v1, v2, v3, v4, v5, v6) ->
+      let v1 = token env v1 (* "type" *) in
+      let v2 = token env v2 (* identifier *) in
+      let v3 =
+        (match v3 with
+        | Some x -> map_type_parameters env x
+        | None -> todo env ())
+      in
+      let v4 = token env v4 (* "=" *) in
+      let v5 = map_type_ env v5 in
+      let v6 = map_anon_choice_auto_semi env v6 in
+      todo env (v1, v2, v3, v4, v5, v6)
+  | `Decl_enum_decl (v1, v2, v3, v4) ->
+      let v1 =
+        (match v1 with
+        | Some tok -> token env tok (* "const" *)
+        | None -> todo env ())
+      in
+      let v2 = token env v2 (* "enum" *) in
+      let v3 = token env v3 (* identifier *) in
+      let v4 = map_enum_body env v4 in
+      todo env (v1, v2, v3, v4)
+  | `Decl_inte_decl (v1, v2, v3, v4, v5) ->
+      let v1 = token env v1 (* "interface" *) in
+      let v2 = token env v2 (* identifier *) in
+      let v3 =
+        (match v3 with
+        | Some x -> map_type_parameters env x
+        | None -> todo env ())
+      in
+      let v4 =
+        (match v4 with
+        | Some x -> map_extends_clause env x
+        | None -> todo env ())
+      in
+      let v5 = map_object_type env v5 in
+      todo env (v1, v2, v3, v4, v5)
+  | `Decl_impo_alias (v1, v2, v3, v4, v5) ->
+      let v1 = token env v1 (* "import" *) in
+      let v2 = token env v2 (* identifier *) in
+      let v3 = token env v3 (* "=" *) in
+      let v4 = map_anon_choice_id_ env v4 in
+      let v5 = map_anon_choice_auto_semi env v5 in
+      todo env (v1, v2, v3, v4, v5)
+  | `Decl_ambi_decl (v1, v2) ->
+      let v1 = token env v1 (* "declare" *) in
+      let v2 =
+        (match v2 with
+        | `Decl x -> map_declaration env x
+        | `Glob_stmt_blk (v1, v2) ->
+            let v1 = token env v1 (* "global" *) in
+            let v2 = map_statement_block env v2 in
+            todo env (v1, v2)
+        | `Modu_DOT_id_COLON_type (v1, v2, v3, v4, v5) ->
+            let v1 = token env v1 (* "module" *) in
+            let v2 = token env v2 (* "." *) in
+            let v3 = token env v3 (* identifier *) in
+            let v4 = token env v4 (* ":" *) in
+            let v5 = map_type_ env v5 in
+            todo env (v1, v2, v3, v4, v5)
+        )
+      in
+      todo env (v1, v2)
+  )
 
 let map_jsx_expression (env : env) ((v1, v2, v3) : CST.jsx_expression) =
   let v1 = token env v1 (* "{" *) in
@@ -3291,98 +2203,17 @@ let map_program (env : env) ((v1, v2) : CST.program) =
     | Some tok -> token env tok (* pattern #!.* *)
     | None -> todo env ())
   in
-  let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Expo_stmt x -> map_export_statement env x
-      | `Impo_stmt x -> map_import_statement env x
-      | `Debu_stmt x -> map_debugger_statement env x
-      | `Exp_stmt x -> map_expression_statement env x
-      | `Decl x -> map_declaration env x
-      | `Stmt_blk x -> map_statement_block env x
-      | `If_stmt x -> map_if_statement env x
-      | `Swit_stmt x -> map_switch_statement env x
-      | `For_stmt x -> map_for_statement env x
-      | `For_in_stmt x -> map_for_in_statement env x
-      | `While_stmt x -> map_while_statement env x
-      | `Do_stmt x -> map_do_statement env x
-      | `Try_stmt x -> map_try_statement env x
-      | `With_stmt x -> map_with_statement env x
-      | `Brk_stmt x -> map_break_statement env x
-      | `Cont_stmt x -> map_continue_statement env x
-      | `Ret_stmt x -> map_return_statement env x
-      | `Throw_stmt x -> map_throw_statement env x
-      | `Empty_stmt tok -> token env tok (* ";" *)
-      | `Labe_stmt x -> map_labeled_statement env x
-      )
-    ) v2
-  in
+  let v2 = List.map (map_anon_choice_expo_stmt_ env) v2 in
   todo env (v1, v2)
 
-let rec map_jsx_element (env : env) ((v1, v2, v3) : CST.jsx_element) =
-  let v1 = map_jsx_opening_element env v1 in
-  let v2 =
-    List.map (fun x ->
-      (match x with
-      | `Jsx_text tok -> token env tok (* pattern [^{}<>]+ *)
-      | `Choice_jsx_elem x ->
-          (match x with
-          | `Jsx_elem x -> map_jsx_element env x
-          | `Jsx_self_clos_elem x ->
-              map_jsx_self_closing_element env x
-          )
-      | `Jsx_exp x -> map_jsx_expression env x
-      )
-    ) v2
-  in
-  let v3 = map_jsx_closing_element env v3 in
-  todo env (v1, v2, v3)
-
-
-and map_jsx_fragment (env : env) ((v1, v2, v3, v4, v5, v6) : CST.jsx_fragment) =
-  let v1 = token env v1 (* "<" *) in
-  let v2 = token env v2 (* ">" *) in
-  let v3 =
-    List.map (fun x ->
-      (match x with
-      | `Jsx_text tok -> token env tok (* pattern [^{}<>]+ *)
-      | `Choice_jsx_elem x ->
-          (match x with
-          | `Jsx_elem x -> map_jsx_element env x
-          | `Jsx_self_clos_elem x ->
-              map_jsx_self_closing_element env x
-          )
-      | `Jsx_exp x -> map_jsx_expression env x
-      )
-    ) v3
-  in
-  let v4 = token env v4 (* "<" *) in
-  let v5 = token env v5 (* "/" *) in
-  let v6 = token env v6 (* ">" *) in
-  todo env (v1, v2, v3, v4, v5, v6)
-
-
-and map_jsx_opening_element (env : env) ((v1, v2, v3, v4) : CST.jsx_opening_element) =
+let rec map_jsx_opening_element (env : env) ((v1, v2, v3, v4) : CST.jsx_opening_element) =
   let v1 = token env v1 (* "<" *) in
   let v2 =
     (match v2 with
     | `Choice_choice_jsx_id x ->
-        (match x with
-        | `Choice_jsx_id x ->
-            (match x with
-            | `Jsx_id tok ->
-                token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
-            | `Id tok -> token env tok (* identifier *)
-            )
-        | `Jsx_name_name x -> map_jsx_namespace_name env x
-        )
+        map_anon_choice_choice_jsx_id env x
     | `Choice_id_opt_type_args (v1, v2) ->
-        let v1 =
-          (match v1 with
-          | `Id tok -> token env tok (* identifier *)
-          | `Nest_id x -> map_nested_identifier env x
-          )
-        in
+        let v1 = map_anon_choice_id_ env v1 in
         let v2 =
           (match v2 with
           | Some x -> map_type_arguments env x
@@ -3391,76 +2222,61 @@ and map_jsx_opening_element (env : env) ((v1, v2, v3, v4) : CST.jsx_opening_elem
         todo env (v1, v2)
     )
   in
-  let v3 =
-    List.map (fun x ->
-      (match x with
-      | `Jsx_attr x -> map_jsx_attribute env x
-      | `Jsx_exp x -> map_jsx_expression env x
-      )
-    ) v3
-  in
+  let v3 = List.map (map_anon_choice_jsx_attr env) v3 in
   let v4 = token env v4 (* ">" *) in
   todo env (v1, v2, v3, v4)
 
-
-and map_jsx_self_closing_element (env : env) ((v1, v2, v3, v4, v5) : CST.jsx_self_closing_element) =
-  let v1 = token env v1 (* "<" *) in
-  let v2 =
-    (match v2 with
-    | `Choice_jsx_id x ->
-        (match x with
-        | `Jsx_id tok ->
-            token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
-        | `Id tok -> token env tok (* identifier *)
-        )
-    | `Nest_id x -> map_nested_identifier env x
-    | `Jsx_name_name x -> map_jsx_namespace_name env x
-    )
-  in
-  let v3 =
-    List.map (fun x ->
-      (match x with
-      | `Jsx_attr x -> map_jsx_attribute env x
-      | `Jsx_exp x -> map_jsx_expression env x
-      )
-    ) v3
-  in
-  let v4 = token env v4 (* "/" *) in
-  let v5 = token env v5 (* ">" *) in
-  todo env (v1, v2, v3, v4, v5)
-
-
-and map_jsx_attribute (env : env) ((v1, v2) : CST.jsx_attribute) =
-  let v1 =
-    (match v1 with
-    | `Choice_jsx_id x ->
-        (match x with
-        | `Jsx_id tok ->
-            token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
-        | `Id tok -> token env tok (* identifier *)
-        )
-    | `Jsx_name_name x -> map_jsx_namespace_name env x
-    )
-  in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) ->
-        let v1 = token env v1 (* "=" *) in
-        let v2 =
-          (match v2 with
-          | `Str x -> map_string_ env x
-          | `Jsx_exp x -> map_jsx_expression env x
-          | `Choice_jsx_elem x ->
-              (match x with
-              | `Jsx_elem x -> map_jsx_element env x
-              | `Jsx_self_clos_elem x ->
-                  map_jsx_self_closing_element env x
+and map_anon_choice_jsx_attr (env : env) (x : CST.anon_choice_jsx_attr) =
+  (match x with
+  | `Jsx_attr (v1, v2) ->
+      let v1 = map_anon_choice_choice_jsx_id env v1 in
+      let v2 =
+        (match v2 with
+        | Some (v1, v2) ->
+            let v1 = token env v1 (* "=" *) in
+            let v2 =
+              (match v2 with
+              | `Str x -> map_string_ env x
+              | `Jsx_exp x -> map_jsx_expression env x
+              | `Choice_jsx_elem x -> map_anon_choice_jsx_elem env x
+              | `Jsx_frag x -> map_jsx_fragment env x
               )
-          | `Jsx_frag x -> map_jsx_fragment env x
-          )
-        in
-        todo env (v1, v2)
-    | None -> todo env ())
-  in
-  todo env (v1, v2)
+            in
+            todo env (v1, v2)
+        | None -> todo env ())
+      in
+      todo env (v1, v2)
+  | `Jsx_exp x -> map_jsx_expression env x
+  )
 
+and map_jsx_fragment (env : env) ((v1, v2, v3, v4, v5, v6) : CST.jsx_fragment) =
+  let v1 = token env v1 (* "<" *) in
+  let v2 = token env v2 (* ">" *) in
+  let v3 = List.map (map_anon_choice_jsx_text env) v3 in
+  let v4 = token env v4 (* "<" *) in
+  let v5 = token env v5 (* "/" *) in
+  let v6 = token env v6 (* ">" *) in
+  todo env (v1, v2, v3, v4, v5, v6)
+
+and map_anon_choice_jsx_text (env : env) (x : CST.anon_choice_jsx_text) =
+  (match x with
+  | `Jsx_text tok -> token env tok (* pattern [^{}<>]+ *)
+  | `Choice_jsx_elem x -> map_anon_choice_jsx_elem env x
+  | `Jsx_exp x -> map_jsx_expression env x
+  )
+
+and map_anon_choice_jsx_elem (env : env) (x : CST.anon_choice_jsx_elem) =
+  (match x with
+  | `Jsx_elem (v1, v2, v3) ->
+      let v1 = map_jsx_opening_element env v1 in
+      let v2 = List.map (map_anon_choice_jsx_text env) v2 in
+      let v3 = map_jsx_closing_element env v3 in
+      todo env (v1, v2, v3)
+  | `Jsx_self_clos_elem (v1, v2, v3, v4, v5) ->
+      let v1 = token env v1 (* "<" *) in
+      let v2 = map_anon_choice_choice_jsx_id_ env v2 in
+      let v3 = List.map (map_anon_choice_jsx_attr env) v3 in
+      let v4 = token env v4 (* "/" *) in
+      let v5 = token env v5 (* ">" *) in
+      todo env (v1, v2, v3, v4, v5)
+  )

--- a/typescript/lib/CST.ml
+++ b/typescript/lib/CST.ml
@@ -8,12 +8,56 @@
 open! Sexplib.Conv
 open Tree_sitter_run
 
+type hash_bang_line = Token.t (* pattern #!.* *)
+[@@deriving sexp_of]
+
+type regex_pattern = Token.t
+[@@deriving sexp_of]
+
+type template_chars = Token.t
+[@@deriving sexp_of]
+
+type automatic_semicolon = Token.t
+[@@deriving sexp_of]
+
+type number = Token.t
+[@@deriving sexp_of]
+
+type anon_choice_get_ = [
+    `Get of Token.t (* "get" *)
+  | `Set of Token.t (* "set" *)
+  | `Async of Token.t (* "async" *)
+  | `Stat of Token.t (* "static" *)
+]
+[@@deriving sexp_of]
+
+type escape_sequence = Token.t
+[@@deriving sexp_of]
+
+type jsx_identifier =
+  Token.t (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
+[@@deriving sexp_of]
+
 type jsx_text = Token.t (* pattern [^{}<>]+ *)
 [@@deriving sexp_of]
 
-type meta_property = (
-    Token.t (* "new" *) * Token.t (* "." *) * Token.t (* "target" *)
-)
+type anon_choice_get = [
+    `Get of Token.t (* "get" *)
+  | `Set of Token.t (* "set" *)
+  | `STAR of Token.t (* "*" *)
+]
+[@@deriving sexp_of]
+
+type anon_choice_type = [
+    `Type_599dcce of Token.t (* "type" *)
+  | `Type_ac95254 of Token.t (* "typeof" *)
+]
+[@@deriving sexp_of]
+
+type import = Token.t
+[@@deriving sexp_of]
+
+type regex_flags = Token.t (* pattern [a-z]+ *)
 [@@deriving sexp_of]
 
 type predefined_type = [
@@ -26,33 +70,6 @@ type predefined_type = [
 ]
 [@@deriving sexp_of]
 
-type template_chars = Token.t
-[@@deriving sexp_of]
-
-type regex_pattern = Token.t
-[@@deriving sexp_of]
-
-type escape_sequence = Token.t
-[@@deriving sexp_of]
-
-type number = Token.t
-[@@deriving sexp_of]
-
-type hash_bang_line = Token.t (* pattern #!.* *)
-[@@deriving sexp_of]
-
-type automatic_semicolon = Token.t
-[@@deriving sexp_of]
-
-type identifier = Token.t
-[@@deriving sexp_of]
-
-type import = Token.t
-[@@deriving sexp_of]
-
-type regex_flags = Token.t (* pattern [a-z]+ *)
-[@@deriving sexp_of]
-
 type accessibility_modifier = [
     `Publ of Token.t (* "public" *)
   | `Priv of Token.t (* "private" *)
@@ -60,61 +77,45 @@ type accessibility_modifier = [
 ]
 [@@deriving sexp_of]
 
-type jsx_identifier =
-  Token.t (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
+type identifier = Token.t
 [@@deriving sexp_of]
 
-type string_ = [
-    `Str_DQUOT_rep_choice_blank_DQUOT of (
-        Token.t (* "\"" *)
-      * [ `Blank of unit (* blank *) | `Esc_seq of escape_sequence (*tok*) ]
-          list (* zero or more *)
-      * Token.t (* "\"" *)
-    )
-  | `Str_SQUOT_rep_choice_blank_SQUOT of (
-        Token.t (* "'" *)
-      * [ `Blank of unit (* blank *) | `Esc_seq of escape_sequence (*tok*) ]
-          list (* zero or more *)
-      * Token.t (* "'" *)
-    )
+type anon_choice_PLUSPLUS = [
+    `PLUSPLUS of Token.t (* "++" *)
+  | `DASHDASH of Token.t (* "--" *)
 ]
 [@@deriving sexp_of]
 
-type debugger_statement = (
-    Token.t (* "debugger" *)
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
-)
+type anon_choice_auto_semi = [
+    `Auto_semi of automatic_semicolon (*tok*)
+  | `SEMI of Token.t (* ";" *)
+]
 [@@deriving sexp_of]
 
-type continue_statement = (
-    Token.t (* "continue" *)
-  * identifier (*tok*) option
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
-)
+type anon_choice_blank = [
+    `Blank of unit (* blank *)
+  | `Esc_seq of escape_sequence (*tok*)
+]
 [@@deriving sexp_of]
 
-type nested_identifier = (
-    [ `Id of identifier (*tok*) | `Nest_id of nested_identifier ]
-  * Token.t (* "." *)
-  * identifier (*tok*)
-)
-[@@deriving sexp_of]
-
-type import_export_specifier = (
-    [
-        `Type_599dcce of Token.t (* "type" *)
-      | `Type_ac95254 of Token.t (* "typeof" *)
-    ]
-      option
-  * identifier (*tok*)
-  * (Token.t (* "as" *) * identifier (*tok*)) option
-)
+type anon_choice_decl = [
+    `Decl of Token.t (* "declare" *)
+  | `Name of Token.t (* "namespace" *)
+  | `Type of Token.t (* "type" *)
+  | `Publ of Token.t (* "public" *)
+  | `Priv of Token.t (* "private" *)
+  | `Prot of Token.t (* "protected" *)
+  | `Read of Token.t (* "readonly" *)
+  | `Modu of Token.t (* "module" *)
+  | `Any of Token.t (* "any" *)
+  | `Num of Token.t (* "number" *)
+  | `Bool of Token.t (* "boolean" *)
+  | `Str of Token.t (* "string" *)
+  | `Symb of Token.t (* "symbol" *)
+  | `Void of Token.t (* "void" *)
+  | `Expo of Token.t (* "export" *)
+  | `Choice_get of anon_choice_get_
+]
 [@@deriving sexp_of]
 
 type namespace_import = (
@@ -122,63 +123,74 @@ type namespace_import = (
 )
 [@@deriving sexp_of]
 
-type break_statement = (
-    Token.t (* "break" *)
-  * identifier (*tok*) option
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
+type anon_choice_jsx_id = [
+    `Jsx_id of jsx_identifier (*tok*)
+  | `Id of identifier (*tok*)
+]
+[@@deriving sexp_of]
+
+type anon_choice_id_ = [
+    `Id of identifier (*tok*)
+  | `Nest_id of nested_identifier
+]
+
+and nested_identifier = (
+    anon_choice_id_ * Token.t (* "." *) * identifier (*tok*)
 )
 [@@deriving sexp_of]
 
-type decorator_member_expression = (
-    [
-        `Choice_id of [
-            `Id of identifier (*tok*)
-          | `Choice_decl of [
-                `Decl of Token.t (* "declare" *)
-              | `Name of Token.t (* "namespace" *)
-              | `Type of Token.t (* "type" *)
-              | `Publ of Token.t (* "public" *)
-              | `Priv of Token.t (* "private" *)
-              | `Prot of Token.t (* "protected" *)
-              | `Read of Token.t (* "readonly" *)
-              | `Modu of Token.t (* "module" *)
-              | `Any of Token.t (* "any" *)
-              | `Num of Token.t (* "number" *)
-              | `Bool of Token.t (* "boolean" *)
-              | `Str of Token.t (* "string" *)
-              | `Symb of Token.t (* "symbol" *)
-              | `Void of Token.t (* "void" *)
-              | `Expo of Token.t (* "export" *)
-              | `Choice_get of [
-                    `Get of Token.t (* "get" *)
-                  | `Set of Token.t (* "set" *)
-                  | `Async of Token.t (* "async" *)
-                  | `Stat of Token.t (* "static" *)
-                ]
-            ]
-        ]
-      | `Deco_memb_exp of decorator_member_expression
-    ]
-  * Token.t (* "." *)
+type import_export_specifier = (
+    anon_choice_type option
   * identifier (*tok*)
+  * (Token.t (* "as" *) * identifier (*tok*)) option
 )
 [@@deriving sexp_of]
 
-type regex = (
-    Token.t (* "/" *)
-  * regex_pattern (*tok*)
-  * Token.t (* "/" *)
-  * regex_flags (*tok*) option
-)
+type anon_choice_COMMA = [
+    `COMMA of Token.t (* "," *)
+  | `Choice_auto_semi of anon_choice_auto_semi
+]
+[@@deriving sexp_of]
+
+type string_ = [
+    `Str_DQUOT_rep_choice_blank_DQUOT of (
+        Token.t (* "\"" *)
+      * anon_choice_blank list (* zero or more *)
+      * Token.t (* "\"" *)
+    )
+  | `Str_SQUOT_rep_choice_blank_SQUOT of (
+        Token.t (* "'" *)
+      * anon_choice_blank list (* zero or more *)
+      * Token.t (* "'" *)
+    )
+]
+[@@deriving sexp_of]
+
+type anon_choice_choice_decl = [
+    `Choice_decl of anon_choice_decl
+  | `Id of identifier (*tok*)
+]
+[@@deriving sexp_of]
+
+type anon_choice_id4 = [
+    `Id of identifier (*tok*)
+  | `Choice_decl of anon_choice_decl
+]
 [@@deriving sexp_of]
 
 type jsx_namespace_name = (
-    [ `Jsx_id of jsx_identifier (*tok*) | `Id of identifier (*tok*) ]
-  * Token.t (* ":" *)
-  * [ `Jsx_id of jsx_identifier (*tok*) | `Id of identifier (*tok*) ]
+    anon_choice_jsx_id * Token.t (* ":" *) * anon_choice_jsx_id
+)
+[@@deriving sexp_of]
+
+type nested_type_identifier = (
+    anon_choice_id_ * Token.t (* "." *) * identifier (*tok*)
+)
+[@@deriving sexp_of]
+
+type anon_impo_expo_spec_rep_COMMA_impo_expo_spec = (
+    import_export_specifier
+  * (Token.t (* "," *) * import_export_specifier) list (* zero or more *)
 )
 [@@deriving sexp_of]
 
@@ -186,9 +198,6 @@ type import_require_clause = (
     identifier (*tok*) * Token.t (* "=" *) * Token.t (* "require" *)
   * Token.t (* "(" *) * string_ * Token.t (* ")" *)
 )
-[@@deriving sexp_of]
-
-type from_clause = (Token.t (* "from" *) * string_)
 [@@deriving sexp_of]
 
 type literal_type = [
@@ -203,48 +212,56 @@ type literal_type = [
 ]
 [@@deriving sexp_of]
 
-type nested_type_identifier = (
-    [ `Id of identifier (*tok*) | `Nest_id of nested_identifier ]
-  * Token.t (* "." *)
-  * identifier (*tok*)
-)
+type from_clause = (Token.t (* "from" *) * string_)
 [@@deriving sexp_of]
 
-type export_clause = (
+type decorator_member_expression = (
+    anon_choice_choice_id_ * Token.t (* "." *) * identifier (*tok*)
+)
+
+and anon_choice_choice_id_ = [
+    `Choice_id of anon_choice_id4
+  | `Deco_memb_exp of decorator_member_expression
+]
+[@@deriving sexp_of]
+
+type anon_choice_choice_jsx_id = [
+    `Choice_jsx_id of anon_choice_jsx_id
+  | `Jsx_name_name of jsx_namespace_name
+]
+[@@deriving sexp_of]
+
+type anon_choice_choice_jsx_id_ = [
+    `Choice_jsx_id of anon_choice_jsx_id
+  | `Nest_id of nested_identifier
+  | `Jsx_name_name of jsx_namespace_name
+]
+[@@deriving sexp_of]
+
+type anon_choice_id = [
+    `Id of identifier (*tok*)
+  | `Nest_type_id of nested_type_identifier
+]
+[@@deriving sexp_of]
+
+type named_imports = (
     Token.t (* "{" *)
-  * (
-        import_export_specifier
-      * (Token.t (* "," *) * import_export_specifier) list (* zero or more *)
-    )
-      option
+  * anon_impo_expo_spec_rep_COMMA_impo_expo_spec option
   * Token.t (* "," *) option
   * Token.t (* "}" *)
 )
 [@@deriving sexp_of]
 
-type named_imports = (
+type export_clause = (
     Token.t (* "{" *)
-  * (
-        import_export_specifier
-      * (Token.t (* "," *) * import_export_specifier) list (* zero or more *)
-    )
-      option
+  * anon_impo_expo_spec_rep_COMMA_impo_expo_spec option
   * Token.t (* "," *) option
   * Token.t (* "}" *)
 )
 [@@deriving sexp_of]
 
 type jsx_closing_element = (
-    Token.t (* "<" *)
-  * Token.t (* "/" *)
-  * [
-        `Choice_jsx_id of [
-            `Jsx_id of jsx_identifier (*tok*)
-          | `Id of identifier (*tok*)
-        ]
-      | `Nest_id of nested_identifier
-      | `Jsx_name_name of jsx_namespace_name
-    ]
+    Token.t (* "<" *) * Token.t (* "/" *) * anon_choice_choice_jsx_id_
   * Token.t (* ">" *)
 )
 [@@deriving sexp_of]
@@ -266,343 +283,427 @@ type import_clause = [
 ]
 [@@deriving sexp_of]
 
-type import_statement = (
-    Token.t (* "import" *)
+type parenthesized_expression = (
+    Token.t (* "(" *)
   * [
-        `Type_599dcce of Token.t (* "type" *)
-      | `Type_ac95254 of Token.t (* "typeof" *)
+        `Exp_opt_type_anno of (expression * type_annotation option)
+      | `Seq_exp of sequence_expression
     ]
-      option
-  * [
-        `Impo_clau_from_clau of (import_clause * from_clause)
-      | `Impo_requ_clau of import_require_clause
-      | `Str of string_
-    ]
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
+  * Token.t (* ")" *)
 )
-[@@deriving sexp_of]
 
-type export_statement = [
-    `Choice_expo_choice_STAR_from_clau_choice_auto_semi of [
-        `Expo_choice_STAR_from_clau_choice_auto_semi of (
-            Token.t (* "export" *)
-          * [
-                `STAR_from_clau_choice_auto_semi of (
-                    Token.t (* "*" *)
-                  * from_clause
-                  * [
-                        `Auto_semi of automatic_semicolon (*tok*)
-                      | `SEMI of Token.t (* ";" *)
-                    ]
-                )
-              | `Expo_clau_from_clau_choice_auto_semi of (
-                    export_clause
-                  * from_clause
-                  * [
-                        `Auto_semi of automatic_semicolon (*tok*)
-                      | `SEMI of Token.t (* ";" *)
-                    ]
-                )
-              | `Expo_clau_choice_auto_semi of (
-                    export_clause
-                  * [
-                        `Auto_semi of automatic_semicolon (*tok*)
-                      | `SEMI of Token.t (* ";" *)
-                    ]
-                )
-            ]
-        )
-      | `Rep_deco_expo_choice_decl of (
-            decorator list (* zero or more *)
-          * Token.t (* "export" *)
-          * [
-                `Decl of declaration
-              | `Defa_exp_choice_auto_semi of (
-                    Token.t (* "default" *)
-                  * expression
-                  * [
-                        `Auto_semi of automatic_semicolon (*tok*)
-                      | `SEMI of Token.t (* ";" *)
-                    ]
-                )
-            ]
-        )
-    ]
-  | `Expo_EQ_id_choice_auto_semi of (
-        Token.t (* "export" *)
-      * Token.t (* "=" *)
-      * identifier (*tok*)
-      * [
-            `Auto_semi of automatic_semicolon (*tok*)
-          | `SEMI of Token.t (* ";" *)
-        ]
-    )
-  | `Expo_as_name_id_choice_auto_semi of (
-        Token.t (* "export" *)
-      * Token.t (* "as" *)
-      * Token.t (* "namespace" *)
-      * identifier (*tok*)
-      * [
-            `Auto_semi of automatic_semicolon (*tok*)
-          | `SEMI of Token.t (* ";" *)
-        ]
-    )
-]
-and declaration = [
-    `Decl_choice_func_decl of [
-        `Func_decl of function_declaration
-      | `Gene_func_decl of generator_function_declaration
-      | `Class_decl of class_declaration
-      | `Lexi_decl of lexical_declaration
-      | `Var_decl of variable_declaration
-    ]
-  | `Decl_func_sign of (
-        Token.t (* "async" *) option
-      * Token.t (* "function" *)
-      * identifier (*tok*)
-      * call_signature
-      * [
-            `Auto_semi of automatic_semicolon (*tok*)
-          | `SEMI of Token.t (* ";" *)
-        ]
-    )
-  | `Decl_abst_class_decl of (
-        Token.t (* "abstract" *)
-      * Token.t (* "class" *)
-      * identifier (*tok*)
-      * type_parameters option
-      * class_heritage option
-      * class_body
-    )
-  | `Decl_modu of (Token.t (* "module" *) * module__)
-  | `Decl_inte_modu of internal_module
-  | `Decl_type_alias_decl of (
-        Token.t (* "type" *)
-      * identifier (*tok*)
-      * type_parameters option
-      * Token.t (* "=" *)
-      * type_
-      * [
-            `Auto_semi of automatic_semicolon (*tok*)
-          | `SEMI of Token.t (* ";" *)
-        ]
-    )
-  | `Decl_enum_decl of (
-        Token.t (* "const" *) option
-      * Token.t (* "enum" *)
-      * identifier (*tok*)
-      * enum_body
-    )
-  | `Decl_inte_decl of (
-        Token.t (* "interface" *)
-      * identifier (*tok*)
-      * type_parameters option
-      * extends_clause option
-      * object_type
-    )
-  | `Decl_impo_alias of (
-        Token.t (* "import" *)
-      * identifier (*tok*)
-      * Token.t (* "=" *)
-      * [ `Id of identifier (*tok*) | `Nest_id of nested_identifier ]
-      * [
-            `Auto_semi of automatic_semicolon (*tok*)
-          | `SEMI of Token.t (* ";" *)
-        ]
-    )
-  | `Decl_ambi_decl of (
-        Token.t (* "declare" *)
-      * [
-            `Decl of declaration
-          | `Glob_stmt_blk of (Token.t (* "global" *) * statement_block)
-          | `Modu_DOT_id_COLON_type of (
-                Token.t (* "module" *) * Token.t (* "." *)
-              * identifier (*tok*) * Token.t (* ":" *) * type_
-            )
-        ]
-    )
-]
-and expression_statement = (
-    [ `Exp of expression | `Seq_exp of sequence_expression ]
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
-)
+and call_signature_ = call_signature
+
 and variable_declaration = (
     Token.t (* "var" *)
   * variable_declarator
   * (Token.t (* "," *) * variable_declarator) list (* zero or more *)
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
+  * anon_choice_auto_semi
 )
-and lexical_declaration = (
-    [ `Let of Token.t (* "let" *) | `Const of Token.t (* "const" *) ]
-  * variable_declarator
-  * (Token.t (* "," *) * variable_declarator) list (* zero or more *)
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
+
+and function_ = (
+    Token.t (* "async" *) option
+  * Token.t (* "function" *)
+  * identifier (*tok*) option
+  * call_signature_
+  * statement_block
 )
+
+and generic_type = (anon_choice_id * type_arguments)
+
+and anon_choice_expo_stmt = [
+    `Expo_stmt of export_statement
+  | `Prop_sign of (
+        accessibility_modifier option
+      * Token.t (* "static" *) option
+      * Token.t (* "readonly" *) option
+      * property_name
+      * Token.t (* "?" *) option
+      * type_annotation option
+    )
+  | `Call_sign_ of call_signature_
+  | `Cons_sign of (
+        Token.t (* "new" *)
+      * type_parameters option
+      * formal_parameters
+      * type_annotation option
+    )
+  | `Index_sign of index_signature
+  | `Meth_sign of method_signature
+]
+
+and implements_clause = (
+    Token.t (* "implements" *)
+  * type_
+  * (Token.t (* "," *) * type_) list (* zero or more *)
+)
+
+and anon_choice_exp = [
+    `Exp of expression
+  | `Seq_exp of sequence_expression
+]
+
+and switch_default = (
+    Token.t (* "default" *)
+  * Token.t (* ":" *)
+  * anon_choice_expo_stmt_ list (* zero or more *)
+)
+
+and binary_expression = [
+    `Bin_exp_exp_AMPAMP_exp of (expression * Token.t (* "&&" *) * expression)
+  | `Bin_exp_exp_BARBAR_exp of (expression * Token.t (* "||" *) * expression)
+  | `Bin_exp_exp_GTGT_exp of (expression * Token.t (* ">>" *) * expression)
+  | `Bin_exp_exp_GTGTGT_exp of (
+        expression * Token.t (* ">>>" *) * expression
+    )
+  | `Bin_exp_exp_LTLT_exp of (expression * Token.t (* "<<" *) * expression)
+  | `Bin_exp_exp_AMP_exp of (expression * Token.t (* "&" *) * expression)
+  | `Bin_exp_exp_HAT_exp of (expression * Token.t (* "^" *) * expression)
+  | `Bin_exp_exp_BAR_exp of (expression * Token.t (* "|" *) * expression)
+  | `Bin_exp_exp_PLUS_exp of (expression * Token.t (* "+" *) * expression)
+  | `Bin_exp_exp_DASH_exp of (expression * Token.t (* "-" *) * expression)
+  | `Bin_exp_exp_STAR_exp of (expression * Token.t (* "*" *) * expression)
+  | `Bin_exp_exp_SLASH_exp of (expression * Token.t (* "/" *) * expression)
+  | `Bin_exp_exp_PERC_exp of (expression * Token.t (* "%" *) * expression)
+  | `Bin_exp_exp_STARSTAR_exp of (
+        expression * Token.t (* "**" *) * expression
+    )
+  | `Bin_exp_exp_LT_exp of (expression * Token.t (* "<" *) * expression)
+  | `Bin_exp_exp_LTEQ_exp of (expression * Token.t (* "<=" *) * expression)
+  | `Bin_exp_exp_EQEQ_exp of (expression * Token.t (* "==" *) * expression)
+  | `Bin_exp_exp_EQEQEQ_exp of (
+        expression * Token.t (* "===" *) * expression
+    )
+  | `Bin_exp_exp_BANGEQ_exp of (expression * Token.t (* "!=" *) * expression)
+  | `Bin_exp_exp_BANGEQEQ_exp of (
+        expression * Token.t (* "!==" *) * expression
+    )
+  | `Bin_exp_exp_GTEQ_exp of (expression * Token.t (* ">=" *) * expression)
+  | `Bin_exp_exp_GT_exp of (expression * Token.t (* ">" *) * expression)
+  | `Bin_exp_exp_QMARKQMARK_exp of (
+        expression * Token.t (* "??" *) * expression
+    )
+  | `Bin_exp_exp_inst_exp of (
+        expression * Token.t (* "instanceof" *) * expression
+    )
+  | `Bin_exp_exp_in_exp of (expression * Token.t (* "in" *) * expression)
+]
+
+and arguments = (
+    Token.t (* "(" *) * anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp
+  * Token.t (* ")" *)
+)
+
+and generator_function_declaration = (
+    Token.t (* "async" *) option
+  * Token.t (* "function" *)
+  * Token.t (* "*" *)
+  * identifier (*tok*)
+  * call_signature_
+  * statement_block
+  * automatic_semicolon (*tok*) option
+)
+
 and variable_declarator = (
-    [
-        `Id of identifier (*tok*)
-      | `Choice_obj of [ `Obj of object_ | `Array of array_ ]
-    ]
+    anon_choice_id3
   * type_annotation option
   * initializer_ option
 )
-and statement_block = (
+
+and sequence_expression = (
+    expression
+  * Token.t (* "," *)
+  * [ `Seq_exp of sequence_expression | `Exp of expression ]
+)
+
+and type_arguments = (
+    Token.t (* "<" *)
+  * type_
+  * (Token.t (* "," *) * type_) list (* zero or more *)
+  * Token.t (* "," *) option
+  * Token.t (* ">" *)
+)
+
+and class_body = (
     Token.t (* "{" *)
   * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
+        `Deco of decorator
+      | `Meth_defi_opt_choice_auto_semi of (
+            method_definition
+          * anon_choice_auto_semi option
+        )
+      | `Choice_abst_meth_sign_choice_choice_auto_semi of (
+            [
+                `Abst_meth_sign of abstract_method_signature
+              | `Index_sign of index_signature
+              | `Meth_sign of method_signature
+              | `Publ_field_defi of public_field_definition
+            ]
+          * [
+                `Choice_auto_semi of anon_choice_auto_semi
+              | `COMMA of Token.t (* "," *)
+            ]
+        )
     ]
       list (* zero or more *)
   * Token.t (* "}" *)
-  * automatic_semicolon (*tok*) option
 )
-and if_statement = (
-    Token.t (* "if" *)
-  * parenthesized_expression
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
-  * (
-        Token.t (* "else" *)
+
+and type_parameter = (
+    identifier (*tok*)
+  * constraint_ option
+  * default_type option
+)
+
+and anon_choice_obj = [ `Obj of object_ | `Array of array_ ]
+
+and anon_choice_this = [
+    `This of Token.t (* "this" *)
+  | `Id of identifier (*tok*)
+  | `Choice_decl of anon_choice_decl
+  | `Num of number (*tok*)
+  | `Str of string_
+  | `Temp_str of template_string
+  | `Regex of (
+        Token.t (* "/" *)
+      * regex_pattern (*tok*)
+      * Token.t (* "/" *)
+      * regex_flags (*tok*) option
+    )
+  | `True of Token.t (* "true" *)
+  | `False of Token.t (* "false" *)
+  | `Null of Token.t (* "null" *)
+  | `Unde of Token.t (* "undefined" *)
+  | `Impo of import (*tok*)
+  | `Obj of object_
+  | `Array of array_
+  | `Func of function_
+  | `Arrow_func of (
+        Token.t (* "async" *) option
       * [
-            `Expo_stmt of export_statement
-          | `Impo_stmt of import_statement
-          | `Debu_stmt of debugger_statement
-          | `Exp_stmt of expression_statement
-          | `Decl of declaration
-          | `Stmt_blk of statement_block
-          | `If_stmt of if_statement
-          | `Swit_stmt of switch_statement
-          | `For_stmt of for_statement
-          | `For_in_stmt of for_in_statement
-          | `While_stmt of while_statement
-          | `Do_stmt of do_statement
-          | `Try_stmt of try_statement
-          | `With_stmt of with_statement
-          | `Brk_stmt of break_statement
-          | `Cont_stmt of continue_statement
-          | `Ret_stmt of return_statement
-          | `Throw_stmt of throw_statement
-          | `Empty_stmt of Token.t (* ";" *)
-          | `Labe_stmt of labeled_statement
+            `Choice_choice_decl of anon_choice_choice_decl
+          | `Call_sign of call_signature_
         ]
+      * Token.t (* "=>" *)
+      * [ `Exp of expression | `Stmt_blk of statement_block ]
+    )
+  | `Gene_func of (
+        Token.t (* "async" *) option
+      * Token.t (* "function" *)
+      * Token.t (* "*" *)
+      * identifier (*tok*) option
+      * call_signature_
+      * statement_block
+    )
+  | `Class of (
+        decorator list (* zero or more *)
+      * Token.t (* "class" *)
+      * identifier (*tok*) option
+      * type_parameters option
+      * class_heritage option
+      * class_body
+    )
+  | `Paren_exp of parenthesized_expression
+  | `Subs_exp of subscript_expression
+  | `Memb_exp of member_expression
+  | `Meta_prop of (
+        Token.t (* "new" *) * Token.t (* "." *) * Token.t (* "target" *)
+    )
+  | `New_exp of (Token.t (* "new" *) * anon_choice_this * arguments option)
+]
+
+and anon_choice_memb_exp = [
+    `Memb_exp of member_expression
+  | `Subs_exp of subscript_expression
+  | `Id of identifier (*tok*)
+  | `Choice_decl of anon_choice_decl
+  | `Choice_obj of anon_choice_obj
+]
+
+and member_expression = (
+    [
+        `Exp of expression
+      | `Id of identifier (*tok*)
+      | `Super of Token.t (* "super" *)
+      | `Choice_decl of anon_choice_decl
+    ]
+  * Token.t (* "." *)
+  * identifier (*tok*)
+)
+
+and anon_choice_pair = [
+    `Pair of (property_name * Token.t (* ":" *) * expression)
+  | `Spre_elem of spread_element
+  | `Meth_defi of method_definition
+  | `Assign_pat of (
+        [
+            `Choice_choice_decl of anon_choice_choice_decl
+          | `Choice_obj of anon_choice_obj
+        ]
+      * Token.t (* "=" *)
+      * expression
+    )
+  | `Choice_id of anon_choice_id4
+]
+
+and subscript_expression = (
+    [ `Exp of expression | `Super of Token.t (* "super" *) ]
+  * Token.t (* "[" *)
+  * anon_choice_exp
+  * Token.t (* "]" *)
+)
+
+and anon_choice_expo_stmt_ = [
+    `Expo_stmt of export_statement
+  | `Impo_stmt of (
+        Token.t (* "import" *)
+      * anon_choice_type option
+      * [
+            `Impo_clau_from_clau of (import_clause * from_clause)
+          | `Impo_requ_clau of import_require_clause
+          | `Str of string_
+        ]
+      * anon_choice_auto_semi
+    )
+  | `Debu_stmt of (Token.t (* "debugger" *) * anon_choice_auto_semi)
+  | `Exp_stmt of expression_statement
+  | `Decl of declaration
+  | `Stmt_blk of statement_block
+  | `If_stmt of (
+        Token.t (* "if" *)
+      * parenthesized_expression
+      * anon_choice_expo_stmt_
+      * (Token.t (* "else" *) * anon_choice_expo_stmt_) option
+    )
+  | `Swit_stmt of (
+        Token.t (* "switch" *) * parenthesized_expression * switch_body
+    )
+  | `For_stmt of (
+        Token.t (* "for" *)
+      * Token.t (* "(" *)
+      * [
+            `Lexi_decl of lexical_declaration
+          | `Var_decl of variable_declaration
+          | `Exp_stmt of expression_statement
+          | `Empty_stmt of Token.t (* ";" *)
+        ]
+      * [
+            `Exp_stmt of expression_statement
+          | `Empty_stmt of Token.t (* ";" *)
+        ]
+      * anon_choice_exp option
+      * Token.t (* ")" *)
+      * anon_choice_expo_stmt_
+    )
+  | `For_in_stmt of (
+        Token.t (* "for" *)
+      * Token.t (* "await" *) option
+      * for_header
+      * anon_choice_expo_stmt_
+    )
+  | `While_stmt of (
+        Token.t (* "while" *) * parenthesized_expression
+      * anon_choice_expo_stmt_
+    )
+  | `Do_stmt of (
+        Token.t (* "do" *) * anon_choice_expo_stmt_ * Token.t (* "while" *)
+      * parenthesized_expression * anon_choice_auto_semi
+    )
+  | `Try_stmt of (
+        Token.t (* "try" *)
+      * statement_block
+      * catch_clause option
+      * finally_clause option
+    )
+  | `With_stmt of (
+        Token.t (* "with" *) * parenthesized_expression
+      * anon_choice_expo_stmt_
+    )
+  | `Brk_stmt of (
+        Token.t (* "break" *)
+      * identifier (*tok*) option
+      * anon_choice_auto_semi
+    )
+  | `Cont_stmt of (
+        Token.t (* "continue" *)
+      * identifier (*tok*) option
+      * anon_choice_auto_semi
+    )
+  | `Ret_stmt of (
+        Token.t (* "return" *)
+      * anon_choice_exp option
+      * anon_choice_auto_semi
+    )
+  | `Throw_stmt of (
+        Token.t (* "throw" *) * anon_choice_exp * anon_choice_auto_semi
+    )
+  | `Empty_stmt of Token.t (* ";" *)
+  | `Labe_stmt of (
+        anon_choice_id4 * Token.t (* ":" *) * anon_choice_expo_stmt_
+    )
+]
+
+and initializer_ = (Token.t (* "=" *) * expression)
+
+and anon_choice_prop_name = [
+    `Prop_name of property_name
+  | `Enum_assign of (property_name * initializer_)
+]
+
+and module__ = (
+    [
+        `Str of string_
+      | `Id of identifier (*tok*)
+      | `Nest_id of nested_identifier
+    ]
+  * statement_block option
+)
+
+and expression_statement = (anon_choice_exp * anon_choice_auto_semi)
+
+and catch_clause = (
+    Token.t (* "catch" *)
+  * (Token.t (* "(" *) * anon_choice_id3 * Token.t (* ")" *)) option
+  * statement_block
+)
+
+and object_type = (
+    [ `LCURL of Token.t (* "{" *) | `LCURLBAR of Token.t (* "{|" *) ]
+  * (
+        [ `COMMA of Token.t (* "," *) | `SEMI of Token.t (* ";" *) ] option
+      * anon_choice_expo_stmt
+      * (anon_choice_COMMA * anon_choice_expo_stmt) list (* zero or more *)
+      * anon_choice_COMMA option
     )
       option
+  * [ `RCURL of Token.t (* "}" *) | `BARRCURL of Token.t (* "|}" *) ]
 )
-and switch_statement = (
-    Token.t (* "switch" *) * parenthesized_expression * switch_body
-)
-and for_statement = (
-    Token.t (* "for" *)
-  * Token.t (* "(" *)
+
+and template_string = (
+    Token.t (* "`" *)
   * [
-        `Lexi_decl of lexical_declaration
-      | `Var_decl of variable_declaration
-      | `Exp_stmt of expression_statement
-      | `Empty_stmt of Token.t (* ";" *)
+        `Temp_chars of template_chars (*tok*)
+      | `Esc_seq of escape_sequence (*tok*)
+      | `Temp_subs of template_substitution
     ]
-  * [ `Exp_stmt of expression_statement | `Empty_stmt of Token.t (* ";" *) ]
-  * [ `Exp of expression | `Seq_exp of sequence_expression ] option
-  * Token.t (* ")" *)
+      list (* zero or more *)
+  * Token.t (* "`" *)
+)
+
+and decorator = (
+    Token.t (* "@" *)
   * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
+        `Choice_id of anon_choice_id4
+      | `Deco_memb_exp of decorator_member_expression
+      | `Deco_call_exp of decorator_call_expression
     ]
 )
-and for_in_statement = (
-    Token.t (* "for" *)
-  * Token.t (* "await" *) option
-  * for_header
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
-)
+
+and internal_module = (Token.t (* "namespace" *) * module__)
+
+and anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp =
+  (anon_choice_exp_ option * anon_rep_COMMA_opt_choice_exp) option
+
 and for_header = (
     Token.t (* "(" *)
   * [
@@ -611,281 +712,12 @@ and for_header = (
       | `Const of Token.t (* "const" *)
     ]
       option
-  * [
-        `Paren_exp of parenthesized_expression
-      | `Choice_memb_exp of [
-            `Memb_exp of member_expression
-          | `Subs_exp of subscript_expression
-          | `Id of identifier (*tok*)
-          | `Choice_decl of [
-                `Decl of Token.t (* "declare" *)
-              | `Name of Token.t (* "namespace" *)
-              | `Type of Token.t (* "type" *)
-              | `Publ of Token.t (* "public" *)
-              | `Priv of Token.t (* "private" *)
-              | `Prot of Token.t (* "protected" *)
-              | `Read of Token.t (* "readonly" *)
-              | `Modu of Token.t (* "module" *)
-              | `Any of Token.t (* "any" *)
-              | `Num of Token.t (* "number" *)
-              | `Bool of Token.t (* "boolean" *)
-              | `Str of Token.t (* "string" *)
-              | `Symb of Token.t (* "symbol" *)
-              | `Void of Token.t (* "void" *)
-              | `Expo of Token.t (* "export" *)
-              | `Choice_get of [
-                    `Get of Token.t (* "get" *)
-                  | `Set of Token.t (* "set" *)
-                  | `Async of Token.t (* "async" *)
-                  | `Stat of Token.t (* "static" *)
-                ]
-            ]
-          | `Choice_obj of [ `Obj of object_ | `Array of array_ ]
-        ]
-    ]
+  * anon_choice_paren_exp
   * [ `In of Token.t (* "in" *) | `Of of Token.t (* "of" *) ]
-  * [ `Exp of expression | `Seq_exp of sequence_expression ]
+  * anon_choice_exp
   * Token.t (* ")" *)
 )
-and while_statement = (
-    Token.t (* "while" *)
-  * parenthesized_expression
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
-)
-and do_statement = (
-    Token.t (* "do" *)
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
-  * Token.t (* "while" *)
-  * parenthesized_expression
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
-)
-and try_statement = (
-    Token.t (* "try" *)
-  * statement_block
-  * catch_clause option
-  * finally_clause option
-)
-and with_statement = (
-    Token.t (* "with" *)
-  * parenthesized_expression
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
-)
-and return_statement = (
-    Token.t (* "return" *)
-  * [ `Exp of expression | `Seq_exp of sequence_expression ] option
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
-)
-and throw_statement = (
-    Token.t (* "throw" *)
-  * [ `Exp of expression | `Seq_exp of sequence_expression ]
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
-)
-and labeled_statement = (
-    [
-        `Id of identifier (*tok*)
-      | `Choice_decl of [
-            `Decl of Token.t (* "declare" *)
-          | `Name of Token.t (* "namespace" *)
-          | `Type of Token.t (* "type" *)
-          | `Publ of Token.t (* "public" *)
-          | `Priv of Token.t (* "private" *)
-          | `Prot of Token.t (* "protected" *)
-          | `Read of Token.t (* "readonly" *)
-          | `Modu of Token.t (* "module" *)
-          | `Any of Token.t (* "any" *)
-          | `Num of Token.t (* "number" *)
-          | `Bool of Token.t (* "boolean" *)
-          | `Str of Token.t (* "string" *)
-          | `Symb of Token.t (* "symbol" *)
-          | `Void of Token.t (* "void" *)
-          | `Expo of Token.t (* "export" *)
-          | `Choice_get of [
-                `Get of Token.t (* "get" *)
-              | `Set of Token.t (* "set" *)
-              | `Async of Token.t (* "async" *)
-              | `Stat of Token.t (* "static" *)
-            ]
-        ]
-    ]
-  * Token.t (* ":" *)
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
-)
-and switch_body = (
-    Token.t (* "{" *)
-  * [ `Swit_case of switch_case | `Swit_defa of switch_default ]
-      list (* zero or more *)
-  * Token.t (* "}" *)
-)
-and switch_case = (
-    Token.t (* "case" *)
-  * [ `Exp of expression | `Seq_exp of sequence_expression ]
-  * Token.t (* ":" *)
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
-      list (* zero or more *)
-)
-and switch_default = (
-    Token.t (* "default" *)
-  * Token.t (* ":" *)
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
-      list (* zero or more *)
-)
-and catch_clause = (
-    Token.t (* "catch" *)
-  * (
-        Token.t (* "(" *)
-      * [
-            `Id of identifier (*tok*)
-          | `Choice_obj of [ `Obj of object_ | `Array of array_ ]
-        ]
-      * Token.t (* ")" *)
-    )
-      option
-  * statement_block
-)
-and finally_clause = (Token.t (* "finally" *) * statement_block)
-and parenthesized_expression = (
-    Token.t (* "(" *)
-  * [
-        `Exp_opt_type_anno of (expression * type_annotation option)
-      | `Seq_exp of sequence_expression
-    ]
-  * Token.t (* ")" *)
-)
+
 and expression = [
     `Exp_as_exp of (
         expression
@@ -896,116 +728,15 @@ and expression = [
   | `Exp_inte_modu of internal_module
   | `Exp_super of Token.t (* "super" *)
   | `Exp_type_asse of (type_arguments * expression)
-  | `Exp_choice_this of [
-        `This of Token.t (* "this" *)
-      | `Id of identifier (*tok*)
-      | `Choice_decl of [
-            `Decl of Token.t (* "declare" *)
-          | `Name of Token.t (* "namespace" *)
-          | `Type of Token.t (* "type" *)
-          | `Publ of Token.t (* "public" *)
-          | `Priv of Token.t (* "private" *)
-          | `Prot of Token.t (* "protected" *)
-          | `Read of Token.t (* "readonly" *)
-          | `Modu of Token.t (* "module" *)
-          | `Any of Token.t (* "any" *)
-          | `Num of Token.t (* "number" *)
-          | `Bool of Token.t (* "boolean" *)
-          | `Str of Token.t (* "string" *)
-          | `Symb of Token.t (* "symbol" *)
-          | `Void of Token.t (* "void" *)
-          | `Expo of Token.t (* "export" *)
-          | `Choice_get of [
-                `Get of Token.t (* "get" *)
-              | `Set of Token.t (* "set" *)
-              | `Async of Token.t (* "async" *)
-              | `Stat of Token.t (* "static" *)
-            ]
-        ]
-      | `Num of number (*tok*)
-      | `Str of string_
-      | `Temp_str of template_string
-      | `Regex of regex
-      | `True of Token.t (* "true" *)
-      | `False of Token.t (* "false" *)
-      | `Null of Token.t (* "null" *)
-      | `Unde of Token.t (* "undefined" *)
-      | `Impo of import (*tok*)
-      | `Obj of object_
-      | `Array of array_
-      | `Func of function_
-      | `Arrow_func of arrow_function
-      | `Gene_func of generator_function
-      | `Class of class_
-      | `Paren_exp of parenthesized_expression
-      | `Subs_exp of subscript_expression
-      | `Memb_exp of member_expression
-      | `Meta_prop of meta_property
-      | `New_exp of new_expression
-    ]
+  | `Exp_choice_this of anon_choice_this
   | `Exp_assign_exp of (
-        [
-            `Paren_exp of parenthesized_expression
-          | `Choice_memb_exp of [
-                `Memb_exp of member_expression
-              | `Subs_exp of subscript_expression
-              | `Id of identifier (*tok*)
-              | `Choice_decl of [
-                    `Decl of Token.t (* "declare" *)
-                  | `Name of Token.t (* "namespace" *)
-                  | `Type of Token.t (* "type" *)
-                  | `Publ of Token.t (* "public" *)
-                  | `Priv of Token.t (* "private" *)
-                  | `Prot of Token.t (* "protected" *)
-                  | `Read of Token.t (* "readonly" *)
-                  | `Modu of Token.t (* "module" *)
-                  | `Any of Token.t (* "any" *)
-                  | `Num of Token.t (* "number" *)
-                  | `Bool of Token.t (* "boolean" *)
-                  | `Str of Token.t (* "string" *)
-                  | `Symb of Token.t (* "symbol" *)
-                  | `Void of Token.t (* "void" *)
-                  | `Expo of Token.t (* "export" *)
-                  | `Choice_get of [
-                        `Get of Token.t (* "get" *)
-                      | `Set of Token.t (* "set" *)
-                      | `Async of Token.t (* "async" *)
-                      | `Stat of Token.t (* "static" *)
-                    ]
-                ]
-              | `Choice_obj of [ `Obj of object_ | `Array of array_ ]
-            ]
-        ]
-      * Token.t (* "=" *)
-      * expression
+        anon_choice_paren_exp * Token.t (* "=" *) * expression
     )
   | `Exp_augm_assign_exp of (
         [
             `Memb_exp of member_expression
           | `Subs_exp of subscript_expression
-          | `Choice_decl of [
-                `Decl of Token.t (* "declare" *)
-              | `Name of Token.t (* "namespace" *)
-              | `Type of Token.t (* "type" *)
-              | `Publ of Token.t (* "public" *)
-              | `Priv of Token.t (* "private" *)
-              | `Prot of Token.t (* "protected" *)
-              | `Read of Token.t (* "readonly" *)
-              | `Modu of Token.t (* "module" *)
-              | `Any of Token.t (* "any" *)
-              | `Num of Token.t (* "number" *)
-              | `Bool of Token.t (* "boolean" *)
-              | `Str of Token.t (* "string" *)
-              | `Symb of Token.t (* "symbol" *)
-              | `Void of Token.t (* "void" *)
-              | `Expo of Token.t (* "export" *)
-              | `Choice_get of [
-                    `Get of Token.t (* "get" *)
-                  | `Set of Token.t (* "set" *)
-                  | `Async of Token.t (* "async" *)
-                  | `Stat of Token.t (* "static" *)
-                ]
-            ]
+          | `Choice_decl of anon_choice_decl
           | `Id of identifier (*tok*)
           | `Paren_exp of parenthesized_expression
         ]
@@ -1050,354 +781,52 @@ and expression = [
         ]
     )
 ]
-and object_ = (
-    Token.t (* "{" *)
-  * (
-        [
-            `Pair of pair
-          | `Spre_elem of spread_element
-          | `Meth_defi of method_definition
-          | `Assign_pat of assignment_pattern
-          | `Choice_id of [
-                `Id of identifier (*tok*)
-              | `Choice_decl of [
-                    `Decl of Token.t (* "declare" *)
-                  | `Name of Token.t (* "namespace" *)
-                  | `Type of Token.t (* "type" *)
-                  | `Publ of Token.t (* "public" *)
-                  | `Priv of Token.t (* "private" *)
-                  | `Prot of Token.t (* "protected" *)
-                  | `Read of Token.t (* "readonly" *)
-                  | `Modu of Token.t (* "module" *)
-                  | `Any of Token.t (* "any" *)
-                  | `Num of Token.t (* "number" *)
-                  | `Bool of Token.t (* "boolean" *)
-                  | `Str of Token.t (* "string" *)
-                  | `Symb of Token.t (* "symbol" *)
-                  | `Void of Token.t (* "void" *)
-                  | `Expo of Token.t (* "export" *)
-                  | `Choice_get of [
-                        `Get of Token.t (* "get" *)
-                      | `Set of Token.t (* "set" *)
-                      | `Async of Token.t (* "async" *)
-                      | `Stat of Token.t (* "static" *)
-                    ]
-                ]
-            ]
-        ]
-          option
-      * (
-            Token.t (* "," *)
-          * [
-                `Pair of pair
-              | `Spre_elem of spread_element
-              | `Meth_defi of method_definition
-              | `Assign_pat of assignment_pattern
-              | `Choice_id of [
-                    `Id of identifier (*tok*)
-                  | `Choice_decl of [
-                        `Decl of Token.t (* "declare" *)
-                      | `Name of Token.t (* "namespace" *)
-                      | `Type of Token.t (* "type" *)
-                      | `Publ of Token.t (* "public" *)
-                      | `Priv of Token.t (* "private" *)
-                      | `Prot of Token.t (* "protected" *)
-                      | `Read of Token.t (* "readonly" *)
-                      | `Modu of Token.t (* "module" *)
-                      | `Any of Token.t (* "any" *)
-                      | `Num of Token.t (* "number" *)
-                      | `Bool of Token.t (* "boolean" *)
-                      | `Str of Token.t (* "string" *)
-                      | `Symb of Token.t (* "symbol" *)
-                      | `Void of Token.t (* "void" *)
-                      | `Expo of Token.t (* "export" *)
-                      | `Choice_get of [
-                            `Get of Token.t (* "get" *)
-                          | `Set of Token.t (* "set" *)
-                          | `Async of Token.t (* "async" *)
-                          | `Stat of Token.t (* "static" *)
-                        ]
-                    ]
-                ]
-            ]
-              option
-        )
-          list (* zero or more *)
+
+and anon_choice_paren_exp = [
+    `Paren_exp of parenthesized_expression
+  | `Choice_memb_exp of anon_choice_memb_exp
+]
+
+and primary_type = [
+    `Prim_type_paren_type of (Token.t (* "(" *) * type_ * Token.t (* ")" *))
+  | `Prim_type_pred_type of predefined_type
+  | `Prim_type_id of identifier (*tok*)
+  | `Prim_type_nest_type_id of nested_type_identifier
+  | `Prim_type_gene_type of generic_type
+  | `Prim_type_type_pred of (identifier (*tok*) * Token.t (* "is" *) * type_)
+  | `Prim_type_obj_type of object_type
+  | `Prim_type_array_type of (
+        primary_type * Token.t (* "[" *) * Token.t (* "]" *)
     )
-      option
-  * Token.t (* "}" *)
-)
-and assignment_pattern = (
-    [
-        `Choice_choice_decl of [
-            `Choice_decl of [
-                `Decl of Token.t (* "declare" *)
-              | `Name of Token.t (* "namespace" *)
-              | `Type of Token.t (* "type" *)
-              | `Publ of Token.t (* "public" *)
-              | `Priv of Token.t (* "private" *)
-              | `Prot of Token.t (* "protected" *)
-              | `Read of Token.t (* "readonly" *)
-              | `Modu of Token.t (* "module" *)
-              | `Any of Token.t (* "any" *)
-              | `Num of Token.t (* "number" *)
-              | `Bool of Token.t (* "boolean" *)
-              | `Str of Token.t (* "string" *)
-              | `Symb of Token.t (* "symbol" *)
-              | `Void of Token.t (* "void" *)
-              | `Expo of Token.t (* "export" *)
-              | `Choice_get of [
-                    `Get of Token.t (* "get" *)
-                  | `Set of Token.t (* "set" *)
-                  | `Async of Token.t (* "async" *)
-                  | `Stat of Token.t (* "static" *)
-                ]
-            ]
-          | `Id of identifier (*tok*)
-        ]
-      | `Choice_obj of [ `Obj of object_ | `Array of array_ ]
-    ]
-  * Token.t (* "=" *)
-  * expression
-)
-and array_ = (
+  | `Prim_type_tuple_type of (
+        Token.t (* "[" *)
+      * type_
+      * (Token.t (* "," *) * type_) list (* zero or more *)
+      * Token.t (* "]" *)
+    )
+  | `Prim_type_flow_maybe_type of (Token.t (* "?" *) * primary_type)
+  | `Prim_type_type_query of (Token.t (* "typeof" *) * anon_choice_id_)
+  | `Prim_type_index_type_query of (Token.t (* "keyof" *) * anon_choice_id)
+  | `Prim_type_this of Token.t (* "this" *)
+  | `Prim_type_exis_type of Token.t (* "*" *)
+  | `Prim_type_lit_type of literal_type
+  | `Prim_type_look_type of (
+        primary_type * Token.t (* "[" *) * type_ * Token.t (* "]" *)
+    )
+]
+
+and index_signature = (
     Token.t (* "[" *)
-  * (
-        [ `Exp of expression | `Spre_elem of spread_element ] option
-      * (
-            Token.t (* "," *)
-          * [ `Exp of expression | `Spre_elem of spread_element ] option
+  * [
+        `Choice_id_COLON_pred_type of (
+            anon_choice_id4 * Token.t (* ":" *) * predefined_type
         )
-          list (* zero or more *)
-    )
-      option
+      | `Mapp_type_clau of mapped_type_clause
+    ]
   * Token.t (* "]" *)
+  * type_annotation
 )
-and class_ = (
-    decorator list (* zero or more *)
-  * Token.t (* "class" *)
-  * identifier (*tok*) option
-  * type_parameters option
-  * class_heritage option
-  * class_body
-)
-and class_declaration = (
-    decorator list (* zero or more *)
-  * Token.t (* "class" *)
-  * identifier (*tok*)
-  * type_parameters option
-  * class_heritage option
-  * class_body
-  * automatic_semicolon (*tok*) option
-)
-and class_heritage = [
-    `Class_heri_extens_clau_opt_imples_clau of (
-        extends_clause
-      * implements_clause option
-    )
-  | `Class_heri_imples_clau of implements_clause
-]
-and function_ = (
-    Token.t (* "async" *) option
-  * Token.t (* "function" *)
-  * identifier (*tok*) option
-  * call_signature
-  * statement_block
-)
-and function_declaration = (
-    Token.t (* "async" *) option
-  * Token.t (* "function" *)
-  * identifier (*tok*)
-  * call_signature
-  * statement_block
-  * automatic_semicolon (*tok*) option
-)
-and generator_function = (
-    Token.t (* "async" *) option
-  * Token.t (* "function" *)
-  * Token.t (* "*" *)
-  * identifier (*tok*) option
-  * call_signature
-  * statement_block
-)
-and generator_function_declaration = (
-    Token.t (* "async" *) option
-  * Token.t (* "function" *)
-  * Token.t (* "*" *)
-  * identifier (*tok*)
-  * call_signature
-  * statement_block
-  * automatic_semicolon (*tok*) option
-)
-and arrow_function = (
-    Token.t (* "async" *) option
-  * [
-        `Choice_choice_decl of [
-            `Choice_decl of [
-                `Decl of Token.t (* "declare" *)
-              | `Name of Token.t (* "namespace" *)
-              | `Type of Token.t (* "type" *)
-              | `Publ of Token.t (* "public" *)
-              | `Priv of Token.t (* "private" *)
-              | `Prot of Token.t (* "protected" *)
-              | `Read of Token.t (* "readonly" *)
-              | `Modu of Token.t (* "module" *)
-              | `Any of Token.t (* "any" *)
-              | `Num of Token.t (* "number" *)
-              | `Bool of Token.t (* "boolean" *)
-              | `Str of Token.t (* "string" *)
-              | `Symb of Token.t (* "symbol" *)
-              | `Void of Token.t (* "void" *)
-              | `Expo of Token.t (* "export" *)
-              | `Choice_get of [
-                    `Get of Token.t (* "get" *)
-                  | `Set of Token.t (* "set" *)
-                  | `Async of Token.t (* "async" *)
-                  | `Stat of Token.t (* "static" *)
-                ]
-            ]
-          | `Id of identifier (*tok*)
-        ]
-      | `Call_sign of call_signature
-    ]
-  * Token.t (* "=>" *)
-  * [ `Exp of expression | `Stmt_blk of statement_block ]
-)
-and call_signature = (
-    type_parameters option
-  * formal_parameters
-  * type_annotation option
-)
-and new_expression = (
-    Token.t (* "new" *)
-  * [
-        `This of Token.t (* "this" *)
-      | `Id of identifier (*tok*)
-      | `Choice_decl of [
-            `Decl of Token.t (* "declare" *)
-          | `Name of Token.t (* "namespace" *)
-          | `Type of Token.t (* "type" *)
-          | `Publ of Token.t (* "public" *)
-          | `Priv of Token.t (* "private" *)
-          | `Prot of Token.t (* "protected" *)
-          | `Read of Token.t (* "readonly" *)
-          | `Modu of Token.t (* "module" *)
-          | `Any of Token.t (* "any" *)
-          | `Num of Token.t (* "number" *)
-          | `Bool of Token.t (* "boolean" *)
-          | `Str of Token.t (* "string" *)
-          | `Symb of Token.t (* "symbol" *)
-          | `Void of Token.t (* "void" *)
-          | `Expo of Token.t (* "export" *)
-          | `Choice_get of [
-                `Get of Token.t (* "get" *)
-              | `Set of Token.t (* "set" *)
-              | `Async of Token.t (* "async" *)
-              | `Stat of Token.t (* "static" *)
-            ]
-        ]
-      | `Num of number (*tok*)
-      | `Str of string_
-      | `Temp_str of template_string
-      | `Regex of regex
-      | `True of Token.t (* "true" *)
-      | `False of Token.t (* "false" *)
-      | `Null of Token.t (* "null" *)
-      | `Unde of Token.t (* "undefined" *)
-      | `Impo of import (*tok*)
-      | `Obj of object_
-      | `Array of array_
-      | `Func of function_
-      | `Arrow_func of arrow_function
-      | `Gene_func of generator_function
-      | `Class of class_
-      | `Paren_exp of parenthesized_expression
-      | `Subs_exp of subscript_expression
-      | `Memb_exp of member_expression
-      | `Meta_prop of meta_property
-      | `New_exp of new_expression
-    ]
-  * arguments option
-)
-and member_expression = (
-    [
-        `Exp of expression
-      | `Id of identifier (*tok*)
-      | `Super of Token.t (* "super" *)
-      | `Choice_decl of [
-            `Decl of Token.t (* "declare" *)
-          | `Name of Token.t (* "namespace" *)
-          | `Type of Token.t (* "type" *)
-          | `Publ of Token.t (* "public" *)
-          | `Priv of Token.t (* "private" *)
-          | `Prot of Token.t (* "protected" *)
-          | `Read of Token.t (* "readonly" *)
-          | `Modu of Token.t (* "module" *)
-          | `Any of Token.t (* "any" *)
-          | `Num of Token.t (* "number" *)
-          | `Bool of Token.t (* "boolean" *)
-          | `Str of Token.t (* "string" *)
-          | `Symb of Token.t (* "symbol" *)
-          | `Void of Token.t (* "void" *)
-          | `Expo of Token.t (* "export" *)
-          | `Choice_get of [
-                `Get of Token.t (* "get" *)
-              | `Set of Token.t (* "set" *)
-              | `Async of Token.t (* "async" *)
-              | `Stat of Token.t (* "static" *)
-            ]
-        ]
-    ]
-  * Token.t (* "." *)
-  * identifier (*tok*)
-)
-and subscript_expression = (
-    [ `Exp of expression | `Super of Token.t (* "super" *) ]
-  * Token.t (* "[" *)
-  * [ `Exp of expression | `Seq_exp of sequence_expression ]
-  * Token.t (* "]" *)
-)
-and initializer_ = (Token.t (* "=" *) * expression)
-and spread_element = (Token.t (* "..." *) * expression)
-and binary_expression = [
-    `Bin_exp_exp_AMPAMP_exp of (expression * Token.t (* "&&" *) * expression)
-  | `Bin_exp_exp_BARBAR_exp of (expression * Token.t (* "||" *) * expression)
-  | `Bin_exp_exp_GTGT_exp of (expression * Token.t (* ">>" *) * expression)
-  | `Bin_exp_exp_GTGTGT_exp of (
-        expression * Token.t (* ">>>" *) * expression
-    )
-  | `Bin_exp_exp_LTLT_exp of (expression * Token.t (* "<<" *) * expression)
-  | `Bin_exp_exp_AMP_exp of (expression * Token.t (* "&" *) * expression)
-  | `Bin_exp_exp_HAT_exp of (expression * Token.t (* "^" *) * expression)
-  | `Bin_exp_exp_BAR_exp of (expression * Token.t (* "|" *) * expression)
-  | `Bin_exp_exp_PLUS_exp of (expression * Token.t (* "+" *) * expression)
-  | `Bin_exp_exp_DASH_exp of (expression * Token.t (* "-" *) * expression)
-  | `Bin_exp_exp_STAR_exp of (expression * Token.t (* "*" *) * expression)
-  | `Bin_exp_exp_SLASH_exp of (expression * Token.t (* "/" *) * expression)
-  | `Bin_exp_exp_PERC_exp of (expression * Token.t (* "%" *) * expression)
-  | `Bin_exp_exp_STARSTAR_exp of (
-        expression * Token.t (* "**" *) * expression
-    )
-  | `Bin_exp_exp_LT_exp of (expression * Token.t (* "<" *) * expression)
-  | `Bin_exp_exp_LTEQ_exp of (expression * Token.t (* "<=" *) * expression)
-  | `Bin_exp_exp_EQEQ_exp of (expression * Token.t (* "==" *) * expression)
-  | `Bin_exp_exp_EQEQEQ_exp of (
-        expression * Token.t (* "===" *) * expression
-    )
-  | `Bin_exp_exp_BANGEQ_exp of (expression * Token.t (* "!=" *) * expression)
-  | `Bin_exp_exp_BANGEQEQ_exp of (
-        expression * Token.t (* "!==" *) * expression
-    )
-  | `Bin_exp_exp_GTEQ_exp of (expression * Token.t (* ">=" *) * expression)
-  | `Bin_exp_exp_GT_exp of (expression * Token.t (* ">" *) * expression)
-  | `Bin_exp_exp_QMARKQMARK_exp of (
-        expression * Token.t (* "??" *) * expression
-    )
-  | `Bin_exp_exp_inst_exp of (
-        expression * Token.t (* "instanceof" *) * expression
-    )
-  | `Bin_exp_exp_in_exp of (expression * Token.t (* "in" *) * expression)
-]
+
 and unary_expression = [
     `Un_exp_BANG_exp of (Token.t (* "!" *) * expression)
   | `Un_exp_TILDE_exp of (Token.t (* "~" *) * expression)
@@ -1407,145 +836,113 @@ and unary_expression = [
   | `Un_exp_void_exp of (Token.t (* "void" *) * expression)
   | `Un_exp_dele_exp of (Token.t (* "delete" *) * expression)
 ]
-and update_expression = [
-    `Exp_choice_PLUSPLUS of (
-        expression
-      * [ `PLUSPLUS of Token.t (* "++" *) | `DASHDASH of Token.t (* "--" *) ]
-    )
-  | `Choice_PLUSPLUS_exp of (
-        [ `PLUSPLUS of Token.t (* "++" *) | `DASHDASH of Token.t (* "--" *) ]
-      * expression
-    )
-]
-and sequence_expression = (
-    expression
-  * Token.t (* "," *)
-  * [ `Seq_exp of sequence_expression | `Exp of expression ]
-)
-and template_string = (
-    Token.t (* "`" *)
-  * [
-        `Temp_chars of template_chars (*tok*)
-      | `Esc_seq of escape_sequence (*tok*)
-      | `Temp_subs of template_substitution
-    ]
-      list (* zero or more *)
-  * Token.t (* "`" *)
-)
-and template_substitution = (
-    Token.t (* "${" *)
-  * [ `Exp of expression | `Seq_exp of sequence_expression ]
-  * Token.t (* "}" *)
-)
-and arguments = (
+
+and formal_parameters = (
     Token.t (* "(" *)
   * (
-        [ `Exp of expression | `Spre_elem of spread_element ] option
+        decorator list (* zero or more *)
+      * anon_choice_requ_param
       * (
             Token.t (* "," *)
-          * [ `Exp of expression | `Spre_elem of spread_element ] option
+          * decorator list (* zero or more *)
+          * anon_choice_requ_param
         )
           list (* zero or more *)
+      * Token.t (* "," *) option
     )
       option
   * Token.t (* ")" *)
 )
-and decorator = (
-    Token.t (* "@" *)
-  * [
-        `Choice_id of [
-            `Id of identifier (*tok*)
-          | `Choice_decl of [
-                `Decl of Token.t (* "declare" *)
-              | `Name of Token.t (* "namespace" *)
-              | `Type of Token.t (* "type" *)
-              | `Publ of Token.t (* "public" *)
-              | `Priv of Token.t (* "private" *)
-              | `Prot of Token.t (* "protected" *)
-              | `Read of Token.t (* "readonly" *)
-              | `Modu of Token.t (* "module" *)
-              | `Any of Token.t (* "any" *)
-              | `Num of Token.t (* "number" *)
-              | `Bool of Token.t (* "boolean" *)
-              | `Str of Token.t (* "string" *)
-              | `Symb of Token.t (* "symbol" *)
-              | `Void of Token.t (* "void" *)
-              | `Expo of Token.t (* "export" *)
-              | `Choice_get of [
-                    `Get of Token.t (* "get" *)
-                  | `Set of Token.t (* "set" *)
-                  | `Async of Token.t (* "async" *)
-                  | `Stat of Token.t (* "static" *)
-                ]
-            ]
-        ]
-      | `Deco_memb_exp of decorator_member_expression
-      | `Deco_call_exp of decorator_call_expression
-    ]
-)
-and decorator_call_expression = (
-    [
-        `Choice_id of [
-            `Id of identifier (*tok*)
-          | `Choice_decl of [
-                `Decl of Token.t (* "declare" *)
-              | `Name of Token.t (* "namespace" *)
-              | `Type of Token.t (* "type" *)
-              | `Publ of Token.t (* "public" *)
-              | `Priv of Token.t (* "private" *)
-              | `Prot of Token.t (* "protected" *)
-              | `Read of Token.t (* "readonly" *)
-              | `Modu of Token.t (* "module" *)
-              | `Any of Token.t (* "any" *)
-              | `Num of Token.t (* "number" *)
-              | `Bool of Token.t (* "boolean" *)
-              | `Str of Token.t (* "string" *)
-              | `Symb of Token.t (* "symbol" *)
-              | `Void of Token.t (* "void" *)
-              | `Expo of Token.t (* "export" *)
-              | `Choice_get of [
-                    `Get of Token.t (* "get" *)
-                  | `Set of Token.t (* "set" *)
-                  | `Async of Token.t (* "async" *)
-                  | `Stat of Token.t (* "static" *)
-                ]
-            ]
-        ]
-      | `Deco_memb_exp of decorator_member_expression
-    ]
-  * arguments
-)
-and class_body = (
+
+and default_type = (Token.t (* "=" *) * type_)
+
+and switch_body = (
     Token.t (* "{" *)
-  * [
-        `Deco of decorator
-      | `Meth_defi_opt_choice_auto_semi of (
-            method_definition
-          * [
-                `Auto_semi of automatic_semicolon (*tok*)
-              | `SEMI of Token.t (* ";" *)
-            ]
-              option
-        )
-      | `Choice_abst_meth_sign_choice_choice_auto_semi of (
-            [
-                `Abst_meth_sign of abstract_method_signature
-              | `Index_sign of index_signature
-              | `Meth_sign of method_signature
-              | `Publ_field_defi of public_field_definition
-            ]
-          * [
-                `Choice_auto_semi of [
-                    `Auto_semi of automatic_semicolon (*tok*)
-                  | `SEMI of Token.t (* ";" *)
-                ]
-              | `COMMA of Token.t (* "," *)
-            ]
-        )
-    ]
+  * [ `Swit_case of switch_case | `Swit_defa of switch_default ]
       list (* zero or more *)
   * Token.t (* "}" *)
 )
+
+and mapped_type_clause = (identifier (*tok*) * Token.t (* "in" *) * type_)
+
+and method_definition = (
+    accessibility_modifier option
+  * Token.t (* "static" *) option
+  * Token.t (* "readonly" *) option
+  * Token.t (* "async" *) option
+  * anon_choice_get option
+  * property_name
+  * Token.t (* "?" *) option
+  * call_signature_
+  * statement_block
+)
+
+and class_declaration = (
+    decorator list (* zero or more *)
+  * Token.t (* "class" *)
+  * identifier (*tok*)
+  * type_parameters option
+  * class_heritage option
+  * class_body
+  * automatic_semicolon (*tok*) option
+)
+
+and array_ = (
+    Token.t (* "[" *) * anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp
+  * Token.t (* "]" *)
+)
+
+and export_statement = [
+    `Choice_expo_choice_STAR_from_clau_choice_auto_semi of [
+        `Expo_choice_STAR_from_clau_choice_auto_semi of (
+            Token.t (* "export" *)
+          * [
+                `STAR_from_clau_choice_auto_semi of (
+                    Token.t (* "*" *) * from_clause * anon_choice_auto_semi
+                )
+              | `Expo_clau_from_clau_choice_auto_semi of (
+                    export_clause * from_clause * anon_choice_auto_semi
+                )
+              | `Expo_clau_choice_auto_semi of (
+                    export_clause * anon_choice_auto_semi
+                )
+            ]
+        )
+      | `Rep_deco_expo_choice_decl of (
+            decorator list (* zero or more *)
+          * Token.t (* "export" *)
+          * [
+                `Decl of declaration
+              | `Defa_exp_choice_auto_semi of (
+                    Token.t (* "default" *) * expression
+                  * anon_choice_auto_semi
+                )
+            ]
+        )
+    ]
+  | `Expo_EQ_id_choice_auto_semi of (
+        Token.t (* "export" *) * Token.t (* "=" *) * identifier (*tok*)
+      * anon_choice_auto_semi
+    )
+  | `Expo_as_name_id_choice_auto_semi of (
+        Token.t (* "export" *) * Token.t (* "as" *)
+      * Token.t (* "namespace" *) * identifier (*tok*)
+      * anon_choice_auto_semi
+    )
+]
+
+and type_annotation = (Token.t (* ":" *) * type_)
+
+and anon_rep_COMMA_opt_choice_exp =
+  (Token.t (* "," *) * anon_choice_exp_ option) list (* zero or more *)
+
+and decorator_call_expression = (anon_choice_choice_id_ * arguments)
+
+and update_expression = [
+    `Exp_choice_PLUSPLUS of (expression * anon_choice_PLUSPLUS)
+  | `Choice_PLUSPLUS_exp of (anon_choice_PLUSPLUS * expression)
+]
+
 and public_field_definition = (
     accessibility_modifier option
   * [
@@ -1567,209 +964,108 @@ and public_field_definition = (
   * type_annotation option
   * initializer_ option
 )
-and formal_parameters = (
-    Token.t (* "(" *)
+
+and lexical_declaration = (
+    [ `Let of Token.t (* "let" *) | `Const of Token.t (* "const" *) ]
+  * variable_declarator
+  * (Token.t (* "," *) * variable_declarator) list (* zero or more *)
+  * anon_choice_auto_semi
+)
+
+and extends_clause = (
+    Token.t (* "extends" *)
+  * anon_choice_choice_id
+  * (Token.t (* "," *) * anon_choice_choice_id) list (* zero or more *)
+)
+
+and anon_choice_requ_param = [
+    `Requ_param of (
+        parameter_name
+      * type_annotation option
+      * initializer_ option
+    )
+  | `Rest_param of (
+        Token.t (* "..." *)
+      * identifier (*tok*)
+      * type_annotation option
+    )
+  | `Opt_param of (
+        parameter_name
+      * Token.t (* "?" *)
+      * type_annotation option
+      * initializer_ option
+    )
+]
+
+and enum_body = (
+    Token.t (* "{" *)
   * (
-        decorator list (* zero or more *)
-      * [
-            `Requ_param of required_parameter
-          | `Rest_param of rest_parameter
-          | `Opt_param of optional_parameter
-        ]
-      * (
-            Token.t (* "," *)
-          * decorator list (* zero or more *)
-          * [
-                `Requ_param of required_parameter
-              | `Rest_param of rest_parameter
-              | `Opt_param of optional_parameter
-            ]
-        )
-          list (* zero or more *)
+        anon_choice_prop_name
+      * (Token.t (* "," *) * anon_choice_prop_name) list (* zero or more *)
       * Token.t (* "," *) option
     )
       option
-  * Token.t (* ")" *)
+  * Token.t (* "}" *)
 )
-and rest_parameter = (
-    Token.t (* "..." *)
-  * identifier (*tok*)
-  * type_annotation option
-)
-and method_definition = (
-    accessibility_modifier option
-  * Token.t (* "static" *) option
-  * Token.t (* "readonly" *) option
-  * Token.t (* "async" *) option
-  * [
-        `Get of Token.t (* "get" *)
-      | `Set of Token.t (* "set" *)
-      | `STAR of Token.t (* "*" *)
-    ]
-      option
-  * property_name
-  * Token.t (* "?" *) option
-  * call_signature
-  * statement_block
-)
-and pair = (property_name * Token.t (* ":" *) * expression)
+
+and class_heritage = [
+    `Class_heri_extens_clau_opt_imples_clau of (
+        extends_clause
+      * implements_clause option
+    )
+  | `Class_heri_imples_clau of implements_clause
+]
+
 and property_name = [
-    `Prop_name_choice_id of [
-        `Id of identifier (*tok*)
-      | `Choice_decl of [
-            `Decl of Token.t (* "declare" *)
-          | `Name of Token.t (* "namespace" *)
-          | `Type of Token.t (* "type" *)
-          | `Publ of Token.t (* "public" *)
-          | `Priv of Token.t (* "private" *)
-          | `Prot of Token.t (* "protected" *)
-          | `Read of Token.t (* "readonly" *)
-          | `Modu of Token.t (* "module" *)
-          | `Any of Token.t (* "any" *)
-          | `Num of Token.t (* "number" *)
-          | `Bool of Token.t (* "boolean" *)
-          | `Str of Token.t (* "string" *)
-          | `Symb of Token.t (* "symbol" *)
-          | `Void of Token.t (* "void" *)
-          | `Expo of Token.t (* "export" *)
-          | `Choice_get of [
-                `Get of Token.t (* "get" *)
-              | `Set of Token.t (* "set" *)
-              | `Async of Token.t (* "async" *)
-              | `Stat of Token.t (* "static" *)
-            ]
-        ]
-    ]
+    `Prop_name_choice_id of anon_choice_id4
   | `Prop_name_str of string_
   | `Prop_name_num of number (*tok*)
   | `Prop_name_comp_prop_name of (
         Token.t (* "[" *) * expression * Token.t (* "]" *)
     )
 ]
-and method_signature = (
-    accessibility_modifier option
-  * Token.t (* "static" *) option
-  * Token.t (* "readonly" *) option
-  * Token.t (* "async" *) option
-  * [
-        `Get of Token.t (* "get" *)
-      | `Set of Token.t (* "set" *)
-      | `STAR of Token.t (* "*" *)
-    ]
-      option
-  * property_name
-  * Token.t (* "?" *) option
-  * call_signature
+
+and switch_case = (
+    Token.t (* "case" *)
+  * anon_choice_exp
+  * Token.t (* ":" *)
+  * anon_choice_expo_stmt_ list (* zero or more *)
 )
+
+and spread_element = (Token.t (* "..." *) * expression)
+
 and abstract_method_signature = (
     accessibility_modifier option
   * Token.t (* "abstract" *)
-  * [
-        `Get of Token.t (* "get" *)
-      | `Set of Token.t (* "set" *)
-      | `STAR of Token.t (* "*" *)
-    ]
-      option
+  * anon_choice_get option
   * property_name
   * Token.t (* "?" *) option
-  * call_signature
+  * call_signature_
 )
-and implements_clause = (
-    Token.t (* "implements" *)
-  * type_
-  * (Token.t (* "," *) * type_) list (* zero or more *)
+
+and finally_clause = (Token.t (* "finally" *) * statement_block)
+
+and call_signature = (
+    type_parameters option
+  * formal_parameters
+  * type_annotation option
 )
-and internal_module = (Token.t (* "namespace" *) * module__)
-and module__ = (
-    [
-        `Str of string_
-      | `Id of identifier (*tok*)
-      | `Nest_id of nested_identifier
-    ]
-  * statement_block option
-)
-and extends_clause = (
-    Token.t (* "extends" *)
-  * [
-        `Choice_id of [
-            `Id of identifier (*tok*)
-          | `Nest_type_id of nested_type_identifier
-          | `Gene_type of generic_type
-        ]
-      | `Exp of expression
-    ]
-  * (
-        Token.t (* "," *)
-      * [
-            `Choice_id of [
-                `Id of identifier (*tok*)
-              | `Nest_type_id of nested_type_identifier
-              | `Gene_type of generic_type
-            ]
-          | `Exp of expression
-        ]
-    )
-      list (* zero or more *)
-)
-and enum_body = (
+
+and object_ = (
     Token.t (* "{" *)
   * (
-        [ `Prop_name of property_name | `Enum_assign of enum_assignment ]
-      * (
-            Token.t (* "," *)
-          * [ `Prop_name of property_name | `Enum_assign of enum_assignment ]
-        )
-          list (* zero or more *)
-      * Token.t (* "," *) option
+        anon_choice_pair option
+      * (Token.t (* "," *) * anon_choice_pair option) list (* zero or more *)
     )
       option
   * Token.t (* "}" *)
 )
-and enum_assignment = (property_name * initializer_)
-and required_parameter = (
-    parameter_name
-  * type_annotation option
-  * initializer_ option
-)
-and optional_parameter = (
-    parameter_name
-  * Token.t (* "?" *)
-  * type_annotation option
-  * initializer_ option
-)
-and parameter_name = (
-    accessibility_modifier option
-  * Token.t (* "readonly" *) option
-  * [
-        `Id of identifier (*tok*)
-      | `Choice_decl of [
-            `Decl of Token.t (* "declare" *)
-          | `Name of Token.t (* "namespace" *)
-          | `Type of Token.t (* "type" *)
-          | `Publ of Token.t (* "public" *)
-          | `Priv of Token.t (* "private" *)
-          | `Prot of Token.t (* "protected" *)
-          | `Read of Token.t (* "readonly" *)
-          | `Modu of Token.t (* "module" *)
-          | `Any of Token.t (* "any" *)
-          | `Num of Token.t (* "number" *)
-          | `Bool of Token.t (* "boolean" *)
-          | `Str of Token.t (* "string" *)
-          | `Symb of Token.t (* "symbol" *)
-          | `Void of Token.t (* "void" *)
-          | `Expo of Token.t (* "export" *)
-          | `Choice_get of [
-                `Get of Token.t (* "get" *)
-              | `Set of Token.t (* "set" *)
-              | `Async of Token.t (* "async" *)
-              | `Stat of Token.t (* "static" *)
-            ]
-        ]
-      | `Choice_obj of [ `Obj of object_ | `Array of array_ ]
-      | `This of Token.t (* "this" *)
-    ]
-)
-and type_annotation = (Token.t (* ":" *) * type_)
+
+and anon_choice_id3 = [
+    `Id of identifier (*tok*)
+  | `Choice_obj of anon_choice_obj
+]
+
 and type_ = [
     `Type_prim_type of primary_type
   | `Type_union_type of (type_ option * Token.t (* "|" *) * type_)
@@ -1788,105 +1084,7 @@ and type_ = [
       * type_
     )
 ]
-and primary_type = [
-    `Prim_type_paren_type of (Token.t (* "(" *) * type_ * Token.t (* ")" *))
-  | `Prim_type_pred_type of predefined_type
-  | `Prim_type_id of identifier (*tok*)
-  | `Prim_type_nest_type_id of nested_type_identifier
-  | `Prim_type_gene_type of generic_type
-  | `Prim_type_type_pred of (identifier (*tok*) * Token.t (* "is" *) * type_)
-  | `Prim_type_obj_type of object_type
-  | `Prim_type_array_type of (
-        primary_type * Token.t (* "[" *) * Token.t (* "]" *)
-    )
-  | `Prim_type_tuple_type of (
-        Token.t (* "[" *)
-      * type_
-      * (Token.t (* "," *) * type_) list (* zero or more *)
-      * Token.t (* "]" *)
-    )
-  | `Prim_type_flow_maybe_type of (Token.t (* "?" *) * primary_type)
-  | `Prim_type_type_query of (
-        Token.t (* "typeof" *)
-      * [ `Id of identifier (*tok*) | `Nest_id of nested_identifier ]
-    )
-  | `Prim_type_index_type_query of (
-        Token.t (* "keyof" *)
-      * [
-            `Id of identifier (*tok*)
-          | `Nest_type_id of nested_type_identifier
-        ]
-    )
-  | `Prim_type_this of Token.t (* "this" *)
-  | `Prim_type_exis_type of Token.t (* "*" *)
-  | `Prim_type_lit_type of literal_type
-  | `Prim_type_look_type of (
-        primary_type * Token.t (* "[" *) * type_ * Token.t (* "]" *)
-    )
-]
-and generic_type = (
-    [ `Id of identifier (*tok*) | `Nest_type_id of nested_type_identifier ]
-  * type_arguments
-)
-and mapped_type_clause = (identifier (*tok*) * Token.t (* "in" *) * type_)
-and type_arguments = (
-    Token.t (* "<" *)
-  * type_
-  * (Token.t (* "," *) * type_) list (* zero or more *)
-  * Token.t (* "," *) option
-  * Token.t (* ">" *)
-)
-and object_type = (
-    [ `LCURL of Token.t (* "{" *) | `LCURLBAR of Token.t (* "{|" *) ]
-  * (
-        [ `COMMA of Token.t (* "," *) | `SEMI of Token.t (* ";" *) ] option
-      * [
-            `Expo_stmt of export_statement
-          | `Prop_sign of property_signature
-          | `Call_sign_ of call_signature_
-          | `Cons_sign of construct_signature
-          | `Index_sign of index_signature
-          | `Meth_sign of method_signature
-        ]
-      * (
-            [
-                `COMMA of Token.t (* "," *)
-              | `Choice_auto_semi of [
-                    `Auto_semi of automatic_semicolon (*tok*)
-                  | `SEMI of Token.t (* ";" *)
-                ]
-            ]
-          * [
-                `Expo_stmt of export_statement
-              | `Prop_sign of property_signature
-              | `Call_sign_ of call_signature_
-              | `Cons_sign of construct_signature
-              | `Index_sign of index_signature
-              | `Meth_sign of method_signature
-            ]
-        )
-          list (* zero or more *)
-      * [
-            `COMMA of Token.t (* "," *)
-          | `Choice_auto_semi of [
-                `Auto_semi of automatic_semicolon (*tok*)
-              | `SEMI of Token.t (* ";" *)
-            ]
-        ]
-          option
-    )
-      option
-  * [ `RCURL of Token.t (* "}" *) | `BARRCURL of Token.t (* "|}" *) ]
-)
-and call_signature_ = call_signature
-and property_signature = (
-    accessibility_modifier option
-  * Token.t (* "static" *) option
-  * Token.t (* "readonly" *) option
-  * property_name
-  * Token.t (* "?" *) option
-  * type_annotation option
-)
+
 and type_parameters = (
     Token.t (* "<" *)
   * type_parameter
@@ -1894,60 +1092,129 @@ and type_parameters = (
   * Token.t (* "," *) option
   * Token.t (* ">" *)
 )
-and type_parameter = (
-    identifier (*tok*)
-  * constraint_ option
-  * default_type option
-)
-and default_type = (Token.t (* "=" *) * type_)
+
 and constraint_ = (
     [ `Extens of Token.t (* "extends" *) | `COLON of Token.t (* ":" *) ]
   * type_
 )
-and construct_signature = (
-    Token.t (* "new" *)
-  * type_parameters option
-  * formal_parameters
-  * type_annotation option
-)
-and index_signature = (
-    Token.t (* "[" *)
+
+and anon_choice_id2 = [
+    `Id of identifier (*tok*)
+  | `Nest_type_id of nested_type_identifier
+  | `Gene_type of generic_type
+]
+
+and parameter_name = (
+    accessibility_modifier option
+  * Token.t (* "readonly" *) option
   * [
-        `Choice_id_COLON_pred_type of (
-            [
-                `Id of identifier (*tok*)
-              | `Choice_decl of [
-                    `Decl of Token.t (* "declare" *)
-                  | `Name of Token.t (* "namespace" *)
-                  | `Type of Token.t (* "type" *)
-                  | `Publ of Token.t (* "public" *)
-                  | `Priv of Token.t (* "private" *)
-                  | `Prot of Token.t (* "protected" *)
-                  | `Read of Token.t (* "readonly" *)
-                  | `Modu of Token.t (* "module" *)
-                  | `Any of Token.t (* "any" *)
-                  | `Num of Token.t (* "number" *)
-                  | `Bool of Token.t (* "boolean" *)
-                  | `Str of Token.t (* "string" *)
-                  | `Symb of Token.t (* "symbol" *)
-                  | `Void of Token.t (* "void" *)
-                  | `Expo of Token.t (* "export" *)
-                  | `Choice_get of [
-                        `Get of Token.t (* "get" *)
-                      | `Set of Token.t (* "set" *)
-                      | `Async of Token.t (* "async" *)
-                      | `Stat of Token.t (* "static" *)
-                    ]
-                ]
-            ]
-          * Token.t (* ":" *)
-          * predefined_type
-        )
-      | `Mapp_type_clau of mapped_type_clause
+        `Id of identifier (*tok*)
+      | `Choice_decl of anon_choice_decl
+      | `Choice_obj of anon_choice_obj
+      | `This of Token.t (* "this" *)
     ]
-  * Token.t (* "]" *)
-  * type_annotation
 )
+
+and anon_choice_exp_ = [ `Exp of expression | `Spre_elem of spread_element ]
+
+and statement_block = (
+    Token.t (* "{" *)
+  * anon_choice_expo_stmt_ list (* zero or more *)
+  * Token.t (* "}" *)
+  * automatic_semicolon (*tok*) option
+)
+
+and function_declaration = (
+    Token.t (* "async" *) option
+  * Token.t (* "function" *)
+  * identifier (*tok*)
+  * call_signature_
+  * statement_block
+  * automatic_semicolon (*tok*) option
+)
+
+and template_substitution = (
+    Token.t (* "${" *) * anon_choice_exp * Token.t (* "}" *)
+)
+
+and method_signature = (
+    accessibility_modifier option
+  * Token.t (* "static" *) option
+  * Token.t (* "readonly" *) option
+  * Token.t (* "async" *) option
+  * anon_choice_get option
+  * property_name
+  * Token.t (* "?" *) option
+  * call_signature_
+)
+
+and anon_choice_choice_id = [
+    `Choice_id of anon_choice_id2
+  | `Exp of expression
+]
+
+and declaration = [
+    `Decl_choice_func_decl of [
+        `Func_decl of function_declaration
+      | `Gene_func_decl of generator_function_declaration
+      | `Class_decl of class_declaration
+      | `Lexi_decl of lexical_declaration
+      | `Var_decl of variable_declaration
+    ]
+  | `Decl_func_sign of (
+        Token.t (* "async" *) option
+      * Token.t (* "function" *)
+      * identifier (*tok*)
+      * call_signature_
+      * anon_choice_auto_semi
+    )
+  | `Decl_abst_class_decl of (
+        Token.t (* "abstract" *)
+      * Token.t (* "class" *)
+      * identifier (*tok*)
+      * type_parameters option
+      * class_heritage option
+      * class_body
+    )
+  | `Decl_modu of (Token.t (* "module" *) * module__)
+  | `Decl_inte_modu of internal_module
+  | `Decl_type_alias_decl of (
+        Token.t (* "type" *)
+      * identifier (*tok*)
+      * type_parameters option
+      * Token.t (* "=" *)
+      * type_
+      * anon_choice_auto_semi
+    )
+  | `Decl_enum_decl of (
+        Token.t (* "const" *) option
+      * Token.t (* "enum" *)
+      * identifier (*tok*)
+      * enum_body
+    )
+  | `Decl_inte_decl of (
+        Token.t (* "interface" *)
+      * identifier (*tok*)
+      * type_parameters option
+      * extends_clause option
+      * object_type
+    )
+  | `Decl_impo_alias of (
+        Token.t (* "import" *) * identifier (*tok*) * Token.t (* "=" *)
+      * anon_choice_id_ * anon_choice_auto_semi
+    )
+  | `Decl_ambi_decl of (
+        Token.t (* "declare" *)
+      * [
+            `Decl of declaration
+          | `Glob_stmt_blk of (Token.t (* "global" *) * statement_block)
+          | `Modu_DOT_id_COLON_type of (
+                Token.t (* "module" *) * Token.t (* "." *)
+              * identifier (*tok*) * Token.t (* ":" *) * type_
+            )
+        ]
+    )
+]
 [@@deriving sexp_of]
 
 type jsx_expression = (
@@ -1964,135 +1231,95 @@ type jsx_expression = (
 
 type program = (
     hash_bang_line (*tok*) option
-  * [
-        `Expo_stmt of export_statement
-      | `Impo_stmt of import_statement
-      | `Debu_stmt of debugger_statement
-      | `Exp_stmt of expression_statement
-      | `Decl of declaration
-      | `Stmt_blk of statement_block
-      | `If_stmt of if_statement
-      | `Swit_stmt of switch_statement
-      | `For_stmt of for_statement
-      | `For_in_stmt of for_in_statement
-      | `While_stmt of while_statement
-      | `Do_stmt of do_statement
-      | `Try_stmt of try_statement
-      | `With_stmt of with_statement
-      | `Brk_stmt of break_statement
-      | `Cont_stmt of continue_statement
-      | `Ret_stmt of return_statement
-      | `Throw_stmt of throw_statement
-      | `Empty_stmt of Token.t (* ";" *)
-      | `Labe_stmt of labeled_statement
-    ]
-      list (* zero or more *)
+  * anon_choice_expo_stmt_ list (* zero or more *)
 )
 [@@deriving sexp_of]
 
-type jsx_element = (
-    jsx_opening_element
+type jsx_opening_element = (
+    Token.t (* "<" *)
   * [
-        `Jsx_text of jsx_text (*tok*)
-      | `Choice_jsx_elem of [
-            `Jsx_elem of jsx_element
-          | `Jsx_self_clos_elem of jsx_self_closing_element
-        ]
-      | `Jsx_exp of jsx_expression
+        `Choice_choice_jsx_id of anon_choice_choice_jsx_id
+      | `Choice_id_opt_type_args of (anon_choice_id_ * type_arguments option)
     ]
-      list (* zero or more *)
-  * jsx_closing_element
+  * anon_choice_jsx_attr list (* zero or more *)
+  * Token.t (* ">" *)
 )
+
+and anon_choice_jsx_attr = [
+    `Jsx_attr of (
+        anon_choice_choice_jsx_id
+      * (
+            Token.t (* "=" *)
+          * [
+                `Str of string_
+              | `Jsx_exp of jsx_expression
+              | `Choice_jsx_elem of anon_choice_jsx_elem
+              | `Jsx_frag of jsx_fragment
+            ]
+        )
+          option
+    )
+  | `Jsx_exp of jsx_expression
+]
+
 and jsx_fragment = (
     Token.t (* "<" *)
   * Token.t (* ">" *)
-  * [
-        `Jsx_text of jsx_text (*tok*)
-      | `Choice_jsx_elem of [
-            `Jsx_elem of jsx_element
-          | `Jsx_self_clos_elem of jsx_self_closing_element
-        ]
-      | `Jsx_exp of jsx_expression
-    ]
-      list (* zero or more *)
+  * anon_choice_jsx_text list (* zero or more *)
   * Token.t (* "<" *)
   * Token.t (* "/" *)
   * Token.t (* ">" *)
 )
-and jsx_opening_element = (
-    Token.t (* "<" *)
-  * [
-        `Choice_choice_jsx_id of [
-            `Choice_jsx_id of [
-                `Jsx_id of jsx_identifier (*tok*)
-              | `Id of identifier (*tok*)
-            ]
-          | `Jsx_name_name of jsx_namespace_name
-        ]
-      | `Choice_id_opt_type_args of (
-            [ `Id of identifier (*tok*) | `Nest_id of nested_identifier ]
-          * type_arguments option
-        )
-    ]
-  * [ `Jsx_attr of jsx_attribute | `Jsx_exp of jsx_expression ]
-      list (* zero or more *)
-  * Token.t (* ">" *)
-)
-and jsx_self_closing_element = (
-    Token.t (* "<" *)
-  * [
-        `Choice_jsx_id of [
-            `Jsx_id of jsx_identifier (*tok*)
-          | `Id of identifier (*tok*)
-        ]
-      | `Nest_id of nested_identifier
-      | `Jsx_name_name of jsx_namespace_name
-    ]
-  * [ `Jsx_attr of jsx_attribute | `Jsx_exp of jsx_expression ]
-      list (* zero or more *)
-  * Token.t (* "/" *)
-  * Token.t (* ">" *)
-)
-and jsx_attribute = (
-    [
-        `Choice_jsx_id of [
-            `Jsx_id of jsx_identifier (*tok*)
-          | `Id of identifier (*tok*)
-        ]
-      | `Jsx_name_name of jsx_namespace_name
-    ]
-  * (
-        Token.t (* "=" *)
-      * [
-            `Str of string_
-          | `Jsx_exp of jsx_expression
-          | `Choice_jsx_elem of [
-                `Jsx_elem of jsx_element
-              | `Jsx_self_clos_elem of jsx_self_closing_element
-            ]
-          | `Jsx_frag of jsx_fragment
-        ]
+
+and anon_choice_jsx_text = [
+    `Jsx_text of jsx_text (*tok*)
+  | `Choice_jsx_elem of anon_choice_jsx_elem
+  | `Jsx_exp of jsx_expression
+]
+
+and anon_choice_jsx_elem = [
+    `Jsx_elem of (
+        jsx_opening_element
+      * anon_choice_jsx_text list (* zero or more *)
+      * jsx_closing_element
     )
-      option
-)
-[@@deriving sexp_of]
-
-type existential_type (* inlined *) = Token.t (* "*" *)
-[@@deriving sexp_of]
-
-type readonly (* inlined *) = Token.t (* "readonly" *)
-[@@deriving sexp_of]
-
-type empty_statement (* inlined *) = Token.t (* ";" *)
-[@@deriving sexp_of]
-
-type this (* inlined *) = Token.t (* "this" *)
+  | `Jsx_self_clos_elem of (
+        Token.t (* "<" *)
+      * anon_choice_choice_jsx_id_
+      * anon_choice_jsx_attr list (* zero or more *)
+      * Token.t (* "/" *)
+      * Token.t (* ">" *)
+    )
+]
 [@@deriving sexp_of]
 
 type null (* inlined *) = Token.t (* "null" *)
 [@@deriving sexp_of]
 
+type meta_property (* inlined *) = (
+    Token.t (* "new" *) * Token.t (* "." *) * Token.t (* "target" *)
+)
+[@@deriving sexp_of]
+
 type false_ (* inlined *) = Token.t (* "false" *)
+[@@deriving sexp_of]
+
+type empty_statement (* inlined *) = Token.t (* ";" *)
+[@@deriving sexp_of]
+
+type existential_type (* inlined *) = Token.t (* "*" *)
+[@@deriving sexp_of]
+
+type this (* inlined *) = Token.t (* "this" *)
+[@@deriving sexp_of]
+
+type readonly (* inlined *) = Token.t (* "readonly" *)
+[@@deriving sexp_of]
+
+type true_ (* inlined *) = Token.t (* "true" *)
+[@@deriving sexp_of]
+
+type super (* inlined *) = Token.t (* "super" *)
 [@@deriving sexp_of]
 
 type comment (* inlined *) = Token.t
@@ -2101,49 +1328,153 @@ type comment (* inlined *) = Token.t
 type undefined (* inlined *) = Token.t (* "undefined" *)
 [@@deriving sexp_of]
 
-type super (* inlined *) = Token.t (* "super" *)
-[@@deriving sexp_of]
-
-type true_ (* inlined *) = Token.t (* "true" *)
-[@@deriving sexp_of]
-
 type number_ (* inlined *) = (
     [ `DASH of Token.t (* "-" *) | `PLUS of Token.t (* "+" *) ]
   * number (*tok*)
 )
 [@@deriving sexp_of]
 
-type type_query (* inlined *) = (
-    Token.t (* "typeof" *)
-  * [ `Id of identifier (*tok*) | `Nest_id of nested_identifier ]
+type regex (* inlined *) = (
+    Token.t (* "/" *)
+  * regex_pattern (*tok*)
+  * Token.t (* "/" *)
+  * regex_flags (*tok*) option
+)
+[@@deriving sexp_of]
+
+type continue_statement (* inlined *) = (
+    Token.t (* "continue" *)
+  * identifier (*tok*) option
+  * anon_choice_auto_semi
+)
+[@@deriving sexp_of]
+
+type debugger_statement (* inlined *) = (
+    Token.t (* "debugger" *) * anon_choice_auto_semi
+)
+[@@deriving sexp_of]
+
+type break_statement (* inlined *) = (
+    Token.t (* "break" *)
+  * identifier (*tok*) option
+  * anon_choice_auto_semi
 )
 [@@deriving sexp_of]
 
 type import_alias (* inlined *) = (
-    Token.t (* "import" *)
-  * identifier (*tok*)
-  * Token.t (* "=" *)
-  * [ `Id of identifier (*tok*) | `Nest_id of nested_identifier ]
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
+    Token.t (* "import" *) * identifier (*tok*) * Token.t (* "=" *)
+  * anon_choice_id_ * anon_choice_auto_semi
 )
+[@@deriving sexp_of]
+
+type type_query (* inlined *) = (Token.t (* "typeof" *) * anon_choice_id_)
 [@@deriving sexp_of]
 
 type index_type_query (* inlined *) = (
-    Token.t (* "keyof" *)
-  * [ `Id of identifier (*tok*) | `Nest_type_id of nested_type_identifier ]
+    Token.t (* "keyof" *) * anon_choice_id
 )
 [@@deriving sexp_of]
 
-type yield_expression (* inlined *) = (
-    Token.t (* "yield" *)
+type import_statement (* inlined *) = (
+    Token.t (* "import" *)
+  * anon_choice_type option
   * [
-        `STAR_exp of (Token.t (* "*" *) * expression)
-      | `Opt_exp of expression option
+        `Impo_clau_from_clau of (import_clause * from_clause)
+      | `Impo_requ_clau of import_require_clause
+      | `Str of string_
     ]
+  * anon_choice_auto_semi
 )
+[@@deriving sexp_of]
+
+type function_signature (* inlined *) = (
+    Token.t (* "async" *) option
+  * Token.t (* "function" *)
+  * identifier (*tok*)
+  * call_signature_
+  * anon_choice_auto_semi
+)
+[@@deriving sexp_of]
+
+type as_expression (* inlined *) = (
+    expression
+  * Token.t (* "as" *)
+  * [ `Type of type_ | `Temp_str of template_string ]
+)
+[@@deriving sexp_of]
+
+type enum_assignment (* inlined *) = (property_name * initializer_)
+[@@deriving sexp_of]
+
+type type_alias_declaration (* inlined *) = (
+    Token.t (* "type" *)
+  * identifier (*tok*)
+  * type_parameters option
+  * Token.t (* "=" *)
+  * type_
+  * anon_choice_auto_semi
+)
+[@@deriving sexp_of]
+
+type labeled_statement (* inlined *) = (
+    anon_choice_id4 * Token.t (* ":" *) * anon_choice_expo_stmt_
+)
+[@@deriving sexp_of]
+
+type type_assertion (* inlined *) = (type_arguments * expression)
+[@@deriving sexp_of]
+
+type property_signature (* inlined *) = (
+    accessibility_modifier option
+  * Token.t (* "static" *) option
+  * Token.t (* "readonly" *) option
+  * property_name
+  * Token.t (* "?" *) option
+  * type_annotation option
+)
+[@@deriving sexp_of]
+
+type assignment_expression (* inlined *) = (
+    anon_choice_paren_exp * Token.t (* "=" *) * expression
+)
+[@@deriving sexp_of]
+
+type do_statement (* inlined *) = (
+    Token.t (* "do" *) * anon_choice_expo_stmt_ * Token.t (* "while" *)
+  * parenthesized_expression * anon_choice_auto_semi
+)
+[@@deriving sexp_of]
+
+type lookup_type (* inlined *) = (
+    primary_type * Token.t (* "[" *) * type_ * Token.t (* "]" *)
+)
+[@@deriving sexp_of]
+
+type assignment_pattern (* inlined *) = (
+    [
+        `Choice_choice_decl of anon_choice_choice_decl
+      | `Choice_obj of anon_choice_obj
+    ]
+  * Token.t (* "=" *)
+  * expression
+)
+[@@deriving sexp_of]
+
+type array_type (* inlined *) = (
+    primary_type * Token.t (* "[" *) * Token.t (* "]" *)
+)
+[@@deriving sexp_of]
+
+type interface_declaration (* inlined *) = (
+    Token.t (* "interface" *)
+  * identifier (*tok*)
+  * type_parameters option
+  * extends_clause option
+  * object_type
+)
+[@@deriving sexp_of]
+
+type flow_maybe_type (* inlined *) = (Token.t (* "?" *) * primary_type)
 [@@deriving sexp_of]
 
 type call_expression (* inlined *) = (
@@ -2157,44 +1488,238 @@ type call_expression (* inlined *) = (
 )
 [@@deriving sexp_of]
 
+type generator_function (* inlined *) = (
+    Token.t (* "async" *) option
+  * Token.t (* "function" *)
+  * Token.t (* "*" *)
+  * identifier (*tok*) option
+  * call_signature_
+  * statement_block
+)
+[@@deriving sexp_of]
+
+type module_ (* inlined *) = (Token.t (* "module" *) * module__)
+[@@deriving sexp_of]
+
+type constructor_type (* inlined *) = (
+    Token.t (* "new" *)
+  * type_parameters option
+  * formal_parameters
+  * Token.t (* "=>" *)
+  * type_
+)
+[@@deriving sexp_of]
+
+type tuple_type (* inlined *) = (
+    Token.t (* "[" *)
+  * type_
+  * (Token.t (* "," *) * type_) list (* zero or more *)
+  * Token.t (* "]" *)
+)
+[@@deriving sexp_of]
+
+type throw_statement (* inlined *) = (
+    Token.t (* "throw" *) * anon_choice_exp * anon_choice_auto_semi
+)
+[@@deriving sexp_of]
+
+type ambient_declaration (* inlined *) = (
+    Token.t (* "declare" *)
+  * [
+        `Decl of declaration
+      | `Glob_stmt_blk of (Token.t (* "global" *) * statement_block)
+      | `Modu_DOT_id_COLON_type of (
+            Token.t (* "module" *) * Token.t (* "." *) * identifier (*tok*)
+          * Token.t (* ":" *) * type_
+        )
+    ]
+)
+[@@deriving sexp_of]
+
+type required_parameter (* inlined *) = (
+    parameter_name
+  * type_annotation option
+  * initializer_ option
+)
+[@@deriving sexp_of]
+
+type union_type (* inlined *) = (type_ option * Token.t (* "|" *) * type_)
+[@@deriving sexp_of]
+
+type pair (* inlined *) = (property_name * Token.t (* ":" *) * expression)
+[@@deriving sexp_of]
+
+type try_statement (* inlined *) = (
+    Token.t (* "try" *)
+  * statement_block
+  * catch_clause option
+  * finally_clause option
+)
+[@@deriving sexp_of]
+
+type rest_parameter (* inlined *) = (
+    Token.t (* "..." *)
+  * identifier (*tok*)
+  * type_annotation option
+)
+[@@deriving sexp_of]
+
+type parenthesized_type (* inlined *) = (
+    Token.t (* "(" *) * type_ * Token.t (* ")" *)
+)
+[@@deriving sexp_of]
+
+type if_statement (* inlined *) = (
+    Token.t (* "if" *)
+  * parenthesized_expression
+  * anon_choice_expo_stmt_
+  * (Token.t (* "else" *) * anon_choice_expo_stmt_) option
+)
+[@@deriving sexp_of]
+
+type new_expression (* inlined *) = (
+    Token.t (* "new" *)
+  * anon_choice_this
+  * arguments option
+)
+[@@deriving sexp_of]
+
+type arrow_function (* inlined *) = (
+    Token.t (* "async" *) option
+  * [
+        `Choice_choice_decl of anon_choice_choice_decl
+      | `Call_sign of call_signature_
+    ]
+  * Token.t (* "=>" *)
+  * [ `Exp of expression | `Stmt_blk of statement_block ]
+)
+[@@deriving sexp_of]
+
+type non_null_expression (* inlined *) = (expression * Token.t (* "!" *))
+[@@deriving sexp_of]
+
 type await_expression (* inlined *) = (Token.t (* "await" *) * expression)
 [@@deriving sexp_of]
 
-type assignment_expression (* inlined *) = (
-    [
-        `Paren_exp of parenthesized_expression
-      | `Choice_memb_exp of [
-            `Memb_exp of member_expression
-          | `Subs_exp of subscript_expression
-          | `Id of identifier (*tok*)
-          | `Choice_decl of [
-                `Decl of Token.t (* "declare" *)
-              | `Name of Token.t (* "namespace" *)
-              | `Type of Token.t (* "type" *)
-              | `Publ of Token.t (* "public" *)
-              | `Priv of Token.t (* "private" *)
-              | `Prot of Token.t (* "protected" *)
-              | `Read of Token.t (* "readonly" *)
-              | `Modu of Token.t (* "module" *)
-              | `Any of Token.t (* "any" *)
-              | `Num of Token.t (* "number" *)
-              | `Bool of Token.t (* "boolean" *)
-              | `Str of Token.t (* "string" *)
-              | `Symb of Token.t (* "symbol" *)
-              | `Void of Token.t (* "void" *)
-              | `Expo of Token.t (* "export" *)
-              | `Choice_get of [
-                    `Get of Token.t (* "get" *)
-                  | `Set of Token.t (* "set" *)
-                  | `Async of Token.t (* "async" *)
-                  | `Stat of Token.t (* "static" *)
-                ]
-            ]
-          | `Choice_obj of [ `Obj of object_ | `Array of array_ ]
-        ]
-    ]
-  * Token.t (* "=" *)
+type class_ (* inlined *) = (
+    decorator list (* zero or more *)
+  * Token.t (* "class" *)
+  * identifier (*tok*) option
+  * type_parameters option
+  * class_heritage option
+  * class_body
+)
+[@@deriving sexp_of]
+
+type computed_property_name (* inlined *) = (
+    Token.t (* "[" *) * expression * Token.t (* "]" *)
+)
+[@@deriving sexp_of]
+
+type while_statement (* inlined *) = (
+    Token.t (* "while" *) * parenthesized_expression * anon_choice_expo_stmt_
+)
+[@@deriving sexp_of]
+
+type optional_parameter (* inlined *) = (
+    parameter_name
+  * Token.t (* "?" *)
+  * type_annotation option
+  * initializer_ option
+)
+[@@deriving sexp_of]
+
+type switch_statement (* inlined *) = (
+    Token.t (* "switch" *) * parenthesized_expression * switch_body
+)
+[@@deriving sexp_of]
+
+type return_statement (* inlined *) = (
+    Token.t (* "return" *)
+  * anon_choice_exp option
+  * anon_choice_auto_semi
+)
+[@@deriving sexp_of]
+
+type intersection_type (* inlined *) = (
+    type_ option
+  * Token.t (* "&" *)
+  * type_
+)
+[@@deriving sexp_of]
+
+type for_in_statement (* inlined *) = (
+    Token.t (* "for" *)
+  * Token.t (* "await" *) option
+  * for_header
+  * anon_choice_expo_stmt_
+)
+[@@deriving sexp_of]
+
+type construct_signature (* inlined *) = (
+    Token.t (* "new" *)
+  * type_parameters option
+  * formal_parameters
+  * type_annotation option
+)
+[@@deriving sexp_of]
+
+type type_predicate (* inlined *) = (
+    identifier (*tok*) * Token.t (* "is" *) * type_
+)
+[@@deriving sexp_of]
+
+type ternary_expression (* inlined *) = (
+    expression * Token.t (* "?" *) * expression * Token.t (* ":" *)
   * expression
+)
+[@@deriving sexp_of]
+
+type abstract_class_declaration (* inlined *) = (
+    Token.t (* "abstract" *)
+  * Token.t (* "class" *)
+  * identifier (*tok*)
+  * type_parameters option
+  * class_heritage option
+  * class_body
+)
+[@@deriving sexp_of]
+
+type with_statement (* inlined *) = (
+    Token.t (* "with" *) * parenthesized_expression * anon_choice_expo_stmt_
+)
+[@@deriving sexp_of]
+
+type for_statement (* inlined *) = (
+    Token.t (* "for" *)
+  * Token.t (* "(" *)
+  * [
+        `Lexi_decl of lexical_declaration
+      | `Var_decl of variable_declaration
+      | `Exp_stmt of expression_statement
+      | `Empty_stmt of Token.t (* ";" *)
+    ]
+  * [ `Exp_stmt of expression_statement | `Empty_stmt of Token.t (* ";" *) ]
+  * anon_choice_exp option
+  * Token.t (* ")" *)
+  * anon_choice_expo_stmt_
+)
+[@@deriving sexp_of]
+
+type yield_expression (* inlined *) = (
+    Token.t (* "yield" *)
+  * [
+        `STAR_exp of (Token.t (* "*" *) * expression)
+      | `Opt_exp of expression option
+    ]
+)
+[@@deriving sexp_of]
+
+type enum_declaration (* inlined *) = (
+    Token.t (* "const" *) option
+  * Token.t (* "enum" *)
+  * identifier (*tok*)
+  * enum_body
 )
 [@@deriving sexp_of]
 
@@ -2202,29 +1727,7 @@ type augmented_assignment_expression (* inlined *) = (
     [
         `Memb_exp of member_expression
       | `Subs_exp of subscript_expression
-      | `Choice_decl of [
-            `Decl of Token.t (* "declare" *)
-          | `Name of Token.t (* "namespace" *)
-          | `Type of Token.t (* "type" *)
-          | `Publ of Token.t (* "public" *)
-          | `Priv of Token.t (* "private" *)
-          | `Prot of Token.t (* "protected" *)
-          | `Read of Token.t (* "readonly" *)
-          | `Modu of Token.t (* "module" *)
-          | `Any of Token.t (* "any" *)
-          | `Num of Token.t (* "number" *)
-          | `Bool of Token.t (* "boolean" *)
-          | `Str of Token.t (* "string" *)
-          | `Symb of Token.t (* "symbol" *)
-          | `Void of Token.t (* "void" *)
-          | `Expo of Token.t (* "export" *)
-          | `Choice_get of [
-                `Get of Token.t (* "get" *)
-              | `Set of Token.t (* "set" *)
-              | `Async of Token.t (* "async" *)
-              | `Stat of Token.t (* "static" *)
-            ]
-        ]
+      | `Choice_decl of anon_choice_decl
       | `Id of identifier (*tok*)
       | `Paren_exp of parenthesized_expression
     ]
@@ -2246,153 +1749,42 @@ type augmented_assignment_expression (* inlined *) = (
 )
 [@@deriving sexp_of]
 
-type ternary_expression (* inlined *) = (
-    expression * Token.t (* "?" *) * expression * Token.t (* ":" *)
-  * expression
-)
-[@@deriving sexp_of]
-
-type computed_property_name (* inlined *) = (
-    Token.t (* "[" *) * expression * Token.t (* "]" *)
-)
-[@@deriving sexp_of]
-
-type non_null_expression (* inlined *) = (expression * Token.t (* "!" *))
-[@@deriving sexp_of]
-
-type function_signature (* inlined *) = (
-    Token.t (* "async" *) option
-  * Token.t (* "function" *)
-  * identifier (*tok*)
-  * call_signature
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
-)
-[@@deriving sexp_of]
-
-type type_assertion (* inlined *) = (type_arguments * expression)
-[@@deriving sexp_of]
-
-type as_expression (* inlined *) = (
-    expression
-  * Token.t (* "as" *)
-  * [ `Type of type_ | `Temp_str of template_string ]
-)
-[@@deriving sexp_of]
-
-type ambient_declaration (* inlined *) = (
-    Token.t (* "declare" *)
-  * [
-        `Decl of declaration
-      | `Glob_stmt_blk of (Token.t (* "global" *) * statement_block)
-      | `Modu_DOT_id_COLON_type of (
-            Token.t (* "module" *) * Token.t (* "." *) * identifier (*tok*)
-          * Token.t (* ":" *) * type_
-        )
-    ]
-)
-[@@deriving sexp_of]
-
-type abstract_class_declaration (* inlined *) = (
-    Token.t (* "abstract" *)
-  * Token.t (* "class" *)
-  * identifier (*tok*)
-  * type_parameters option
-  * class_heritage option
-  * class_body
-)
-[@@deriving sexp_of]
-
-type module_ (* inlined *) = (Token.t (* "module" *) * module__)
-[@@deriving sexp_of]
-
-type interface_declaration (* inlined *) = (
-    Token.t (* "interface" *)
-  * identifier (*tok*)
-  * type_parameters option
-  * extends_clause option
-  * object_type
-)
-[@@deriving sexp_of]
-
-type enum_declaration (* inlined *) = (
-    Token.t (* "const" *) option
-  * Token.t (* "enum" *)
-  * identifier (*tok*)
-  * enum_body
-)
-[@@deriving sexp_of]
-
-type type_alias_declaration (* inlined *) = (
-    Token.t (* "type" *)
-  * identifier (*tok*)
-  * type_parameters option
-  * Token.t (* "=" *)
-  * type_
-  * [
-        `Auto_semi of automatic_semicolon (*tok*)
-      | `SEMI of Token.t (* ";" *)
-    ]
-)
-[@@deriving sexp_of]
-
-type constructor_type (* inlined *) = (
-    Token.t (* "new" *)
-  * type_parameters option
-  * formal_parameters
-  * Token.t (* "=>" *)
-  * type_
-)
-[@@deriving sexp_of]
-
-type type_predicate (* inlined *) = (
-    identifier (*tok*) * Token.t (* "is" *) * type_
-)
-[@@deriving sexp_of]
-
-type lookup_type (* inlined *) = (
-    primary_type * Token.t (* "[" *) * type_ * Token.t (* "]" *)
-)
-[@@deriving sexp_of]
-
-type flow_maybe_type (* inlined *) = (Token.t (* "?" *) * primary_type)
-[@@deriving sexp_of]
-
-type parenthesized_type (* inlined *) = (
-    Token.t (* "(" *) * type_ * Token.t (* ")" *)
-)
-[@@deriving sexp_of]
-
-type array_type (* inlined *) = (
-    primary_type * Token.t (* "[" *) * Token.t (* "]" *)
-)
-[@@deriving sexp_of]
-
-type tuple_type (* inlined *) = (
-    Token.t (* "[" *)
-  * type_
-  * (Token.t (* "," *) * type_) list (* zero or more *)
-  * Token.t (* "]" *)
-)
-[@@deriving sexp_of]
-
-type union_type (* inlined *) = (type_ option * Token.t (* "|" *) * type_)
-[@@deriving sexp_of]
-
-type intersection_type (* inlined *) = (
-    type_ option
-  * Token.t (* "&" *)
-  * type_
-)
-[@@deriving sexp_of]
-
 type function_type (* inlined *) = (
     type_parameters option
   * formal_parameters
   * Token.t (* "=>" *)
   * type_
+)
+[@@deriving sexp_of]
+
+type jsx_element (* inlined *) = (
+    jsx_opening_element
+  * anon_choice_jsx_text list (* zero or more *)
+  * jsx_closing_element
+)
+[@@deriving sexp_of]
+
+type jsx_attribute (* inlined *) = (
+    anon_choice_choice_jsx_id
+  * (
+        Token.t (* "=" *)
+      * [
+            `Str of string_
+          | `Jsx_exp of jsx_expression
+          | `Choice_jsx_elem of anon_choice_jsx_elem
+          | `Jsx_frag of jsx_fragment
+        ]
+    )
+      option
+)
+[@@deriving sexp_of]
+
+type jsx_self_closing_element (* inlined *) = (
+    Token.t (* "<" *)
+  * anon_choice_choice_jsx_id_
+  * anon_choice_jsx_attr list (* zero or more *)
+  * Token.t (* "/" *)
+  * Token.t (* ">" *)
 )
 [@@deriving sexp_of]
 


### PR DESCRIPTION
This creates new types with the `anon_` prefix in `CST.ml`. This should be compatible with the previous versions of `CST.`ml`. `Boilerplate.ml` is now also shorter, which was the goal. The prefix (`anon_`) and the rules for deciding what should be factored out is still negotiable.

Release files generated by ocaml-tree-sitter c0be5fc.